### PR TITLE
Fix regression test script

### DIFF
--- a/test/regression.py
+++ b/test/regression.py
@@ -17,6 +17,7 @@ To run the doctest, just use "python regression.py test".
 from __future__ import print_function
 import os
 import sys
+import importlib
 import inspect
 import logging
 import unittest
@@ -28,42 +29,20 @@ from cclib.parser import ccopen
 from cclib.parser import ADF, GAMESS, GAMESSUK, Gaussian, Jaguar, Molpro, ORCA
 
 import testall
-parsers = testall.parsers
-test_modules = testall.test_modules
 
-# The regression test functions defined below should be named according to the path
-# of the logfile, with some characters changed according to normalisefilename().
 
-def testADF_ADF2004_01_dvb_sp_c_adfout(logfile):
-    """Had homo[0] as 35, when it should be 34."""
-    assert logfile.data.homos[0] == 34
+# The following regression test functions were manually written, because they
+# contain custom checks that were determined on a per-file basis. Care needs to be taken
+# that the function name corresponds to the path of the logfile, with some characters
+# changed according to normalisefilename().
 
+# ADF #
 
 def testADF_ADF2004_01_Fe_ox3_final_out(logfile):
     """Make sure HOMOS are correct."""
     assert logfile.data.homos[0]==59 and logfile.data.homos[1]==54
 
-
-def testGAMESS_basicGAMESS_US_water_ccd_out(logfile):
-    """Keep parsing ccenergies correctly."""
-    assert len(logfile.data.ccenergies) == 1
-    assert abs(logfile.data.ccenergies[0] + 2074.22) < 0.01
-
-def testGAMESS_basicGAMESS_US_water_ccsd_out(logfile):
-    """Keep parsing ccenergies correctly"""
-    assert len(logfile.data.ccenergies) == 1
-    assert abs(logfile.data.ccenergies[0] + 2074.24) < 0.01
-
-def testGAMESS_basicGAMESS_US_water_ccsd_t__out(logfile):
-    """Keep parsing ccenergies correctly."""
-    assert len(logfile.data.ccenergies) == 1
-    assert abs(logfile.data.ccenergies[0] + 2074.32) < 0.01
-
-
-def testGAMESS_basicPCGAMESS_dvb_td_out(logfile):
-    """Previously, etoscs was not extracted for this TD DFT calculation."""
-    assert len(logfile.data.etoscs) == 5
-
+# GAMESS #
 
 def testGAMESS_GAMESS_US2008_N2_UMP2_out(logfile):
     """Check that the new format for GAMESS MP2 is parsed."""
@@ -104,58 +83,19 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     assert abs(max(logfile.data.etoscs) - 0.0) < 0.01
     assert len(logfile.data.etsecs) == number
 
-def testGaussian_Gaussian09_irc_point_log(logfile):
-    """Failed to parse vibfreqs except for 10, 11"""
-    assert hasattr(logfile.data, "vibfreqs")
-    assert len(logfile.data.vibfreqs) == 11
+# Gaussian #
 
-def testGaussian_Gaussian09_Dahlgren_TS_log(logfile):
-    """Failed to parse ccenergies for a variety of reasons"""
-    assert hasattr(logfile.data, "ccenergies")
-    assert abs(logfile.data.ccenergies[0] - (-11819.96506609)) < 0.001
-
-def testGaussian_basicGaussian03_water_ccd_log(logfile):
-    """Ensure that ccenergies continues to be parsed correctly"""
-    assert hasattr(logfile.data, "ccenergies")
-    assert abs(logfile.data.ccenergies[0] - (-2041.32671705)) < 0.001
-
-def testGaussian_basicGaussian03_water_ccsd_log(logfile):
-    """Ensure that ccenergies continues to be parsed correctly"""
-    assert hasattr(logfile.data, "ccenergies")
-    assert abs(logfile.data.ccenergies[0] - (-2041.33503383)) < 0.001
-
-def testGaussian_basicGaussian03_water_ccsd_t__log(logfile):
-    """Ensure that ccenergies continues to be parsed correctly"""
-    assert hasattr(logfile.data, "ccenergies")
-    assert abs(logfile.data.ccenergies[0] - (-2041.3371232)) < 0.001
-
-    ##### ADD TESTS FOR THE OTHERS ######
-
-def testGaussian_Gaussian09_dvb_lowdin_log(logfile):
-    """Check if both Mulliken and Lowdin charges are parsed."""
-    assert "mulliken" in logfile.data.atomcharges
-    assert "lowdin" in logfile.data.atomcharges
-
-def testGaussian_basicGaussian03_dvb_gopt_out(logfile):
-    """Example regression test for Gaussian/basicGaussian03/dvb_gopt.out
-
-    Note: the name of the test must match the full path to the datafile
-    exactly, except that all periods, hyphens, path separators and
-    parentheses, which should be2 replaced by underscores.
-    """
-    assert len(logfile.data.homos)==1
-
+# KML: these functions are not called currently. We probably want to do these checks
+# simply as part of the appropriate unit tests.
 def testGaussian_basicGaussian09_dvb_raman_log(logfile):
     """Was not extracting vibdisps"""
     assert hasattr(logfile.data, "vibdisps")
     assert len(logfile.data.vibdisps) == 54
