### PR TITLE
gamessukparser: Bug fix, convert atomcoord to bohr

### DIFF
--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -138,7 +138,7 @@ class GAMESSUK(logfileparser.Logfile):
             while line.strip():
                 line = next(inputfile)
                 if line.strip()[1:10].strip() and list(set(line.strip())) != ['*']:
-                    atomcoords.append(list(map(float, line.split()[3:6])))
+                    atomcoords.append([utils.convertor(float(x), "bohr", "Angstrom") for x in line.split()[3:6]])
                     atomnos.append(int(round(float(line.split()[2]))))
 
             if not hasattr(self, "atomcoords"):


### PR DESCRIPTION
Example of bug: basicGAMESS-UK8.0/dvb_ir.out atomcoord were parsed in bohr before this fix, now they are correctly converted in to angstroms. 
As requested (see discussion of cclib-data pull request 17) I have added a regression test to cclib-data, for which I will shortly make a pull request. I have also removed the unit test testing atomic coordinates in testvib.py (which was in cclib pull request #214, commit 2bec113bf3d0227a7a47dd2f891b88099b50eaf5). 
