### PR TITLE
Q-Chem: fix for parsing geometries in fragment jobs

### DIFF
--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -42,6 +42,18 @@ class QChem(logfileparser.Logfile):
         # (un)restricted calculation.
         self.unrestricted = False
 
+    def after_parsing(self):
+
+        # If parsing a fragment job, each of the geometries appended to
+        # `atomcoords` may be of different lengths, which will prevent
+        # conversion from a list to NumPy array.
+        # Take the length of the first geometry as correct, and remove
+        # all others with different lengths.
+        if len(self.atomcoords) > 1:
+            correctlen = len(self.atomcoords[0])
+            self.atomcoords[:] = [coords for coords in self.atomcoords
+                                  if len(coords) == correctlen]
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 


### PR DESCRIPTION
For now, remove "non-supersystem" geometries. The first geometry parsed
should always be the full, non-fragmented system. This will have to be
changed once fragment jobs are parsed properly.
