### PR TITLE
Fix remaining Molpro unit tests

### DIFF
--- a/data/Molpro/basicMolpro2012/dvb_gopt.com
+++ b/data/Molpro/basicMolpro2012/dvb_gopt.com
@@ -48,4 +48,4 @@ optg,procedure=rundft
 rundft={ks,b3lyp}
 ks,b3lyp;
 orbprint,9999
-
+pop

--- a/data/Molpro/basicMolpro2012/dvb_gopt.log
+++ b/data/Molpro/basicMolpro2012/dvb_gopt.log
@@ -358,8 +358,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1692779. AND WROTE      779623. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      779623. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
+ SORT1 READ     1692779. AND WROTE      779623. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.07 SEC
+ SORT2 READ      779623. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.11 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -380,7 +380,7 @@
  Functional: VWN5                      Factor:  0.1900
  
  Generated new metagrid on record  1800.2 with target accuracy 1.0D-06 and 90732 points in CPU time    1.2
- Computed new grid on record 1800.1 in CPU time    1.7
+ Computed new grid on record 1800.1 in CPU time    1.6
    52784 words reserved for DFT integration
 
  PROGRAM * RKS-SCF (Restricted closed shell Kohn-Sham)     Authors: W. Meyer, H.-J. Werner, P.J. Knowles, 1993
@@ -453,8 +453,8 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS       INT
- CPU TIMES  *        21.24      7.65      7.27      1.44
- REAL TIME  *        37.50 SEC
+ CPU TIMES  *        21.23      7.46      7.40      1.45
+ REAL TIME  *        33.06 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
@@ -870,7 +870,7 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1698956. AND WROTE      783486. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
+ SORT1 READ     1698956. AND WROTE      783486. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.06 SEC
  SORT2 READ      783486. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
@@ -892,7 +892,7 @@
  Functional: VWN5                      Factor:  0.1900
  
  Generated new metagrid on record  1800.2 with target accuracy 1.0D-06 and 91028 points in CPU time    1.2
- Computed new grid on record 1800.1 in CPU time    1.7
+ Computed new grid on record 1800.1 in CPU time    1.6
    52784 words reserved for DFT integration
 
  PROGRAM * RKS-SCF (Restricted closed shell Kohn-Sham)     Authors: W. Meyer, H.-J. Werner, P.J. Knowles, 1993
@@ -965,12 +965,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS       INT
- CPU TIMES  *        33.57      7.63      7.65      7.27      1.44
- REAL TIME  *        52.54 SEC
+ CPU TIMES  *        33.30      7.50      7.46      7.40      1.45
+ REAL TIME  *        50.93 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        33.5 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        33.2 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
 
@@ -1383,8 +1383,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1702570. AND WROTE      785362. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      785362. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
+ SORT1 READ     1702570. AND WROTE      785362. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.06 SEC
+ SORT2 READ      785362. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.11 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -1405,7 +1405,7 @@
  Functional: VWN5                      Factor:  0.1900
  
  Generated new metagrid on record  1800.2 with target accuracy 1.0D-06 and 90352 points in CPU time    1.2
- Computed new grid on record 1800.1 in CPU time    1.7
+ Computed new grid on record 1800.1 in CPU time    1.6
    52784 words reserved for DFT integration
 
  PROGRAM * RKS-SCF (Restricted closed shell Kohn-Sham)     Authors: W. Meyer, H.-J. Werner, P.J. Knowles, 1993
@@ -1477,12 +1477,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS       INT
- CPU TIMES  *        45.39      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *        66.71 SEC
+ CPU TIMES  *        44.88      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *        66.14 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        45.3 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        44.8 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
    3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907
@@ -1896,8 +1896,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1701911. AND WROTE      784865. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      784865. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.11 SEC
+ SORT1 READ     1701911. AND WROTE      784865. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
+ SORT2 READ      784865. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -1918,7 +1918,7 @@
  Functional: VWN5                      Factor:  0.1900
  
  Generated new metagrid on record  1800.2 with target accuracy 1.0D-06 and 90480 points in CPU time    1.2
- Computed new grid on record 1800.1 in CPU time    1.7
+ Computed new grid on record 1800.1 in CPU time    1.6
    52784 words reserved for DFT integration
 
  PROGRAM * RKS-SCF (Restricted closed shell Kohn-Sham)     Authors: W. Meyer, H.-J. Werner, P.J. Knowles, 1993
@@ -1991,12 +1991,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        57.72      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *        82.70 SEC
+ CPU TIMES  *        56.93      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *        82.96 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        57.6 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        56.8 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
    3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907
