### PR TITLE
Declared encodings for files that need them under Python 2.7.

### DIFF
--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of cclib (http://cclib.sf.net), a library for parsing
 # and interpreting the results of computational chemistry packages.
 #

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of cclib (http://cclib.sf.net), a library for parsing
 # and interpreting the results of computational chemistry packages.
 #


### PR DESCRIPTION
Under Python 2.7 a couple of files containing non-ASCII characters needed encodings declared. With these changes I can use the code under Python 3.4 and 2.7, and 'testall.py' reports identical  results for both Python versions.