-
 def testGaussian_basicGaussian03_dvb_raman_out(logfile):
     """Was extracting the "Depolar P" instead of the "Raman activity". Oops!"""
     assert logfile.data.vibramans[1] - 2.6872 < 0.0001
     assert hasattr(logfile.data, "vibdisps")
     assert len(logfile.data.vibdisps) == 54
-
 def testGaussian_basicGaussian03_dvb_un_sp_out(logfile):
     """
     This file had no atomcoords at all at all, due to only having an
@@ -163,13 +103,6 @@ def testGaussian_basicGaussian03_dvb_un_sp_out(logfile):
     """
     assert len(logfile.data.atomnos) == 20
     assert logfile.data.atomcoords.shape == (1, 20, 3)
-
-
-def testGaussian_basicGaussian09_dvb_gopt_log(logfile):
-    """Check that the atomnos is being parsed correctly."""
-    assert hasattr(logfile.data, "atomnos"), "Missing atomnos"
-    assert len(logfile.data.atomnos) == logfile.data.natom == 20
-
 
 def testGaussian_Gaussian98_C_bigmult_log(logfile):
     """
@@ -190,7 +123,6 @@ def testGaussian_Gaussian98_water_zmatrix_nosym_log(logfile):
     """
     assert len(logfile.data.atomcoords)==1
     assert logfile.data.natom == 3
-
 
 def testGaussian_Gaussian03_AM1_SP_out(logfile):
     """Previously, caused scfvalue parsing to fail."""
@@ -256,7 +188,6 @@ def testGaussian_Gaussian03_orbgs_log(logfile):
     assert logfile.data.coreelectrons[20] == 10
     assert logfile.data.coreelectrons[23] == 10
 
-
 def testGaussian_Gaussian09_25DMF_HRANH_log(logfile):
     """Check that the anharmonicities are being parsed correctly."""
     assert hasattr(logfile.data, "vibanharms"), "Missing vibanharms"
@@ -270,6 +201,21 @@ def testGaussian_Gaussian09_534_out(logfile):
     """Previously, caused etenergies parsing to fail."""
     assert logfile.data.etsyms[0] == "Singlet-?Sym"
     assert logfile.data.etenergies[0] == 20920.55328
+
+def testGaussian_Gaussian09_dvb_lowdin_log(logfile):
+    """Check if both Mulliken and Lowdin charges are parsed."""
+    assert "mulliken" in logfile.data.atomcharges
+    assert "lowdin" in logfile.data.atomcharges
+
+def testGaussian_Gaussian09_Dahlgren_TS_log(logfile):
+    """Failed to parse ccenergies for a variety of reasons"""
+    assert hasattr(logfile.data, "ccenergies")
+    assert abs(logfile.data.ccenergies[0] - (-11819.96506609)) < 0.001
+
+def testGaussian_Gaussian09_irc_point_log(logfile):
+    """Failed to parse vibfreqs except for 10, 11"""
+    assert hasattr(logfile.data, "vibfreqs")
+    assert len(logfile.data.vibfreqs) == 11
 
 def testGaussian_Gaussian09_OPT_td_g09_out(logfile):
     """Couldn't find etrotats as G09 has different output than G03."""