@@ -2411,8 +2411,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1701137. AND WROTE      784530. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      784530. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
+ SORT1 READ     1701137. AND WROTE      784530. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.07 SEC
+ SORT2 READ      784530. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -2504,12 +2504,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        68.03      5.76      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *        95.47 SEC
+ CPU TIMES  *        67.27      5.76      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *        96.89 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        67.9 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        67.2 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
    3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907
@@ -2925,8 +2925,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1701245. AND WROTE      784621. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      784621. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.11 SEC
+ SORT1 READ     1701245. AND WROTE      784621. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.06 SEC
+ SORT2 READ      784621. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.11 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -3018,12 +3018,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        78.33      5.75      5.76      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *       108.33 SEC
+ CPU TIMES  *        77.66      5.83      5.76      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *       112.04 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        78.2 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        77.5 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
    3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907
@@ -3440,8 +3440,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1701245. AND WROTE      784593. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.06 SEC
- SORT2 READ      784593. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.10 SEC
+ SORT1 READ     1701245. AND WROTE      784593. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
+ SORT2 READ      784593. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.08 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -3532,12 +3532,12 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        88.33      5.41      5.75      5.76      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *       121.19 SEC
+ CPU TIMES  *        87.75      5.47      5.83      5.76      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *       125.98 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
- PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        88.2 SEC
+ PROGRESS OF GEOMETRY OPTIMIZATION.    TOTAL CPU:        87.6 SEC
    1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611
    2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181
    3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907

--- a/data/Molpro/basicMolpro2012/dvb_gopt.out
+++ b/data/Molpro/basicMolpro2012/dvb_gopt.out
@@ -1,8 +1,8 @@
 
- Primary working directories    : /lustre/scratch/tmp/pbs.6225424.nova
- Secondary working directories  : /lustre/scratch/tmp/pbs.6225424.nova
+ Primary working directories    : /lustre/scratch/tmp/pbs.6489186.nova
+ Secondary working directories  : /lustre/scratch/tmp/pbs.6489186.nova
  Wavefunction directory         : /home/langner/wfu/
- Main file repository           : /lustre/scratch/tmp/pbs.6225424.nova/
+ Main file repository           : /lustre/scratch/tmp/pbs.6489186.nova/
 
  SHA1      : c18f7d37f9f045f75d4f3096db241dde02ddca0a
  ARCHNAME  : Linux/x86_64
@@ -12,7 +12,7 @@
  id        : dmwwroc
 
  Nodes     nprocs
- wn453        1
+ wn720        1
 
  Using customized tuning parameters: mindgm=20; mindgv=20; mindgc=6; mindgr=1; noblas=0; minvec=7
  default implementation of scratch files=df  
@@ -67,11 +67,11 @@
  rundft={ks,b3lyp}
  ks,b3lyp;
  orbprint,9999
- 
+ pop
 
- Variables initialized (774), CPU time= 0.01 sec
- Commands  initialized (547), CPU time= 0.00 sec, 516 directives.
- Default parameters read. Elapsed time= 0.08 sec
+ Variables initialized (774), CPU time= 0.00 sec
+ Commands  initialized (547), CPU time= 0.01 sec, 516 directives.
+ Default parameters read. Elapsed time= 1.00 sec
 
  Checking input...
  Passed
@@ -86,7 +86,7 @@
 
  **********************************************************************************************************************************
  LABEL *   divinylbenzene geom opt                                                       
- Linux-2.6.18-348.3.1.el5/wn453(x86_64) 64 bit serial version                            DATE: 20-Feb-14          TIME: 22:09:16  
+ Linux-2.6.18-348.3.1.el5/wn720(x86_64) 64 bit serial version                            DATE: 21-Mar-14          TIME: 06:14:03  
  **********************************************************************************************************************************
 
  SHA1:             c18f7d37f9f045f75d4f3096db241dde02ddca0a
@@ -435,8 +435,8 @@
 
  Memory used in sort:       2.23 MW
 
- SORT1 READ     1719389. AND WROTE      795052. INTEGRALS IN      3 RECORDS. CPU TIME:     0.03 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.09 SEC
+ SORT1 READ     1719389. AND WROTE      795052. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
+ SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.07 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -451,8 +451,8 @@
                                            T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
 
  PROGRAMS   *        TOTAL       INT
- CPU TIMES  *         1.55      1.44
- REAL TIME  *         1.89 SEC
+ CPU TIMES  *         1.56      1.45
+ REAL TIME  *         3.39 SEC
  DISK USED  *        27.04 MB      
  **********************************************************************************************************************************
 
