### PR TITLE
Molpro 2012: minor change to parse SCF Energies

### DIFF
--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -236,7 +236,8 @@ class Molpro(logfileparser.Logfile):
             self.scfvalues.append(numpy.array(scfvalues))
 
         # SCF result - RHF/UHF and DFT (RKS) energies.
-        if line[1:5] in ["!RHF", "!UHF", "!RKS"] and line[16:22] == "ENERGY":
+        if (line[1:5] in ["!RHF", "!UHF", "!RKS"] and
+            line[16:22].lower() == "energy"):
             
             if not hasattr(self, "scfenergies"):
                 self.scfenergies = []


### PR DESCRIPTION
Several errors were present because the parser was expecting a line to match 'ENERGY' but the 2012 version prints 'Energy' instead.

Fixes 10 of the errors:

```
adam@mqair:~/cclib/test$ diff -u master-testall3.txt molpro-testall3.txt 
--- master-testall3.txt 2014-03-05 15:49:42.000000000 -0800
+++ molpro-testall3.txt 2014-03-05 15:53:48.000000000 -0800
@@ -51,11 +51,11 @@
 ********* SUMMARY PER PACKAGE ****************
                Total   Passed  Failed  Errors  Skipped
 Molpro2006       67     61   0   2   4
-Molpro2012       67     48   0  15   4
+Molpro2012       67     58   0   5   4


 ********* SUMMARY OF EVERYTHING **************
-TOTAL: 134 PASSED: 109 FAILED: 0   ERRORS: 17  SKIPPED: 8
+TOTAL: 134 PASSED: 119 FAILED: 0   ERRORS: 7   SKIPPED: 8


 *** Visual tests ***
```
