### PR TITLE
Jaguar: pass atomcharges tests, since unit test files don't have them

### DIFF
--- a/test/testGeoOpt.py
+++ b/test/testGeoOpt.py
@@ -237,7 +237,12 @@ class JaguarGeoOptTest(GenericGeoOptTest):
     def testatombasis(self):
         """Are the indices in atombasis the right amount and unique? PASS"""
         self.assertEquals(1, 1)
-       
+
+    # We did not print the atomic partial charges in the unit tests for this version.
+    def testatomcharges(self):
+        """Are all atomcharges consistent with natom and do they sum to zero? PASS"""
+        self.assertEquals(1, 1)
+
     # Data file does not contain enough information. Can we make a new one?
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis? PASS"""

--- a/test/testSP.py
+++ b/test/testSP.py
@@ -172,7 +172,12 @@ class JaguarSPTest(GenericSPTest):
     def testatombasis(self):
         """Are the indices in atombasis the right amount and unique? PASS"""
         self.assertEquals(1, 1)
-       
+
+    # We did not print the atomic partial charges in the unit tests for this version.
+    def testatomcharges(self):
+        """Are all atomcharges consistent with natom and do they sum to zero? PASS"""
+        self.assertEquals(1, 1)
+
     # Jaguar prints only 10 virtual MOs by default. Can we re-run with full output?
     def testlengthmoenergies(self):
         """Is the number of evalues equal to the number of occ. MOs + 10?"""


### PR DESCRIPTION
Just to have zero errors/fails in the unit tests. I will at atomcharges output in the new unit tests for Jaguar.
