### PR TITLE
Add 'from __future__ import print_function' to files that print

### DIFF
--- a/manifest.py
+++ b/manifest.py
@@ -10,6 +10,8 @@
 
 """Create MANIFEST"""
 
+from __future__ import print_function
+
 import glob
 import os
 

--- a/src/cclib/method/cda.py
+++ b/src/cclib/method/cda.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import random # For sometimes running the progress updater
 
 import numpy

--- a/src/cclib/method/volume.py
+++ b/src/cclib/method/volume.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import copy
 
 import numpy

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -8,6 +8,8 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
+
 import numpy
 
 from . import logfileparser

--- a/src/cclib/parser/ccopen.py
+++ b/src/cclib/parser/ccopen.py
@@ -8,6 +8,8 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
+
 from . import logfileparser
 
 from . import adfparser

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import re
 
 import numpy

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import re
 
 import numpy

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -8,6 +8,8 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
+
 import numpy
 
 from . import logfileparser

--- a/src/cclib/progress/textprogress.py
+++ b/src/cclib/progress/textprogress.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import sys
 
 

--- a/src/scripts/ccget
+++ b/src/scripts/ccget
@@ -10,6 +10,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import os
 import sys
 import glob

--- a/src/scripts/cda
+++ b/src/scripts/cda
@@ -10,6 +10,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import os
 import sys
 import glob

--- a/test/methods.py
+++ b/test/methods.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import sys
 import unittest
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -14,6 +14,7 @@ designed to make it easy to add new tests or datafiles.
 To run the doctest, just use "python regression.py test".
 """
 
+from __future__ import print_function
 import os
 import sys
 import inspect

--- a/test/testall.py
+++ b/test/testall.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import os
 import sys
 import unittest

--- a/test/testcda.py
+++ b/test/testcda.py
@@ -8,6 +8,7 @@
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+from __future__ import print_function
 import os
 import logging
 import unittest


### PR DESCRIPTION
I found no changes in the tests compared to `cclib:master`, however, there is an additional regression in Python3 vs. Python2 due to a Unicode problem.
