### PR TITLE
Logfile: fix FileWrapper for Python2

### DIFF
--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -46,59 +46,33 @@ class myGzipFile(gzip.GzipFile):
         line = super().__next__()
         return line.decode("ascii", "replace")
 
-if int(sys.version[0]) == 2:
-    class FileWrapper(object):
-        """Wrap a file object so that we can maintain position"""
 
-        def __init__(self, file):
-            self.file = file
-            self.pos = 0
-            self.file.seek(0, 2)
-            self.size = self.file.tell()
-            self.file.seek(0, 0)
+class FileWrapper(object):
+    """Wrap a file object so that we can maintain position"""
 
-        def next(self):
-            line = next(self.file)
-            self.pos += len(line)
-            return line
+    def __init__(self, file):
+        self.file = file
+        self.pos = 0
+        self.file.seek(0, 2)
+        self.size = self.file.tell()
+        self.file.seek(0, 0)
 
-        def __iter__(self):
-            return self
+    def next(self):
+        line = next(self.file)
+        self.pos += len(line)
+        return line
 
-        def close(self):
-            self.file.close()
+    def __next__(self):
+        return self.next()
 
-        def seek(self, pos, ref):
-            self.file.seek(pos, ref)
+    def __iter__(self):
+        return self
 
-elif int(sys.version[0]) >= 3:
-    class FileWrapper(object):
-        """Wrap a file object so that we can maintain position"""
+    def close(self):
+        self.file.close()
 
-        def __init__(self, file):
-            self.file = file
-            self.pos = 0
-            self.file.seek(0, 2)
-            self.size = self.file.tell()
-            self.file.seek(0, 0)
-
-        def __next__(self):
-            line = next(self.file)
-            self.pos += len(line)
-            return line
-
-        def __iter__(self):
-            line = next(self.file)
-            while line:
-                self.pos += len(line)
-                yield line
-                line = next(self.file)
-
-        def close(self):
-            self.file.close()
-
-        def seek(self, pos, ref):
-            self.file.seek(pos, ref)
+    def seek(self, pos, ref):
+        self.file.seek(pos, ref)
 
 def openlogfile(filename):
     """Return a file object given a filename.


### PR DESCRIPTION
Due to changes between Python2 and Python3, the FileWrapper class added in PR #47 didn't work for Python2. 

The version of Python is now checked, and the appropriate class definition is used.
