### PR TITLE
CJSON writer: can't take len() of a generator.

### DIFF
--- a/src/cclib/writer/ccwrite.py
+++ b/src/cclib/writer/ccwrite.py
@@ -15,11 +15,11 @@ Cartesian coordinates."""
 import os.path
 import sys
 # Python 2->3 changes the default file object hierarchy.
-if sys.version_info[0] == 3:
+if sys.version_info[0] == 2:
+    fileclass = file
+else:
     import io
     fileclass = io.IOBase
-else:
-    fileclass = file
 
 from .. import parser
 

--- a/src/cclib/writer/cjsonwriter.py
+++ b/src/cclib/writer/cjsonwriter.py
@@ -74,7 +74,7 @@ class CJSON(filewriter.Writer):
             cjson_dict['properties']['molecular mass'] = self.pbmol.molwt
 
         cjson_dict['atomCount'] = len(self.ccdata.atomnos)
-        cjson_dict['heavyAtomCount'] = len((x for x in self.ccdata.atomnos if x > 1))
+        cjson_dict['heavyAtomCount'] = len([x for x in self.ccdata.atomnos if x > 1])
 
         if has_openbabel:
             cjson_dict['diagram'] = self.pbmol.write(format='svg')

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -54,14 +54,12 @@ class FileWrapperTest(unittest.TestCase):
         # Unfortunately, the behavior of this wrapper differs between Python 2 and 3,
         # so we need to diverge the assertions. We should try to keep the code as
         # consistent as possible, but the Errors raised are actually different.
-        if sys.version_info[0] == "2":
-            wrapper.seek(0, 2)
-            self.assertEqual(wrapper.pos, wrapper.size)
+        wrapper.seek(0, 2)
+        self.assertEqual(wrapper.pos, wrapper.size)
+        if sys.version_info[0] == 2:
             self.assertRaises(AttributeError, wrapper.seek, 0, 0)
             self.assertRaises(AttributeError, wrapper.seek, 0, 1)
-        elif sys.version_info[0] == "3":
-            wrapper.seek(0, 2)
-            self.assertEqual(wrapper.pos, wrapper.size)
+        else:
             self.assertRaises(io.UnsupportedOperation, wrapper.seek, 0, 0)
             self.assertRaises(io.UnsupportedOperation, wrapper.seek, 0, 1)
 

--- a/test/writer/testfilewriter.py
+++ b/test/writer/testfilewriter.py
@@ -11,7 +11,6 @@
 """Unit tests for writer xyzwriter module."""
 
 import os
-import sys
 import unittest
 
 import cclib
@@ -26,11 +25,11 @@ class WriterTest(unittest.TestCase):
 
     def test_init(self):
         """Does the class initialize correctly?"""
-        fpath = os.path.join(__datadir__,"data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
         data = cclib.parser.ccopen(fpath).parse()
         writer = cclib.writer.filewriter.Writer(data)
 
-        # The object should keep the ccData instnace passed to its constructor.
+        # The object should keep the ccData instance passed to its constructor.
         self.assertEqual(writer.ccdata, data)
 
 

--- a/test/writer/testxyzwriter.py
+++ b/test/writer/testxyzwriter.py
@@ -11,7 +11,6 @@
 """Unit tests for writer xyzwriter module."""
 
 import os
-import sys
 import unittest
 
 import cclib
@@ -29,11 +28,11 @@ class XYZTest(unittest.TestCase):
 
     def test_init(self):
         """Does the class initialize correctly?"""
-        fpath = os.path.join(__datadir__,"data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
         data = cclib.parser.ccopen(fpath).parse()
         xyz = cclib.writer.xyzwriter.XYZ(data)
 
-        # The object should keep the ccData instnace passed to its constructor.
+        # The object should keep the ccData instance passed to its constructor.
         self.assertEqual(xyz.ccdata, data)
 
 


### PR DESCRIPTION
Also:
* Treat Python 2 as a special case, not 3.
* spelling

See https://github.com/cclib/cclib/issues/231.