### PR TITLE
Psi3: add regression with D orbitals and test it (file from Axel Schild)

### DIFF
--- a/data/regressionfiles.txt
+++ b/data/regressionfiles.txt
@@ -197,6 +197,7 @@ ORCA/ORCA2.9/prova.out
 ORCA/ORCA2.9/PCB_1_122.out
 ORCA/ORCA3.0/benzene_td_singlets.out
 ORCA/ORCA3.0/dvb_gopt_unconverged.out
+Psi/Psi3/water_psi3.log
 Psi/Psi4/dvb_gopt_hf_unconverged.out
 Psi/Psi4/psi4.0b5_samples_scf4.out
 QChem/QChem4.2/dvb_gopt_unconverged.out

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -189,6 +189,7 @@ class Psi(logfileparser.Logfile):
                 expression = shells.strip().replace(' ', '+')
                 expression = expression.replace('s', '*1')
                 expression = expression.replace('p', '*3')
+                expression = expression.replace('d', '*6')
                 nfuncs = eval(expression)
                 if len(indices) == 0:
                     indices.append(range(nfuncs))

--- a/test/regression.py
+++ b/test/regression.py
@@ -322,6 +322,14 @@ def testORCA_ORCA3_0_dvb_gopt_unconverged_out(logfile):
 
 # PSI #
 
+def testPsi_Psi3_water_psi3_log(logfile):
+    """An RHF for water with D orbitals and C2v symmetry.
+
+    Here we can check that the D orbitals are considered by checking atombasis and nbasis.
+    """
+    assert logfile.data.nbasis == 25
+    assert [len(ab) for ab in logfile.data.atombasis] == [15, 5, 5]
+
 def testPsi_Psi4_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone


### PR DESCRIPTION
The test file was kindly provided by Axel Schild and broke our Psi parser. Here is the fix. Of course, the Psi parser is not perfect (especially for Psi3, which is an old version of Psi4) and we do not want to put too much effort into it. But at least it should not break the parser.
