### PR TITLE
Q-Chem: Fix for all OpenMP jobs

### DIFF
--- a/data/regressionfiles.txt
+++ b/data/regressionfiles.txt
@@ -175,3 +175,4 @@ QChem/QChem4.2/dvb_gopt_unconverged.out
 QChem/QChem4.2/dvb_sp_unconverged.out
 QChem/QChem4.2/dvb_sp_multipole_10.out
 QChem/QChem4.2/dvb_sp_omp.out
+QChem/QChem4.2/copper_ax2wat_eq0wat4amm.opt_tzvpp.SOS-CIS_D0.out

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -214,7 +214,7 @@ class QChem(logfileparser.Logfile):
             self.mpenergies.append([mp2energy])
 
         # This is the MP3/ccman2 case.
-        if 'MP2 energy' in line:
+        if line[1:11] == 'MP2 energy':
             if not hasattr(self, 'mpenergies'):
                 self.mpenergies = []
             mpenergies = []


### PR DESCRIPTION
The assertion in the parser always failed, since running with OpenMP threading adds a header between the convergence threshold and the start of the SCF iterations; this header happens to have a bunch of dashes in it.

There is also the start of rewriting the MPn/CC parsing sections, which will need to be done with explicit string slicing.

The multipole section is causing problems. 10th-order moments are not parsed properly under Python 2 due to the expanded labels, and there's a parsing error under Python 3 due to the current sorting method.