@@ -285,6 +231,7 @@ def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):
     """Here atomnos wans't added to the gaussian parser before."""
     assert len(logfile.data.atomnos) == 69
 
+# ORCA #
 
 def testORCA_ORCA2_8_co_cosmo_out(logfile):
     """This is related to bug 3184890.
@@ -300,7 +247,6 @@ def testORCA_ORCA2_8_co_cosmo_out(logfile):
     and the number of values in scfenergies preserved.
     """
     assert hasattr(logfile.data, "scfenergies") and len(logfile.data.scfenergies) == 4
-
 
 def testORCA_ORCA2_9_job_out(logfile):
     """First output file and request to parse atomic spin densities.
@@ -350,7 +296,7 @@ def normalisefilename(filename):
 
     >>> import regression
     >>> for x in [ "Gaussian_Gaussian03_Mo4OSibdt2-opt.log" ]:
-    ...     print regression.normalisefilename(x)
+    ...     print(regression.normalisefilename(x))
     ...
     Gaussian_Gaussian03_Mo4OSibdt2_opt_log
     """
@@ -364,15 +310,148 @@ def normalisefilename(filename):
     return "".join(ans)
 
 
-def make_regression_from_old_unittest(filename, module_name, test_name):
-    """Return a regression test function from an old unit test logfile.
+# When a unit test is removed or replaced by a newer version, we normally want
+# the old logfile to become a regression, namely to run the unit test as part of
+# the regression suite. To this end, add the logfile path to the dictionary
+# below along with the appropriate unit test class to use, and the appropriate
+# regression test function will be created automatically. If modifications
+# are necessary due to developments in the unit test class, tweak it here
+# and provide the modified version of the test class.
 
-    When using this, take precaution to ensure that test_name is
-    a valid unit test class within module_name.
-    """
+# We're going to need to import all of the unit test modules.
+test_modules = { m : importlib.import_module('test'+m) for m in testall.test_modules }
+
+# Although there is probably a cleaner way to do this, making the unit class test names
+# global makes reading the dictionary of old unit tests much easier, especially it
+# will contain some classes defined here.
+for m, module in test_modules.items():
+    for name in dir(module):
+        if name[-4:] == "Test":
+            globals()[name] = getattr(module, name)
+
+class ADFSPTest_nosyms(test_modules['SP'].ADFSPTest):
+    def testsymlabels(self):
+        """Symmetry labels were not printed here. PASS"""
+
+class ADFSPTest_nosyms_valence(ADFSPTest_nosyms):
+    def testlengthmoenergies(self):
+        """Only valence orbital energies were printed here."""
+        self.assertEquals(len(self.data.moenergies[0]), 45)
+        self.assertEquals(self.data.moenergies[0][0], 99999.0)
+
+class GAMESSUSSPunTest_charge0(GamessUSSPunTest):
+    def testcharge_and_mult(self):
+        """The charge in the input was wrong."""
+        self.assertEquals(self.data.charge, 0)
+    def testhomos(self):
+        """HOMOs were incorrect due to charge being wrong. PASS"""
+
+class GAMESSUSIRTest_ts(GamessUSIRTest):
+    def testirintens(self):
+        """This is a transition state with different intensities. PASS"""
+
+class GAMESSUSCISTest_dets(GAMESSUSCISTest):
+    nstates = 10
+    def testetsecsvalues(self):
+        """This gives unexpected coeficcients, also for current unit tests. PASSS"""
+
+class JaguarGeoOptTest_nmo45(JaguarGeoOptTest):
+    def testlengthmoenergies(self):
+        """Without special options, Jaguar only print Homo+10 orbital energies."""
+        self.assertEquals(len(self.data.moenergies[0]), 45)
+
+class OrcaSPunTest_charge0(OrcaSPunTest):
+    def testcharge_and_mult(self):
+        """The charge in the input was wrong."""
+        self.assertEquals(self.data.charge, 0)
+    def testhomos(self):
+        """HOMOs were incorrect due to charge being wrong. PASS"""
+
+class OrcaTDDFTTest_error(OrcaTDDFTTest):
+    def testoscs(self):
+        """These values used to be less accurate, probably due to wrong coordinates."""
+        self.assertEqual(len(self.data.etoscs), self.number)
+        self.assertInside(max(self.data.etoscs), 1.0, 0.2)
+
+class OrcaIRTest_old(OrcaIRTest):
+    def testfreqval(self):
+        """These values were wrong due to wrong input coordinates. PASS"""
+    def testirintens(self):
+        """These values were wrong due to wrong input coordinates. PASS"""
+
+old_unittests = {
+
+    "ADF/ADF2004.01/MoOCl4-sp.adfout":      ADFCoreTest,
+    "ADF/ADF2004.01/dvb_gopt.adfout":       ADFGeoOptTest,
+    "ADF/ADF2004.01/dvb_gopt_b.adfout":     ADFGeoOptTest,
+    "ADF/ADF2004.01/dvb_sp.adfout":         ADFSPTest,
+    "ADF/ADF2004.01/dvb_sp_b.adfout":       ADFSPTest,
+    "ADF/ADF2004.01/dvb_sp_c.adfout":       ADFSPTest_nosyms_valence,
+    "ADF/ADF2004.01/dvb_sp_d.adfout":       ADFSPTest_nosyms,
+    "ADF/ADF2004.01/dvb_un_sp.adfout":      ADFSPunTest,
+    "ADF/ADF2004.01/dvb_un_sp_c.adfout":    ADFSPunTest,
+    "ADF/ADF2004.01/dvb_ir.adfout":         ADFIRTest,
+
+    "ADF/ADF2006.01/dvb_gopt.adfout":       ADFGeoOptTest,
+
+    "GAMESS/GAMESS-US2005/water_ccd_2005.06.27.r3.out":         GAMESSUSCCDTest,
+    "GAMESS/GAMESS-US2005/water_ccsd_2005.06.27.r3.out":        GAMESSUSCCSDTest,
+    "GAMESS/GAMESS-US2005/water_ccsd(t)_2005.06.27.r3.out":     GAMESSUSCCSDTTest,
+    "GAMESS/GAMESS-US2005/water_cis_dets_2005.06.27.r3.out":    GAMESSUSCISTest_dets,
+    "GAMESS/GAMESS-US2005/water_cis_saps_2005.06.27.r3.out":    GAMESSUSCISTest,
+    "GAMESS/GAMESS-US2005/MoOCl4-sp_2005.06.27.r3.out":         GAMESSUSCoreTest,
+    "GAMESS/GAMESS-US2005/water_mp2_2005.06.27.r3.out":         GAMESSUSMP2Test,
+
+    "GAMESS/GAMESS-US2006/C_bigbasis_2006.02.22.r3.out":    GamessUSBigBasisTest,
+    "GAMESS/GAMESS-US2006/dvb_gopt_a_2006.02.22.r2.out":    GamessUSGeoOptTest,
+    "GAMESS/GAMESS-US2006/dvb_sp_2006.02.22.r2.out":        GamessUSSPTest,
+    "GAMESS/GAMESS-US2006/dvb_un_sp_2006.02.22.r2.out":     GamessUSSPunTest,
+    "GAMESS/GAMESS-US2006/dvb_ir.2006.02.22.r2.out":        GamessUSIRTest,
+    "GAMESS/GAMESS-US2006/nh3_ts_ir.2006.2.22.r2.out":      GAMESSUSIRTest_ts,
+
+    "GAMESS/GAMESS-US2010/dvb_gopt.log":    GamessUSGeoOptTest,
+    "GAMESS/GAMESS-US2010/dvb_sp.log":      GamessUSSPTest,
+    "GAMESS/GAMESS-US2010/dvb_sp_un.log":   GAMESSUSSPunTest_charge0,
+    "GAMESS/GAMESS-US2010/dvb_td.log":      GAMESSUSTDDFTTest,
+    "GAMESS/GAMESS-US2010/dvb_ir.log":      GamessUSIRTest,
+
+    "GAMESS/WinGAMESS/dvb_td_2007.03.24.r1.out":    GAMESSUSTDDFTTest,
+
+    "Jaguar/Jaguar4.2/dvb_gopt.out":    JaguarGeoOptTest_nmo45,
+    "Jaguar/Jaguar4.2/dvb_gopt_b.out":  JaguarGeoOptTest,
+    "Jaguar/Jaguar4.2/dvb_sp.out":      JaguarSPTest,
+    "Jaguar/Jaguar4.2/dvb_sp_b.out":    JaguarSPTest,
+    "Jaguar/Jaguar4.2/dvb_un_sp.out":   JaguarSPunTest,
+    "Jaguar/Jaguar4.2/dvb_ir.out":      JaguarIRTest,
+
+    "Jaguar/Jaguar6.0/dvb_gopt.out":    JaguarGeoOptTest_nmo45,
+    "Jaguar/Jaguar6.0/dvb_sp.out":      JaguarSPTest,
+    "Jaguar/Jaguar6.0/dvb_un_sp.out" :  JaguarSPunTest,
+
+    "Jaguar/Jaguar6.5/dvb_gopt.out":    JaguarGeoOptTest_nmo45,
+    "Jaguar/Jaguar6.5/dvb_sp.out":      JaguarSPTest,
+    "Jaguar/Jaguar6.5/dvb_un_sp.out":   JaguarSPunTest,
+    "Jaguar/Jaguar6.5/dvb_ir.out":      JaguarIRTest,
+
+    "Molpro/Molpro2006/C_bigbasis_cart.out":    MolproBigBasisTest,
+
+    "ORCA/ORCA2.6/dvb_gopt.out":    OrcaGeoOptTest,
+    "ORCA/ORCA2.6/dvb_sp.out":      OrcaSPTest,
+    "ORCA/ORCA2.6/dvb_sp_un.out":   OrcaSPunTest,
+    "ORCA/ORCA2.6/dvb_td.out":      OrcaTDDFTTest_error,
+    "ORCA/ORCA2.6/dvb_ir.out":      OrcaIRTest,
+
+    "ORCA/ORCA2.8/dvb_gopt.out":    OrcaGeoOptTest,
+    "ORCA/ORCA2.8/dvb_sp.out":      OrcaSPTest,
+    "ORCA/ORCA2.8/dvb_sp_un.out":   OrcaSPunTest_charge0,
+    "ORCA/ORCA2.8/dvb_td.out":      OrcaTDDFTTest,
+    "ORCA/ORCA2.8/dvb_ir.out":      OrcaIRTest_old,
+}
+
+def make_regression_from_old_unittest(test_class):
+    """Return a regression test function from an old unit test logfile."""
 
     def old_unit_test(logfile):