@@ -796,8 +796,8 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS       INT
- CPU TIMES  *         8.82      7.27      1.44
- REAL TIME  *        12.29 SEC
+ CPU TIMES  *         8.96      7.40      1.45
+ REAL TIME  *        14.74 SEC
  DISK USED  *        27.04 MB      
  **********************************************************************************************************************************
 
@@ -811,14 +811,14 @@
  Quadratic Steepest Descent - Minimum Search
 
  ITER.   ENERGY(OLD)    ENERGY(NEW)      DE          GRADMAX     GRADNORM    GRADRMS     STEPMAX     STEPLEN     STEPRMS   CPU-time
-   1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611     21.13
-   2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181     33.46
-   3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907     45.28
+   1  -382.02936906  -382.04929131    -0.01992225  0.10954412  0.15375980  0.03729223  0.20032864  0.26275393  0.01545611     21.12
+   2  -382.04929131  -382.04869539     0.00059592  0.02258077  0.03512807  0.00851981  0.02765825  0.04100083  0.00241181     33.19
+   3  -382.04869539  -382.04801079     0.00068459  0.00757500  0.01151274  0.00279225  0.01170140  0.01562411  0.00091907     44.77
  Freezing grid
-   4  -382.04801079  -382.04825935    -0.00024855  0.00324133  0.00575224  0.00139512  0.00263857  0.00415160  0.00024421     57.61
-   5  -382.04825935  -382.04837814    -0.00011879  0.00085907  0.00161483  0.00039165  0.00158828  0.00229397  0.00013494     67.92
-   6  -382.04837814  -382.04834596     0.00003217  0.00038057  0.00070689  0.00017145  0.00047314  0.00064556  0.00003797     78.22
-   7  -382.04834596  -382.04835616    -0.00001020  0.00026274  0.00042006  0.00010188  0.00019535  0.00035324  0.00002078     88.22
+   4  -382.04801079  -382.04825935    -0.00024855  0.00324133  0.00575224  0.00139512  0.00263857  0.00415160  0.00024421     56.82
+   5  -382.04825935  -382.04837814    -0.00011879  0.00085907  0.00161483  0.00039165  0.00158828  0.00229397  0.00013494     67.16
+   6  -382.04837814  -382.04834596     0.00003217  0.00038057  0.00070689  0.00017145  0.00047314  0.00064556  0.00003797     77.55
+   7  -382.04834596  -382.04835616    -0.00001020  0.00026274  0.00042006  0.00010188  0.00019535  0.00035324  0.00002078     87.64
 
  END OF GEOMETRY OPTIMIZATION.
 
@@ -884,8 +884,8 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL      OPTG        KS        KS        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        88.33      5.41      5.75      5.76      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *       121.20 SEC
+ CPU TIMES  *        87.75      5.47      5.83      5.76      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *       125.99 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 
@@ -894,6 +894,7 @@
  Functional: DIRAC(Automatically generated (new) DIRAC)                        Gradient terms: 0
  Functional: LYP(Automatically generated (new) LYP)                            Gradient terms: 1
  Functional: VWN5(Automatically generated (new) VWN5)                          Gradient terms: 0
+ Use grid at  1800.2
  
 
  Exact exchange will be calculated, factor:  0.2000
@@ -1387,8 +1388,54 @@
                                         OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS      RKS  
 
  PROGRAMS   *        TOTAL        KS        KS        KS        KS        KS        KS        KS        KS        KS       INT
