### PR TITLE
Update ANNOUNCE with some niceties for introduction and changes since 1.1

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,4 +1,4 @@
-cclib 1.2b is now available for download from http://cclib.github.io.
+On behalf of the cclib development team, I am pleased to announce the release of cclib 1.2b, which is now available for download from http://cclib.github.io. This beta version marks the first release to target Python 3, and includes several new features and bug fixes (see below).
 
 cclib is an open source library, written in Python, for parsing and interpreting the results of computational chemistry packages. It currently parses output files from ADF, Firefly, GAMESS (US), GAMESS-UK, Gaussian, Jaguar, Molpro and ORCA.
 
@@ -33,3 +33,26 @@ If your published work uses cclib, please support its development by citing the 
 Regards,
 
  The cclib development team
+
+——-
+Changes since cclib 1.1 include:
+
+Features:
+    * Move project to github
+    * Transition to Python 3 (Python 2.7 will still work)
+    * Add a multifile mode fo ccget script
+    * Extract vibrational displacements for ORCA
+    * Extract natural atom charges for Gaussian (Fedor Zhuravlev)
+    * Updated test file versions to ADF2013.01, GAMESS-US 2012,
+    Gaussian09, Molpro 2012 and ORCA 3.0.1
+
+Bugfixes:
+    * Ignore unicode errors in logfiles
+    * Handle Guassian jobs with terse output (basis set count not reported)
+    * Handle Gaussian jobs using IndoGuess (Scott McKechnie)
+    * Handle Gaussian file with irregular ONION gradients  (Tamilmani S)
+    * Handle ORCA file with SCF convergence issue (Melchor Sanchez)
+    * Handle Gaussian file with problematic IRC output (Clyde Fare)
+    * Handle ORCA file with AM1 output (Julien Idé)
+    * Handle GAMESS-US output with irregular frequency format (Andrew Warden)
+


### PR DESCRIPTION
Provide a bit more context to why this release is important by mentioning this is the first release to target Python 3, and include changes since 1.1 at the end.

I intend to use the text of this file for announcing cclib 1.2b on CCL.net and cclib-users on Sourceforge.