-        test_class = getattr(__import__(module_name), test_name)
         test_class.logfile = logfile
         test_class.data = logfile.data
         devnull = open(os.devnull, 'w')
@@ -383,12 +462,12 @@ def make_regression_from_old_unittest(filename, module_name, test_name):
 
 def main(which=[], traceback=False):
 
-    dummyfiles = [eval(n)("") for n in parsers]
+    dummyfiles = [eval(n)("") for n in testall.parsers]
 
     # It would be nice to fix the structure of this nested list,
     # because in its current form it is not amenable to tweaks.
     regdir = os.path.join("..", "data", "regression")
-    programs = [os.path.join(regdir,testall.get_program_dir(p)) for p in parsers]
+    programs = [os.path.join(regdir,testall.get_program_dir(p)) for p in testall.parsers]
     try:
         filenames = [[os.path.join(p,version,fn) for version in os.listdir(p) for fn in os.listdir(os.path.join(p,version))] for p in programs]
     except OSError as e:
@@ -397,37 +476,45 @@ def main(which=[], traceback=False):
         print("Run regression_download.sh in the ../data directory to update.")
         sys.exit(1)
 
-    # Print a warning if you haven't downloaded all of the regression test files,
-    # or an error if not all of the regression test files are included in filenames.
+    # This file should contain the paths to all regresssion test files we have gathered
+    # over the years. It is not really necessary, since we can discover them on the disk,
+    # but we keep it as a legacy and a way to track double check the regression tests.
     regfile = open(os.path.join("..", "data", "regressionfiles.txt"), "r")
     regfilenames = [os.sep.join(x.strip().split("/")) for x in regfile.readlines()]
     regfile.close()
 