- CPU TIMES  *        89.33      0.99      5.41      5.75      5.76      7.51      7.06      7.63      7.65      7.27      1.44
- REAL TIME  *       123.00 SEC
+ CPU TIMES  *        88.77      1.01      5.47      5.83      5.76      7.45      6.99      7.50      7.46      7.40      1.45
+ REAL TIME  *       128.23 SEC
+ DISK USED  *        27.19 MB      
+ **********************************************************************************************************************************
+
+1PROGRAM * POP (Mulliken population analysis)
+
+ 
+ Density matrix read from record         2101.2  Type=RKS/CHARGE (state 1.1)
+ 
+ Population analysis by basis function type
+
+ Unique atom        s        p        d        f        g    Total    Charge
+   2  C       3.12421  2.88180  0.00000  0.00000  0.00000  6.00601  - 0.00601
+   3  C       3.14501  2.93137  0.00000  0.00000  0.00000  6.07638  - 0.07638
+   4  C       3.14305  2.93311  0.00000  0.00000  0.00000  6.07616  - 0.07616
+   5  C       3.12421  2.88180  0.00000  0.00000  0.00000  6.00601  - 0.00601
+   6  C       3.14501  2.93137  0.00000  0.00000  0.00000  6.07638  - 0.07638
+   7  C       3.14305  2.93311  0.00000  0.00000  0.00000  6.07616  - 0.07616
+   8  C       3.14852  2.92817  0.00000  0.00000  0.00000  6.07669  - 0.07669
+   9  C       3.14852  2.92817  0.00000  0.00000  0.00000  6.07669  - 0.07669
+  10  H       0.92107  0.00000  0.00000  0.00000  0.00000  0.92107  + 0.07893
+  11  H       0.92107  0.00000  0.00000  0.00000  0.00000  0.92107  + 0.07893
+  12  H       0.92233  0.00000  0.00000  0.00000  0.00000  0.92233  + 0.07767
+  13  H       0.92233  0.00000  0.00000  0.00000  0.00000  0.92233  + 0.07767
+  14  C       3.16784  2.98531  0.00000  0.00000  0.00000  6.15315  - 0.15315
+  15  C       3.16784  2.98531  0.00000  0.00000  0.00000  6.15315  - 0.15315
+  16  H       0.92266  0.00000  0.00000  0.00000  0.00000  0.92266  + 0.07734
+  17  H       0.92266  0.00000  0.00000  0.00000  0.00000  0.92266  + 0.07734
+  18  H       0.92155  0.00000  0.00000  0.00000  0.00000  0.92155  + 0.07845
+  19  H       0.92155  0.00000  0.00000  0.00000  0.00000  0.92155  + 0.07845
+  20  H       0.92401  0.00000  0.00000  0.00000  0.00000  0.92401  + 0.07599
+  21  H       0.92401  0.00000  0.00000  0.00000  0.00000  0.92401  + 0.07599
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      20       13.79       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700     1800   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER     GRID   
+
+              2       7        1.05       200      700     1000      520     1800     2100     2101   
+                                        OPTIONS   GEOM     BASIS   MCVARS    GRID      RKS      RKS  
+
+ PROGRAMS   *        TOTAL       POP        KS        KS        KS        KS        KS        KS        KS        KS        KS
+ CPU TIMES  *        88.78      0.01      1.01      5.47      5.83      5.76      7.45      6.99      7.50      7.46      7.40
+ REAL TIME  *       128.24 SEC
  DISK USED  *        27.19 MB      
  **********************************************************************************************************************************
 

--- a/data/Molpro/basicMolpro2012/dvb_sphf.com
+++ b/data/Molpro/basicMolpro2012/dvb_sphf.com
@@ -45,6 +45,7 @@ hcc20=      126.000
 
 hf
 orbprint,9999
+pop
 {matrop
 load,s
 print,s}

--- a/data/Molpro/basicMolpro2012/dvb_sphf.out
+++ b/data/Molpro/basicMolpro2012/dvb_sphf.out
@@ -1,8 +1,8 @@
 
- Primary working directories    : /lustre/scratch/tmp/pbs.6225433.nova
- Secondary working directories  : /lustre/scratch/tmp/pbs.6225433.nova
+ Primary working directories    : /lustre/scratch/tmp/pbs.6489172.nova
+ Secondary working directories  : /lustre/scratch/tmp/pbs.6489172.nova
  Wavefunction directory         : /home/langner/wfu/
- Main file repository           : /lustre/scratch/tmp/pbs.6225433.nova/
+ Main file repository           : /lustre/scratch/tmp/pbs.6489172.nova/
 
  SHA1      : c18f7d37f9f045f75d4f3096db241dde02ddca0a
  ARCHNAME  : Linux/x86_64
@@ -12,7 +12,7 @@
  id        : dmwwroc
 
  Nodes     nprocs
- wn453        1
+ wn719        1
 
  Using customized tuning parameters: mindgm=20; mindgv=20; mindgc=6; mindgr=1; noblas=0; minvec=7
  default implementation of scratch files=df  
@@ -64,13 +64,14 @@
  
  hf
  orbprint,9999
+ pop
  {matrop
  load,s
  print,s}
 
  Variables initialized (774), CPU time= 0.01 sec
- Commands  initialized (547), CPU time= 0.01 sec, 516 directives.
- Default parameters read. Elapsed time= 0.10 sec
+ Commands  initialized (547), CPU time= 0.00 sec, 516 directives.
+ Default parameters read. Elapsed time= 0.09 sec
 
  Checking input...
  Passed
@@ -85,7 +86,7 @@
 
  **********************************************************************************************************************************
  LABEL *   divinylbenzene sp scf                                                         
