### PR TITLE
Upstream

### DIFF
--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -61,6 +61,7 @@ class ccData(object):
         nocoeffs -- natural orbital coefficients (array[2])
         nooccnos -- natural orbital occupation numbers (array[1])
         optdone -- flags whether an optimization has converged (Boolean)
+        oniomenergies -- energies of components involved in an oniom calculation (list)
         scancoords -- geometries of each scan step (array[3], angstroms)
         scanenergies -- energies of potential energy surface (list)
         scannames -- names of varaibles scanned (list of strings)
@@ -123,6 +124,7 @@ class ccData(object):
         "nmo":            int,
         "nocoeffs":       numpy.ndarray,
         "nooccnos":       numpy.ndarray,
+        "oniomenergies":  list,
         "optdone":        bool,
         "scancoords":     numpy.ndarray,
         "scanenergies":   list,

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -670,10 +670,8 @@ class Gaussian(logfileparser.Logfile):
 
             scanenergies = []
             scanparm = []
-
             colmnames = next(inputfile)
-            self.skip_line(inputfile, 'dashes')
-
+            hyphens = next(inputfile)
             line = next(inputfile)
             while line != hyphens:
                 broken = line.split()

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -340,7 +340,9 @@ class Gaussian(logfileparser.Logfile):
         # Atom C1       Shell     2 SP   3    bf    2 -     5          0.509245180608         -2.664678875191          0.000000000000
         #       0.2941249355D+01 -0.9996722919D-01  0.1559162750D+00
         # ...
-        if line[1:13] == "AO basis set":
+
+        #ONIOM calculations result basis sets reported for atoms that are not in order of atom number which breaks this code (line 390 relies on atoms coming in order)
+        if line[1:13] == "AO basis set" and not self.oniom:
         
             self.gbasis = []
 

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -586,6 +586,23 @@ class Gaussian(logfileparser.Logfile):
                 self.ccenergies.append(utils.convertor(self.ccenergy, "hartree", "eV"))
                 del self.ccenergy
 
+        #ONIOM component energy extraction
+        if self.oniom and line[1:26] == "ONIOM: calculating energy":
+
+            if not hasattr(self, "oniomenergies"):
+                self.oniomenergies = []
+
+            line = next(inputfile)
+
+            component_energies = []
+            while line.find('extrapolated') == -1:
+                component_energy = float(line.split()[8])
+                component_energy = utils.convertor(component_energy, "hartree", "eV")
+                component_energies.append(component_energy)
+                line = next(inputfile)
+
+            self.oniomenergies.append(component_energies)
+
         # Geometry convergence information.
         if line[49:59] == 'Converged?':
 

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -872,14 +872,27 @@ class Gaussian(logfileparser.Logfile):
                 
                     if not hasattr(self, 'vibirs'):
                         self.vibirs = []
-                    irs = [self.float(f) for f in line[15:].split()]
+
+                    irs = []
+                    for ir in line[15:].split():
+                        try:
+                            irs.append(self.float(ir))
+                        except ValueError:
+                            irs.append(self.float('nan'))
                     self.vibirs.extend(irs)
 
                 if line[1:15] == "Raman Activ --":
                 
                     if not hasattr(self, 'vibramans'):
                         self.vibramans = []
-                    ramans = [self.float(f) for f in line[15:].split()]
+
+                    ramans = []
+                    for raman in line[15:].split():
+                        try:
+                            ramans.append(self.float(raman))
+                        except ValueError:
+                            ramans.append(self.float('nan'))
+
                     self.vibramans.extend(ramans)
                 
                 # Block with displacement should start with this.

--- a/test/regression.py
+++ b/test/regression.py
@@ -253,6 +253,14 @@ def testGaussian_Gaussian09_OPT_td_out(logfile):
     assert len(logfile.data.etrotats) == 10
     assert logfile.data.etrotats[0] == -0.4568
 
+def testGaussian_Gaussian09_OPT_oniom(logfile):
+    """AO basis extraction broke with ONIOM"""
+
+def testGaussian_Gaussian09_oniom_IR_intensity(logfile):
+    """Problem parsing IR intensity from mode 192"""
+    assert hasattr(logfile.data, 'vibirs')
+    assert len(logfile.data.vibirs) == 216
+
 def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):
     """Here atomnos wans't added to the gaussian parser before."""
     assert len(logfile.data.atomnos) == 69


### PR DESCRIPTION
Made some modifications to the Gaussian parser:

* Reverted to the previous PES scan parsing code as the current version referenced an undefined variable 'hyphens'.

* Added an exception to the AO basis set extraction for ONIOM calculations that include GFPRINT. The current version assumes that basis sets are provided for atoms in atomic order whereas basis sets for the model region of an ONIOM calculation violate this assumption.

* Fixed a problem parsing IR intensities from frequency calculations where Gaussian has reported ****** inplace of the ferquency which causes the current version to break and pre-emptively applied the fix to raman intensities too.

* Added an oniomenergies field which extracts the energies associated with the components of an oniom calculation.