-    missing = []
+    # We will want to print a warning if you haven't downloaded all of the regression
+    # test files, or when, vice versa, not all of the regression test files found on disk
+    # are included in filenames. However, gather that data here and print the warnings
+    # at the end so that we test all available files and the messages are displayed
+    # prominently at the end.
+    missing_on_disk = []
+    missing_in_list = []
     for x in regfilenames:
         if not os.path.isfile(os.path.join("..", "data", "regression", x)):
-            missing.append(x)
+            missing_on_disk.append(x)
         elif os.path.join("..", "data", "regression", x) not in flatten(filenames):
-            print("\nERROR: The regression file %s is on disk, but not in the 'filenames' list.\n" % x)
-            sys.exit(1)       
+            missing_in_list.append(x)
 
-    # When a unit test is removed or replaced by a newer version, the old logfile
-    # typically becomes a regression, and normally we still want to run the unit test
-    # within the regression suite. To this end, add the logfile location to a list
-    # called 'old_tests' in the appropriate unit test class, in which case the
-    # following code will find it and create the becessary regression test function.
-    for mod in test_modules:
-        mod_name = "test" + mod
-        tests = inspect.getmembers(__import__(mod_name), inspect.isclass)
-        tests = [tc for tc in tests if tc[0][-4:] == "Test"]
-        for test_name, test_class in tests:
-            for old in getattr(test_class, "old_tests", []):
-                funcname = "test" + normalisefilename(old)
-                func = make_regression_from_old_unittest(old, mod_name, test_name)
-                globals()[funcname] = func
+    # Create the regression test functions from logfiles that were old unittests.
+    for path, test_class in old_unittests.items():
+        funcname = "test" + normalisefilename(path)
+        func = make_regression_from_old_unittest(test_class)
+        globals()[funcname] = func
+
+    # Gather orphaned tests - functions starting with 'test' and not corresponding
+    # to any regression file name.
+    orphaned_tests = []
+    for ip, parser in enumerate(testall.parsers):
+        prefix = "test%s" % parser
+        tests = [fn for fn in globals() if fn[:len(prefix)] == prefix]
+        normalize = lambda fn: normalisefilename("_".join(fn.split(os.sep)[3:]))
+        normalized = [normalize(fname) for fname in filenames[ip]]
+        orphaned = [t for t in tests if t[4:] not in normalized]
+        orphaned_tests.extend(orphaned)
 
     failures = errors = total = 0