- Linux-2.6.18-348.3.1.el5/wn453(x86_64) 64 bit serial version                            DATE: 20-Feb-14          TIME: 22:14:26  
+ Linux-2.6.18-348.3.1.el5/wn719(x86_64) 64 bit serial version                            DATE: 21-Mar-14          TIME: 05:52:10  
  **********************************************************************************************************************************
 
  SHA1:             c18f7d37f9f045f75d4f3096db241dde02ddca0a
@@ -410,7 +411,7 @@
  Memory used in sort:       2.23 MW
 
  SORT1 READ     1719389. AND WROTE      795052. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
+ SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.05 SEC, REAL TIME:     0.09 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -425,8 +426,8 @@
                                            T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
 
  PROGRAMS   *        TOTAL       INT
- CPU TIMES  *         1.57      1.46
- REAL TIME  *         1.89 SEC
+ CPU TIMES  *         1.52      1.42
+ REAL TIME  *         1.99 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 
@@ -924,8 +925,54 @@
                                          GEOM     BASIS   MCVARS     RHF  
 
  PROGRAMS   *        TOTAL        HF       INT
- CPU TIMES  *         1.85      0.28      1.46
- REAL TIME  *         2.23 SEC
+ CPU TIMES  *         1.80      0.28      1.42
+ REAL TIME  *         2.42 SEC
+ DISK USED  *        26.78 MB      
+ **********************************************************************************************************************************
+
+1PROGRAM * POP (Mulliken population analysis)
+
+ 
+ Density matrix read from record         2100.2  Type=RHF/CHARGE (state 1.1)
+ 
+ Population analysis by basis function type
+
+ Unique atom        s        p        d        f        g    Total    Charge
+   2  C       3.11797  2.88497  0.00000  0.00000  0.00000  6.00294  - 0.00294
+   3  C       3.14091  2.91892  0.00000  0.00000  0.00000  6.05984  - 0.05984
+   4  C       3.13961  2.92010  0.00000  0.00000  0.00000  6.05971  - 0.05971
+   5  C       3.11797  2.88497  0.00000  0.00000  0.00000  6.00294  - 0.00294
+   6  C       3.14091  2.91892  0.00000  0.00000  0.00000  6.05984  - 0.05984
+   7  C       3.13961  2.92010  0.00000  0.00000  0.00000  6.05971  - 0.05971
+   8  C       3.13511  2.92246  0.00000  0.00000  0.00000  6.05756  - 0.05756
+   9  C       3.13511  2.92246  0.00000  0.00000  0.00000  6.05756  - 0.05756
+  10  H       0.94177  0.00000  0.00000  0.00000  0.00000  0.94177  + 0.05823
+  11  H       0.94177  0.00000  0.00000  0.00000  0.00000  0.94177  + 0.05823
+  12  H       0.94377  0.00000  0.00000  0.00000  0.00000  0.94377  + 0.05623
+  13  H       0.94377  0.00000  0.00000  0.00000  0.00000  0.94377  + 0.05623
+  14  C       3.15749  2.96746  0.00000  0.00000  0.00000  6.12495  - 0.12495
+  15  C       3.15749  2.96746  0.00000  0.00000  0.00000  6.12495  - 0.12495
+  16  H       0.93798  0.00000  0.00000  0.00000  0.00000  0.93798  + 0.06202
+  17  H       0.93798  0.00000  0.00000  0.00000  0.00000  0.93798  + 0.06202
+  18  H       0.94105  0.00000  0.00000  0.00000  0.00000  0.94105  + 0.05895
+  19  H       0.94105  0.00000  0.00000  0.00000  0.00000  0.94105  + 0.05895
+  20  H       0.93043  0.00000  0.00000  0.00000  0.00000  0.93043  + 0.06957
+  21  H       0.93043  0.00000  0.00000  0.00000  0.00000  0.93043  + 0.06957
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      19       10.93       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
+
+              2       4        0.59       700     1000      520     2100   
+                                         GEOM     BASIS   MCVARS     RHF  
+
+ PROGRAMS   *        TOTAL       POP        HF       INT
+ CPU TIMES  *         1.80      0.00      0.28      1.42
+ REAL TIME  *         2.44 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 
@@ -1010,9 +1057,9 @@
               2       4        0.59       700     1000      520     2100   
                                          GEOM     BASIS   MCVARS     RHF  
 
