### PR TITLE
Regressions: fix for Gaussian03/m1b1.out

### DIFF
--- a/data/regressionfiles.txt
+++ b/data/regressionfiles.txt
@@ -131,6 +131,7 @@ Gaussian/Gaussian03/borane-opt.log
 Gaussian/Gaussian03/chn1.log
 Gaussian/Gaussian03/cyclopropenyl.rhf.g03.cut.log
 Gaussian/Gaussian03/dvb_gopt_symmfollow.log
+Gaussian/Gaussian03/m1b1.out
 Gaussian/Gaussian03/maheshkumar.log
 Gaussian/Gaussian03/mendes.out
 Gaussian/Gaussian03/neoprene.out

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -314,16 +314,26 @@ class Logfile(object):
         return "ERROR: This should be overwritten by this subclass"
 
     def float(self, number):
-        """Convert a string to a float avoiding the problem with Ds.
+        """Convert a string to a float.
+
+        This method should perform certain checks that are specific to cclib,
+        including avoiding the problem with Ds instead of Es in scientific notation.
+        Another point is converting string signifying numerical problems (*****)
+        to something we can manage (Numpy's NaN).
 
         >>> t = Logfile("dummyfile")
         >>> t.float("123.2323E+02")
         12323.23
         >>> t.float("123.2323D+02")
         12323.23
+        >>> t.float("*****")
+        nan
         """
-        number = number.replace("D","E")
-        return float(number)
+
+        if list(set(number)) == ['*']:
+            return numpy.nan
+
+        return float(number.replace("D","E"))
 
     def set_attribute(self, name, value, check=True):
         """Set an attribute and perform a check when it already exists.


### PR DESCRIPTION
I recently downloaded all the NIST CCCBDB output files (a lot of data) and starting parsing them with cclib. There are some errors, and this a fix for one I already added to the regression suite -- involving '****' in the output file. Since this signifies numerical problems, I made cclib convert the string to numpy.nan in this case, which seems somewhat reasnoable. I did this in Logfile.float() so that it's a bit more general and should fix similar problems in other cases.

FTR, I have been communicating with Russel Johnson from NIST and have permission to make these files public, with appropriate attribution (will add special notes as needed).