-    for iname, name in enumerate(parsers):
+    for iname, name in enumerate(testall.parsers):
 
         # Continue to next iteration if we are limiting the regression and the current
         #   name was not explicitely chosen (that is, passed as an argument).
@@ -508,21 +595,30 @@ def main(which=[], traceback=False):
             
     print("Total: %d   Failed: %d  Errors: %d" % (total, failures, errors))
     if not traceback and failures + errors > 0:
-        print("\nFor more information on failures/errors, add 'traceback' as argument.")
+        print("\nFor more information on failures/errors, add 'traceback' as an argument.")
 
-    # Show this warning at the end, so that it's easy to notice.
-    if len(missing) > 0:
-        print("\nWARNING: You are missing %d regression file(s)." % len(missing))
+    # Show these warnings at the end, so that they're easy to notice. Notice that the lists
+    # were populated at the beginning of this function.
+    if len(missing_on_disk) > 0:
+        print("\nWARNING: You are missing %d regression file(s)." % len(missing_on_disk))
         print("Run regression_download.sh in the ../data directory to update.")
         print("Missing files:")
-        print("\n".join(missing))
-
+        print("\n".join(missing_on_disk))
+    if len(missing_in_list) > 0:
+        print("\nWARNING: The list in 'regressionfiles.txt' is missing %d file(s)." % len(missing_in_list))
+        print("Add these files paths to the list and commit the change.")
+        print("Missing files:")
+        print("\n".join(missing_in_list))
+    if len(orphaned_tests) > 0:
+        print("\nWARNING: There are %d orphaned regression test function." % len(orphaned_tests))
+        print("Please make sure these function names correspond to regression files:")
+        print("\n".join(orphaned_tests))
 
 if __name__=="__main__":
 
     # If 'test' is passed as the first argument, do a doctest on this module.
     # Otherwise, any arguments are used to limit the test to the packages/parsers
-    #   passed as arguments. Not arguments implies all parsers.
+    # passed as arguments. No arguments implies all parsers.
     if len(sys.argv) == 2 and sys.argv[1] == "test":
         import doctest
         doctest.testmod()