- PROGRAMS   *        TOTAL    MATROP        HF       INT
- CPU TIMES  *         1.87      0.02      0.28      1.46
- REAL TIME  *         2.27 SEC
+ PROGRAMS   *        TOTAL    MATROP       POP        HF       INT
+ CPU TIMES  *         1.82      0.02      0.00      0.28      1.42
+ REAL TIME  *         2.47 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 

--- a/data/Molpro/basicMolpro2012/dvb_spks.com
+++ b/data/Molpro/basicMolpro2012/dvb_spks.com
@@ -45,6 +45,7 @@ hcc20=      126.000
 
 ks,b3lyp;
 orbprint,10
+pop
 {matrop
 load,s
 print,s}

--- a/data/Molpro/basicMolpro2012/dvb_spks.out
+++ b/data/Molpro/basicMolpro2012/dvb_spks.out
@@ -1,8 +1,8 @@
 
- Primary working directories    : /lustre/scratch/tmp/pbs.6225435.nova
- Secondary working directories  : /lustre/scratch/tmp/pbs.6225435.nova
+ Primary working directories    : /lustre/scratch/tmp/pbs.6489173.nova
+ Secondary working directories  : /lustre/scratch/tmp/pbs.6489173.nova
  Wavefunction directory         : /home/langner/wfu/
- Main file repository           : /lustre/scratch/tmp/pbs.6225435.nova/
+ Main file repository           : /lustre/scratch/tmp/pbs.6489173.nova/
 
  SHA1      : c18f7d37f9f045f75d4f3096db241dde02ddca0a
  ARCHNAME  : Linux/x86_64
@@ -12,7 +12,7 @@
  id        : dmwwroc
 
  Nodes     nprocs
- wn452        1
+ wn719        1
 
  Using customized tuning parameters: mindgm=20; mindgv=20; mindgc=6; mindgr=1; noblas=0; minvec=7
  default implementation of scratch files=df  
@@ -64,13 +64,14 @@
  
  ks,b3lyp;
  orbprint,10
+ pop
  {matrop
  load,s
  print,s}
 
  Variables initialized (774), CPU time= 0.01 sec
- Commands  initialized (547), CPU time= 0.00 sec, 516 directives.
- Default parameters read. Elapsed time= 0.13 sec
+ Commands  initialized (547), CPU time= 0.01 sec, 516 directives.
+ Default parameters read. Elapsed time= 0.21 sec
 
  Checking input...
  Passed
@@ -85,7 +86,7 @@
 
  **********************************************************************************************************************************
  LABEL *   divinylbenzene sp dft                                                         
- Linux-2.6.18-348.3.1.el5/wn452(x86_64) 64 bit serial version                            DATE: 20-Feb-14          TIME: 22:14:28  
+ Linux-2.6.18-348.3.1.el5/wn719(x86_64) 64 bit serial version                            DATE: 21-Mar-14          TIME: 05:55:10  
  **********************************************************************************************************************************
 
  SHA1:             c18f7d37f9f045f75d4f3096db241dde02ddca0a
@@ -410,7 +411,7 @@
  Memory used in sort:       2.23 MW
 
  SORT1 READ     1719389. AND WROTE      795052. INTEGRALS IN      3 RECORDS. CPU TIME:     0.04 SEC, REAL TIME:     0.07 SEC
- SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.05 SEC, REAL TIME:     0.10 SEC
+ SORT2 READ      795052. AND WROTE     1675365. INTEGRALS IN     22 RECORDS. CPU TIME:     0.06 SEC, REAL TIME:     0.10 SEC
 
  FILE SIZES:   FILE 1:    13.7 MBYTE,  FILE 4:    12.6 MBYTE,   TOTAL:     26.3 MBYTE
 
@@ -425,8 +426,8 @@
                                            T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER   
 
  PROGRAMS   *        TOTAL       INT
- CPU TIMES  *         1.51      1.41
- REAL TIME  *         1.88 SEC
+ CPU TIMES  *         1.54      1.44
+ REAL TIME  *         2.13 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 
@@ -839,8 +840,54 @@
                                          GEOM     BASIS   MCVARS    GRID      RKS  
 
  PROGRAMS   *        TOTAL        KS       INT
