### PR TITLE
When opening logfiles, use io.open instead of open

### DIFF
--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -77,7 +77,7 @@ def openlogfile(filename):
             fileobject = myBZ2File(filename, "r")
 
         else:
-            fileobject = open(filename, "r")
+            fileobject = io.open(filename, "r", errors='ignore')
 
         return fileobject
     


### PR DESCRIPTION
- This allows passing in errors='ignore' which is unavailable to the plain open function in Python2.
- Fixes Issue #30
