### PR TITLE
Regression: clean up in QChem files

### DIFF
--- a/data/regressionfiles.txt
+++ b/data/regressionfiles.txt
@@ -211,6 +211,15 @@ Psi/Psi4/dvb_gopt_hf_unconverged.out
 Psi/Psi4/psi4.0b5_samples_scf4.out
 QChem/QChem4.2/CH3---Na+.out
 QChem/QChem4.2/CH4---Na+.out
+QChem/QChem4.2/CH3---Na+_RS.out
+QChem/QChem4.2/CO2.out
+QChem/QChem4.2/CO2_cation_ROHF_bigprint.out
+QChem/QChem4.2/CO2_cation_ROHF.out
+QChem/QChem4.2/CO2_cation_UHF.out
+QChem/QChem4.2/CH3---Na+_RS_SCF.out
+QChem/QChem4.2/CO2_cation_UHF_bigprint.out
+QChem/QChem4.2/CO2_cation_ROHF_bigprint_allvirt.out
+QChem/QChem4.2/CO2_cation_UHF_bigprint_allvirt.out
 QChem/QChem4.2/copper_ax2wat_eq0wat4amm.opt_tzvpp.SOS-CIS_D0.out
 QChem/QChem4.2/dvb_gopt_unconverged.out
 QChem/QChem4.2/dvb_sp_multipole_10.out


### PR DESCRIPTION
I added some files to regressionfiles.txt that were missing. It seems there is on file that was supposed to be added but wasn't, since there's even a test written for it:
```
$ python regression.py QChem
Are the QChem files ccopened and parsed correctly?
  ../data/regression/QChem/QChem4.2/CH3---Na+_RS.out... parsed
  ../data/regression/QChem/QChem4.2/CH3---Na+_RS_SCF.out... parsed
  ../data/regression/QChem/QChem4.2/CH4---Na+.out... parsed and tested
  ../data/regression/QChem/QChem4.2/CO2.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_ROHF.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_ROHF_bigprint.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_ROHF_bigprint_allvirt.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_UHF.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_UHF_bigprint.out... parsed
  ../data/regression/QChem/QChem4.2/CO2_cation_UHF_bigprint_allvirt.out... parsed
  ../data/regression/QChem/QChem4.2/copper_ax2wat_eq0wat4amm.opt_tzvpp.SOS-CIS_D0.out... parsed
  ../data/regression/QChem/QChem4.2/dvb_gopt_unconverged.out... parsed and tested
  ../data/regression/QChem/QChem4.2/dvb_sp_multipole_10.out... parsed and tested
  ../data/regression/QChem/QChem4.2/dvb_sp_omp.out... parsed
  ../data/regression/QChem/QChem4.2/dvb_sp_unconverged.out... parsed
  ../data/regression/QChem/QChem4.2/qchem_tddft_rpa.out... parsed and tested

Total: 16   Failed: 0  Errors: 0

WARNING: You are missing 1 regression file(s).
Run regression_download.sh in the ../data directory to update.
Missing files:
QChem/QChem4.2/CH3---Na+.out

WARNING: There are 1 orphaned regression test functions.
Please make sure these function names correspond to regression files:
testQChem_QChem4_2_CH3___Na__out
```

@berquist: will you be adding the missing file?