- CPU TIMES  *         8.11      6.59      1.41
- REAL TIME  *        11.36 SEC
+ CPU TIMES  *         8.12      6.58      1.44
+ REAL TIME  *        11.95 SEC
+ DISK USED  *        26.78 MB      
+ **********************************************************************************************************************************
+
+1PROGRAM * POP (Mulliken population analysis)
+
+ 
+ Density matrix read from record         2100.2  Type=RKS/CHARGE (state 1.1)
+ 
+ Population analysis by basis function type
+
+ Unique atom        s        p        d        f        g    Total    Charge
+   2  C       3.12270  2.88553  0.00000  0.00000  0.00000  6.00823  - 0.00823
+   3  C       3.15039  2.92626  0.00000  0.00000  0.00000  6.07665  - 0.07665
+   4  C       3.14892  2.92674  0.00000  0.00000  0.00000  6.07567  - 0.07567
+   5  C       3.12270  2.88553  0.00000  0.00000  0.00000  6.00823  - 0.00823
+   6  C       3.15039  2.92626  0.00000  0.00000  0.00000  6.07665  - 0.07665
+   7  C       3.14892  2.92674  0.00000  0.00000  0.00000  6.07567  - 0.07567
+   8  C       3.14395  2.93385  0.00000  0.00000  0.00000  6.07780  - 0.07780
+   9  C       3.14395  2.93385  0.00000  0.00000  0.00000  6.07780  - 0.07780
+  10  H       0.92393  0.00000  0.00000  0.00000  0.00000  0.92393  + 0.07607
+  11  H       0.92393  0.00000  0.00000  0.00000  0.00000  0.92393  + 0.07607
+  12  H       0.92433  0.00000  0.00000  0.00000  0.00000  0.92433  + 0.07567
+  13  H       0.92433  0.00000  0.00000  0.00000  0.00000  0.92433  + 0.07567
+  14  C       3.17035  2.98337  0.00000  0.00000  0.00000  6.15373  - 0.15373
+  15  C       3.17035  2.98337  0.00000  0.00000  0.00000  6.15373  - 0.15373
+  16  H       0.92026  0.00000  0.00000  0.00000  0.00000  0.92026  + 0.07974
+  17  H       0.92026  0.00000  0.00000  0.00000  0.00000  0.92026  + 0.07974
+  18  H       0.92266  0.00000  0.00000  0.00000  0.00000  0.92266  + 0.07734
+  19  H       0.92266  0.00000  0.00000  0.00000  0.00000  0.92266  + 0.07734
+  20  H       0.91676  0.00000  0.00000  0.00000  0.00000  0.91676  + 0.08324
+  21  H       0.91676  0.00000  0.00000  0.00000  0.00000  0.91676  + 0.08324
+
+
+ **********************************************************************************************************************************
+ DATASETS  * FILE   NREC   LENGTH (MB)   RECORD NAMES
+              1      20       13.87       500      610      700      900      950      970     1000      129      960     1100   
+                                          VAR    BASINP    GEOM    SYMINP    ZMAT    AOBASIS   BASIS     P2S    ABASIS      S 
+                                         1400     1410     1200     1210     1080     1600     1650     1300     1700     1800   
+                                           T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS     OPER     GRID   
+
+              2       5        0.61       700     1000      520     1800     2100   
+                                         GEOM     BASIS   MCVARS    GRID      RKS  
+
+ PROGRAMS   *        TOTAL       POP        KS       INT
+ CPU TIMES  *         8.12      0.00      6.58      1.44
+ REAL TIME  *        11.96 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 
@@ -925,9 +972,9 @@
               2       5        0.61       700     1000      520     1800     2100   
                                          GEOM     BASIS   MCVARS    GRID      RKS  
 
- PROGRAMS   *        TOTAL    MATROP        KS       INT
- CPU TIMES  *         8.13      0.03      6.59      1.41
- REAL TIME  *        11.39 SEC
+ PROGRAMS   *        TOTAL    MATROP       POP        KS       INT
+ CPU TIMES  *         8.14      0.02      0.00      6.58      1.44
+ REAL TIME  *        12.00 SEC
  DISK USED  *        26.78 MB      
  **********************************************************************************************************************************
 

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -659,6 +659,40 @@ class Molpro(logfileparser.Logfile):
                 line = next(inputfile)
                 self.amass += list(map(float, line.strip().split()[2:]))        
 