--- a/test/testBasis.py
+++ b/test/testBasis.py
@@ -79,7 +79,6 @@ class GamessUSBasisTest(GenericBasisTest):
 class GamessUSBigBasisTest(GenericBigBasisTest):
     """GAMESS-US big basis set unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/MoOCl4-sp_2005.06.27.r3.out.bz2"]
 
 class GaussianBasisTest(GenericBasisTest):
     """Gaussian basis set unittest."""

--- a/test/testCC.py
+++ b/test/testCC.py
@@ -48,19 +48,11 @@ class GenericCCSDTTest(GenericCCTest):
 class GAMESSUSCCDTest(GenericCCDTest):
     """GAMESS-US CCD unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/water_ccd_2005.06.27.r3.out.gz"]
-
-
 class GAMESSUSCCSDTest(GenericCCSDTest):
     """GAMESS-US CCSD unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/water_ccsd_2005.06.27.r3.out.gz"]
-
-    
 class GAMESSUSCCSDTTest(GenericCCSDTTest):
     """GAMESS-US CCSD(T) unittest."""
-
-    old_tests = ["GAMESS/GAMESS-US/water_ccsd(t)_2005.06.27.r3.out.gz"]
 
     
 class GaussianCCDTest(GenericCCDTest):

--- a/test/testCore.py
+++ b/test/testCore.py
@@ -42,8 +42,6 @@ class GAMESSUKCoreTest(GenericCoreTest):
 class GAMESSUSCoreTest(GenericCoreTest):
     """GAMESS-US core electrons unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/C_bigbasis_2006.02.22.r3.out.gz"]
-
     coredict = {'Mo': 28, 'O':0, 'Cl':10}
 
 

--- a/test/testGeoOpt.py
+++ b/test/testGeoOpt.py
@@ -214,8 +214,6 @@ class GamessUKGeoOptTest(GenericGeoOptTest):
 class GamessUSGeoOptTest(GenericGeoOptTest):
     """GAMESS-US geometry optimization unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/dvb_gopt_a_2006.02.22.r2.out.gz"]
-
 
 class GaussianGeoOptTest(GenericGeoOptTest):
     """Gaussian geometry optimization unittest."""

--- a/test/testMP.py
+++ b/test/testMP.py
@@ -99,8 +99,6 @@ class GAMESSUKMP3Test(GenericMP3Test):
 class GAMESSUSMP2Test(GenericMP2Test):
     """GAMESS-US MP2 unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/water_mp2_2005.06.27.r3.out.gz"]
-
 
 class GaussianMP2Test(GenericMP2Test):
     """Gaussian MP2 unittest."""

--- a/test/testSP.py
+++ b/test/testSP.py
@@ -150,8 +150,6 @@ class GamessUKSPTest(GenericSPTest):
 class GamessUSSPTest(GenericSPTest):
     """GAMESS-US restricted single point unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/dvb_sp_2006.02.22.r2.out.gz"]
-
 
 class GaussianSPTest(GenericSPTest):
     """Gaussian restricted single point unittest."""

--- a/test/testSPun.py
+++ b/test/testSPun.py
@@ -79,8 +79,6 @@ class GamessUKSPunTest(GenericSPunTest):
 class GamessUSSPunTest(GenericSPunTest):
     """GAMESS-US unrestricted single point unittest."""
 
-    old_tests = ["GAMESS/GAMESS-US/dvb_un_sp_2006.02.22.r2.out.gz"]
-
 
 class GaussianSPunTest(GenericSPunTest):
     """Gaussian unrestricted single point unittest."""

--- a/test/testTD.py
+++ b/test/testTD.py
@@ -79,8 +79,6 @@ class GAMESSUSTDDFTTest(GenericTDTest):
 
     number = 10
 
-    old_tests = ["GAMESS/WinGAMESS/dvb_td_2007.03.24.r1.out.gz"]
-
 
 class PCGamessTDDFTTest(GenericTDTest):
     """PC-GAMESS time-dependent HF/DFT unittest."""


### PR DESCRIPTION
With the move to GitHub and storing regression files uncompressed, the specific regression tests were not called. This re-introduces **most** of the specific tests. However, some of the specific tests do **not** run because of the new directory layout (e.g. data/regression/Gaussian vs. data/Gaussian).
