### PR TITLE
ORCA: fix parsing of geotargets and geovalues, and implement custom covergence condition for unit test (fixes #75)

### DIFF
--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -152,40 +152,101 @@ class ORCA(logfileparser.Logfile):
 
             self._append_scfvalues_scftargets(inputfile, line)  
 
+        # The convergence targets for geometry optimizations are printed at the
+        # beginning of the output, although the order and their description is
+        # different than later on. So, try to standardize the names of the criteria
+        # and save them for later so that we can get the order right.
+        #
+        #                        *****************************
+        #                        * Geometry Optimization Run *
+        #                        *****************************
+        #
+        # Geometry optimization settings:
+        # Update method            Update   .... BFGS
+        # Choice of coordinates    CoordSys .... Redundant Internals
+        # Initial Hessian          InHess   .... Almoef's Model
+        #
+        # Convergence Tolerances:
+        # Energy Change            TolE     ....  5.0000e-06 Eh
+        # Max. Gradient            TolMAXG  ....  3.0000e-04 Eh/bohr
+        # RMS Gradient             TolRMSG  ....  1.0000e-04 Eh/bohr
+        # Max. Displacement        TolMAXD  ....  4.0000e-03 bohr
+        # RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
+        #
         if line[25:50] == "Geometry Optimization Run":
+
+            stars = next(inputfile)
+            blank = next(inputfile)
 
             line = next(inputfile)
             while line[0:23] != "Convergence Tolerances:":
                 line = next(inputfile)
 
-            self.geotargets = numpy.zeros((5,), "d")
+            if hasattr(self, 'geotargets'):
+                self.logger.warning('The geotargets attribute should not exist yet. There is a problem in the parser.')
+            self.geotargets = []
+            self.geotargets_names = []
+
+            # There should always be five tolerance values printed here.
             for i in range(5):
                 line = next(inputfile)
-                self.geotargets[i] = float(line.split()[-2])
+                name = line[:25].strip().lower().replace('.','').replace('displacement', 'step')
+                target = float(line.split()[-2])
+                self.geotargets_names.append(name)
+                self.geotargets.append(target)
 
-        #get geometry convergence criteria
+        # After each geometry optimization step, ORCA prints the current convergence
+        # parameters and the targets (again), so it is a good idea to check that they
+        # have not changed. Note that the order of these criteria here are different
+        # than at the beginning of the output, so make use of the geotargets_names created
+        # before and save the new geovalues in correct order.
+        #
+        #          ----------------------|Geometry convergence|---------------------
+        #          Item                value                 Tolerance   Converged
+        #          -----------------------------------------------------------------
+        #          Energy change       0.00006021            0.00000500      NO
+        #          RMS gradient        0.00031313            0.00010000      NO
+        #          RMS step            0.01596159            0.00200000      NO
+        #          MAX step            0.04324586            0.00400000      NO
+        #          ....................................................
+        #          Max(Bonds)      0.0218      Max(Angles)    2.48
+        #          Max(Dihed)        0.00      Max(Improp)    0.00
+        #          -----------------------------------------------------------------
+        #
         if line[33:53] == "Geometry convergence":
+
             if not hasattr(self, "geovalues"):
-                self.geovalues = [ ]
+                self.geovalues = []
             
-            newlist = []
             headers = next(inputfile)
             dashes = next(inputfile)
-            
-            #check if energy change is present (steps > 1)
-            line = next(inputfile)
-            if line.find("Energy change") > 0:
-                newlist.append(float(line.split()[2]))
-                line = next(inputfile)
-            else:
-                newlist.append(0.0)
 
-            #get rest of info
-            for i in range(4):
-                newlist.append(float(line.split()[2]))
+            names = []
+            values = []
+            targets = []
+            line = next(inputfile)
+            while list(set(line.strip())) != ["."]:
+                name = line[10:28].strip().lower()
+                value = float(line.split()[2])
+                target = float(line.split()[3])
+                names.append(name)
+                values.append(value)
+                targets.append(target)
                 line = next(inputfile)
+
+            # The energy change is normally not printed in the first iteration, because
+            # there was no previous energy -- in that case assume zero, but check that
+            # no previous geovalues were parsed.
+            newvalues = []
+            for i, n in enumerate(self.geotargets_names):
+                if (n == "energy change") and (n not in names):
+                    assert len(self.geovalues) == 0
+                    newvalues.append(0.0)
+                else:
+                    newvalues.append(values[names.index(n)])
+                    assert targets[names.index(n)] == self.geotargets[i]
             
-            self.geovalues.append(newlist)
+            self.geovalues.append(newvalues)
 
         #if not an optimization, determine structure used
         if line[0:21] == "CARTESIAN COORDINATES" and not hasattr(self, "atomcoords"):

--- a/test/testGeoOpt.py
+++ b/test/testGeoOpt.py
@@ -309,6 +309,36 @@ class OrcaGeoOptTest(GenericGeoOptTest):
         """Are all the symmetry labels either Ag/u or Bg/u? PASS"""
         self.assertEquals(1,1)
 
+    # Besides all the geovalues being below their tolerances, ORCA also considers
+    # an optimization finished in some extra cases. These are:
+    #   1) everything converged except the energy (within 25 x tolerance)
+    #   2) gradient is overachieved and displacement is reasonable (3 x tolerance)
+    #   3) displacement is overachieved and gradient is reasonable (3 x tolerance)
+    #   4) energy, gradients and angles are converged (displacements not considered)
+    # All these exceptions are signaleld in the output with some comments, and here
+    # we include the first three exceptions for the pruposes of the unit test.
+    def testoptdone(self):
+        """Has the geometry converged and set optdone to True?"""
+
+        self.assertTrue(self.data.optdone)
+
+        targets = self.data.geotargets
+        values = numpy.abs(self.data.geovalues[-1])
+
+        target_e = targets[0]
+        target_g = targets[1:3]
+        target_x = targets[3:]
+        value_e = values[0]
+        value_g = values[1:3]
+        value_x = values[3:]
+
+        conv_all = all(values < targets)
+        conv_e = value_e < 25*target_e and all(value_g < target_g) and all(value_x < target_x)
+        conv_g = value_e < target_e and all(value_g < target_g/3.0) and all(value_x < target_x*3.0)
+        conv_x = value_e < target_e and all(value_g < target_g*3.0) and all(value_x < target_x/3.0)
+        converged = conv_all or conv_e or conv_g or conv_x
+        self.assertTrue(converged)
+
 
 class PCGamessGeoOptTest(GenericGeoOptTest):
     """PC-GAMESS geometry optimization unittest."""


### PR DESCRIPTION
This is the last bit for optdone in v1.2, involving a custom covergence condition for the unit test for ORCA. Also noticed a problem with the order of geotargets/geovalues, so fixed that in the parser.