+        #1PROGRAM * POP (Mulliken population analysis)
+        #
+        #
+        # Density matrix read from record         2100.2  Type=RHF/CHARGE (state 1.1)
+        # 
+        # Population analysis by basis function type
+        #
+        # Unique atom        s        p        d        f        g    Total    Charge
+        #   2  C       3.11797  2.88497  0.00000  0.00000  0.00000  6.00294  - 0.00294
+        #   3  C       3.14091  2.91892  0.00000  0.00000  0.00000  6.05984  - 0.05984
+        # ...
+        if line.strip() == "1PROGRAM * POP (Mulliken population analysis)":
+
+            blank = next(inputfile)
+            blank = next(inputfile)
+            density_source = next(inputfile)
+            blank = next(inputfile)
+            function_type_comment = next(inputfile)
+            blank = next(inputfile)
+
+            header = next(inputfile)
+            icharge = header.split().index('Charge')
+
+            charges = []
+            line = next(inputfile)
+            while line.strip():
+                cols = line.split()
+                charges.append(float(cols[icharge]+cols[icharge+1]))
+                line = next(inputfile)
+
+            if not hasattr(self, "atomcharges"):
+                self.atomcharges = {}
+            self.atomcharges['mulliken'] = charges
+
 
 if __name__ == "__main__":
     import doctest, molproparser

--- a/test/testGeoOpt.py
+++ b/test/testGeoOpt.py
@@ -258,6 +258,16 @@ class MolproGeoOptTest(GenericGeoOptTest):
         """Are all the symmetry labels either Ag/u or Bg/u? PASS"""
         self.assertEquals(1,1)
 
+class MolproGeoOptTest2006(MolproGeoOptTest):
+    """Molpro 2006 geometry optimization unittest."""
+
+    # Same situation as SP -- this is tested for in the 2012 logfiles, but
+    # the 2006 logfiles were created before atomcharges was an attribute and
+    # we don't have access to Molpro 2006 anymore.
+    def testatomcharges(self):
+        """Are all atomcharges consistent with natom and do they sum to zero? PASS"""
+        self.assertEquals(1,1)
+
 
 class OrcaGeoOptTest(GenericGeoOptTest):
     """ORCA geometry optimization unittest."""

--- a/test/testSP.py
+++ b/test/testSP.py
@@ -191,6 +191,15 @@ class MolproSPTest(GenericSPTest):
         """Are all the symmetry labels either Ag/u or Bg/u? PASS"""
         self.assertEquals(1,1)
 
+class MolproSPTest2006(MolproSPTest):
+    """Molpro restricted single point unittest for version 2006."""
+
+    # These tests were run a long time ago and since we don't have access
+    # to Molpro 2006 anymore, we can skip this test (it is tested in 2012).
+    def testatomcharges(self):
+        """Are atomcharges (at least Mulliken) consistent with natom and sum to zero? PASS"""
+        self.assertEquals(1,1)
+
 
 class OrcaSPTest(GenericSPTest):
     """ORCA restricted single point unittest."""

--- a/test/testdata
+++ b/test/testdata
@@ -56,7 +56,7 @@ GeoOpt    Gaussian    GaussianGeoOptTest    basicGaussian03       dvb_gopt.out
 GeoOpt    Gaussian    GaussianGeoOptTest    basicGaussian09       dvb_gopt.out
 GeoOpt    Jaguar      JaguarGeoOptTest      basicJaguar7.0        dvb_gopt_b.out
 GeoOpt    GAMESS      PCGamessGeoOptTest    basicPCGAMESS         dvb_gopt_b.out
-GeoOpt    Molpro      MolproGeoOptTest      basicMolpro2006       dvb_gopt.out          dvb_gopt.log
+GeoOpt    Molpro      MolproGeoOptTest2006  basicMolpro2006       dvb_gopt.out          dvb_gopt.log
 GeoOpt    Molpro      MolproGeoOptTest      basicMolpro2012       dvb_gopt.out          dvb_gopt.log
 GeoOpt    ORCA        OrcaGeoOptTest        basicORCA2.9          dvb_gopt.out
 GeoOpt    ORCA        OrcaGeoOptTest        basicORCA3.0          dvb_gopt.out
@@ -94,7 +94,7 @@ SP        Gaussian    GaussianSPTest        basicGaussian03       dvb_sp.out
 SP        Gaussian    GaussianSPTest        basicGaussian09       dvb_sp.out
 SP        Jaguar      JaguarSPTest          basicJaguar7.0        dvb_sp.out
 SP        GAMESS      PCGamessSPTest        basicPCGAMESS         dvb_sp.out
-SP        Molpro      MolproSPTest          basicMolpro2006       dvb_sphf.out
+SP        Molpro      MolproSPTest2006      basicMolpro2006       dvb_sphf.out
 SP        Molpro      MolproSPTest          basicMolpro2012       dvb_sphf.out
 SP        ORCA        OrcaSPTest            basicORCA2.9          dvb_sp.out
 SP        ORCA        OrcaSPTest            basicORCA3.0          dvb_sp.out


### PR DESCRIPTION
Had to rerun the logfiles that are supposed to contain atomic charges, and added the attribute to the parser.

This fixes #42
