### PR TITLE
Q-Chem: fix charge/mult and fragment/supsersystem parsing

### DIFF
--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -50,7 +50,7 @@ class QChem(logfileparser.Logfile):
 
         # Keep track of whether or not this is a fragment calculation,
         # so that only the supersystem is parsed.
-        self.is_fragment_calculation = False
+        self.is_fragment_section = False
 
         # Compile the dashes-and-or-spaces-only regex.
         self.re_dashes_and_spaces = re.compile('^[\s-]+$')
@@ -134,591 +134,571 @@ class QChem(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
-        # If the input section is repeated back, parse the $rem and
-        # $molecule sections.
-        if line[0:11] == 'User input:':
-            self.skip_line(inputfile, 'd')
-            while list(set(line.strip())) != ['-']:
+        # Disable/enable parsing for fragment sections.
+        fragment_section_headers = (
+            'Guess MOs from converged MOs on fragments',
+            'CP correction for fragment',
+        )
+        supersystem_section_headers = (
+            'Done with SCF on isolated fragments',
+            'Done with counterpoise correction on fragments',
+        )
 
-                if '$rem' in line:
-                    while '$end' not in line:
-                        line = next(inputfile)
-                        if 'print_orbitals' in line.lower():
-                            # Stay with the default value if a number isn't
-                            # specified.
-                            if line.split()[-1].lower() in ('true', 'false'):
-                                continue
-                            else:
-                                norbdisp_aonames = int(line.split()[-1])
-                                self.norbdisp_alpha_aonames = norbdisp_aonames
-                                self.norbdisp_beta_aonames = norbdisp_aonames
-                                self.norbdisp_set = True
+        if any(message in line for message in fragment_section_headers):
+            self.is_fragment_section = True
+        if any(message in line for message in supersystem_section_headers):
+            self.is_fragment_section = False
 
-                line = next(inputfile)
+        if not self.is_fragment_section:
+            # If the input section is repeated back, parse the $rem and
+            # $molecule sections.
+            if line[0:11] == 'User input:':
+                self.skip_line(inputfile, 'd')
+                while list(set(line.strip())) != ['-']:
 
-        # Parse the general basis for `gbasis`, in the style used by
-        # Gaussian.
-        if 'Basis set in general basis input format:' in line:
-            self.skip_lines(inputfile, ['d', '$basis'])
-            line = next(inputfile)
-            if not hasattr(self, 'gbasis'):
-                self.gbasis = []
-            # The end of the general basis block.
-            while '$end' not in line:
-                atom = []
-                # 1. Contains element symbol and atomic index of
-                # basis functions; if 0, applies to all atoms of
-                # same element.
-                assert len(line.split()) == 2
-                line = next(inputfile)
-                # The end of each atomic block.
-                while '****' not in line:
-                    # 2. Contains the type of basis function {S, SP,
-                    # P, D, F, G, H, ...}, the number of primitives,
-                    # and the weight of the final contracted function.
-                    bfsplitline = line.split()
-                    assert len(bfsplitline) == 3
-                    bftype = bfsplitline[0]
-                    nprim = int(bfsplitline[1])
+                    if '$rem' in line:
+                        while '$end' not in line:
+                            line = next(inputfile)
+                            if 'print_orbitals' in line.lower():
+                                # Stay with the default value if a number isn't
+                                # specified.
+                                if line.split()[-1].lower() in ('true', 'false'):
+                                    continue
+                                else:
+                                    norbdisp_aonames = int(line.split()[-1])
+                                    self.norbdisp_alpha_aonames = norbdisp_aonames
+                                    self.norbdisp_beta_aonames = norbdisp_aonames
+                                    self.norbdisp_set = True
+
                     line = next(inputfile)
-                    # 3. The primitive basis functions that compose
-                    # the contracted basis function; there are `nprim`
-                    # of them. The first value is the exponent, and
-                    # the second value is the contraction
-                    # coefficient. If `bftype == 'SP'`, the primitives
-                    # are for both S- and P-type basis functions but
-                    # with separate contraction coefficients,
-                    # resulting in three columns.
-                    if bftype == 'SP':
-                        primitives_S = []
-                        primitives_P = []
-                    else:
-                        primitives = []
-                    # For each primitive in the contracted basis
-                    # function...
-                    for iprim in range(nprim):
-                        primsplitline = line.split()
-                        exponent = float(primsplitline[0])
-                        if bftype == 'SP':
-                            assert len(primsplitline) == 3
-                            coefficient_S = float(primsplitline[1])
-                            coefficient_P = float(primsplitline[2])
-                            primitives_S.append((exponent, coefficient_S))
-                            primitives_P.append((exponent, coefficient_P))
-                        else:
-                            assert len(primsplitline) == 2
-                            coefficient = float(primsplitline[1])
-                            primitives.append((exponent, coefficient))
+
+            # Parse the general basis for `gbasis`, in the style used by
+            # Gaussian.
+            if 'Basis set in general basis input format:' in line:
+                self.skip_lines(inputfile, ['d', '$basis'])
+                line = next(inputfile)
+                if not hasattr(self, 'gbasis'):
+                    self.gbasis = []
+                # The end of the general basis block.
+                while '$end' not in line:
+                    atom = []
+                    # 1. Contains element symbol and atomic index of
+                    # basis functions; if 0, applies to all atoms of
+                    # same element.
+                    assert len(line.split()) == 2
+                    line = next(inputfile)
+                    # The end of each atomic block.
+                    while '****' not in line:
+                        # 2. Contains the type of basis function {S, SP,
+                        # P, D, F, G, H, ...}, the number of primitives,
+                        # and the weight of the final contracted function.
+                        bfsplitline = line.split()
+                        assert len(bfsplitline) == 3
+                        bftype = bfsplitline[0]
+                        nprim = int(bfsplitline[1])
                         line = next(inputfile)
-                    if bftype == 'SP':
-                        bf_S = ('S', primitives_S)
-                        bf_P = ('P', primitives_P)
-                        atom.append(bf_S)
-                        atom.append(bf_P)
+                        # 3. The primitive basis functions that compose
+                        # the contracted basis function; there are `nprim`
+                        # of them. The first value is the exponent, and
+                        # the second value is the contraction
+                        # coefficient. If `bftype == 'SP'`, the primitives
+                        # are for both S- and P-type basis functions but
+                        # with separate contraction coefficients,
+                        # resulting in three columns.
+                        if bftype == 'SP':
+                            primitives_S = []
+                            primitives_P = []
+                        else:
+                            primitives = []
+                        # For each primitive in the contracted basis
+                        # function...
+                        for iprim in range(nprim):
+                            primsplitline = line.split()
+                            exponent = float(primsplitline[0])
+                            if bftype == 'SP':
+                                assert len(primsplitline) == 3
+                                coefficient_S = float(primsplitline[1])
+                                coefficient_P = float(primsplitline[2])
+                                primitives_S.append((exponent, coefficient_S))
+                                primitives_P.append((exponent, coefficient_P))
+                            else:
+                                assert len(primsplitline) == 2
+                                coefficient = float(primsplitline[1])
+                                primitives.append((exponent, coefficient))
+                            line = next(inputfile)
+                        if bftype == 'SP':
+                            bf_S = ('S', primitives_S)
+                            bf_P = ('P', primitives_P)
+                            atom.append(bf_S)
+                            atom.append(bf_P)
+                        else:
+                            bf = (bftype, primitives)
+                            atom.append(bf)
+                        # Move to the next contracted basis function
+                        # as long as we don't hit the '****' atom
+                        # delimiter.
+                    self.gbasis.append(atom)
+                    line = next(inputfile)
+
+            # Extract the atomic numbers and coordinates of the atoms.
+            if 'Standard Nuclear Orientation (Angstroms)' in line:
+                if not hasattr(self, 'atomcoords'):
+                    self.atomcoords = []
+                self.skip_lines(inputfile, ['cols', 'dashes'])
+                atomelements = []
+                atomcoords = []
+                line = next(inputfile)
+                while list(set(line.strip())) != ['-']:
+                    entry = line.split()
+                    atomelements.append(entry[1])
+                    atomcoords.append(list(map(float, entry[2:])))
+                    line = next(inputfile)
+
+                self.atomcoords.append(atomcoords)
+
+                # We calculate and handle atomnos no matter what, since in
+                # the case of fragment calculations the atoms may change,
+                # along with the charge and spin multiplicity.
+                self.atomnos = []
+                self.atomelements = []
+                for atomelement in atomelements:
+                    self.atomelements.append(atomelement)
+                    if atomelement == 'GH':
+                        self.atomnos.append(0)
                     else:
-                        bf = (bftype, primitives)
-                        atom.append(bf)
-                    # Move to the next contracted basis function
-                    # as long as we don't hit the '****' atom
-                    # delimiter.
-                self.gbasis.append(atom)
+                        self.atomnos.append(self.table.number[atomelement])
+                self.natom = len(self.atomnos)
+                self.atommap = self.generate_atom_map()
+                self.formula_histogram = self.generate_formula_histogram()
+
+            # Number of electrons.
+            # Useful for determining the number of occupied/virtual orbitals.
+            if 'Nuclear Repulsion Energy' in line:
                 line = next(inputfile)
+                nelec_re_string = 'There are(\s+[0-9]+) alpha and(\s+[0-9]+) beta electrons'
+                match = re.findall(nelec_re_string, line.strip())
+                self.set_attribute('nalpha', int(match[0][0].strip()))
+                self.set_attribute('nbeta', int(match[0][1].strip()))
+                self.norbdisp_alpha += self.nalpha
+                self.norbdisp_alpha_aonames += self.nalpha
+                self.norbdisp_beta += self.nbeta
+                self.norbdisp_beta_aonames += self.nbeta
+                # Calculate the spin multiplicity (2S + 1), where S is the
+                # total spin of the system.
+                S = (self.nalpha - self.nbeta) / 2
+                mult = int(2 * S + 1)
+                self.set_attribute('mult', mult)
+                # Calculate the molecular charge as the difference between
+                # the atomic numbers and the number of electrons.
+                if hasattr(self, 'atomnos'):
+                    charge = sum(self.atomnos) - (self.nalpha + self.nbeta)
+                    self.set_attribute('charge', charge)
 
-        # Extract the atomic numbers and coordinates of the atoms.
-        if 'Standard Nuclear Orientation (Angstroms)' in line:
-            if not hasattr(self, 'atomcoords'):
-                self.atomcoords = []
-            self.skip_lines(inputfile, ['cols', 'dashes'])
-            atomelements = []
-            atomcoords = []
-            line = next(inputfile)
-            while list(set(line.strip())) != ['-']:
-                entry = line.split()
-                atomelements.append(entry[1])
-                atomcoords.append(list(map(float, entry[2:])))
-                line = next(inputfile)
+            # Number of basis functions.
+            # Because Q-Chem's integral recursion scheme is defined using
+            # Cartesian basis functions, there is often a distinction between the
+            # two in the output. We only parse for *pure* functions.
+            # Examples:
+            #  Only one type:
+            #   There are 30 shells and 60 basis functions
+            #  Both Cartesian and pure:
+            #   ...
+            if 'basis functions' in line:
+                if not hasattr(self, 'nbasis'):
+                    self.set_attribute('nbasis', int(line.split()[-3]))
 
-            self.atomcoords.append(atomcoords)
-
-            # We calculate and handle atomnos no matter what, since in
-            # the case of fragment calculations the atoms may change,
-            # along with the charge and spin multiplicity.
-            self.atomnos = []
-            self.atomelements = []
-            for atomelement in atomelements:
-                self.atomelements.append(atomelement)
-                if atomelement == 'GH':
-                    self.atomnos.append(0)
-                else:
-                    self.atomnos.append(self.table.number[atomelement])
-            self.natom = len(self.atomnos)
-            self.atommap = self.generate_atom_map()
-            self.formula_histogram = self.generate_formula_histogram()
-
-        # Number of electrons.
-        # Useful for determining the number of occupied/virtual orbitals.
-        if 'Nuclear Repulsion Energy' in line:
-            line = next(inputfile)
-            nelec_re_string = 'There are(\s+[0-9]+) alpha and(\s+[0-9]+) beta electrons'
-            match = re.findall(nelec_re_string, line.strip())
-            self.set_attribute('nalpha', int(match[0][0].strip()))
-            self.set_attribute('nbeta', int(match[0][1].strip()))
-            self.norbdisp_alpha += self.nalpha
-            self.norbdisp_alpha_aonames += self.nalpha
-            self.norbdisp_beta += self.nbeta
-            self.norbdisp_beta_aonames += self.nbeta
-            # Calculate the spin multiplicity (2S + 1), where S is the
-            # total spin of the system.
-            S = (self.nalpha - self.nbeta) / 2
-            mult = int(2 * S + 1)
-            self.set_attribute('mult', mult)
-            # Calculate the molecular charge as the difference between
-            # the atomic numbers and the number of electrons.
-            if hasattr(self, 'atomnos'):
-                charge = sum(self.atomnos) - (self.nalpha + self.nbeta)
-                self.set_attribute('charge', charge)
-
-        # Number of basis functions.
-        # Because Q-Chem's integral recursion scheme is defined using
-        # Cartesian basis functions, there is often a distinction between the
-        # two in the output. We only parse for *pure* functions.
-        # Examples:
-        #  Only one type:
-        #   There are 30 shells and 60 basis functions
-        #  Both Cartesian and pure:
-        #   ...
-        if 'basis functions' in line:
-            if not hasattr(self, 'nbasis'):
-                self.set_attribute('nbasis', int(line.split()[-3]))
-
-        # Where do the guess MOs come from? We don't care, but they
-        # identify fragment calculations.
-        if 'Guess MOs from converged MOs on fragments' in line:
-            self.is_fragment_calculation = True
-
-        if 'Done with SCF on isolated fragments' in line:
-            self.is_fragment_calculation = False
-
-        # Check for whether or not we're peforming an
-        # (un)restricted calculation.
-        if 'calculation will be' in line:
-            if ' restricted' in line:
-                self.unrestricted = False
-            if 'unrestricted' in line:
-                self.unrestricted = True
-            if hasattr(self, 'nalpha') and hasattr(self, 'nbeta'):
-                if self.nalpha != self.nbeta:
+            # Check for whether or not we're peforming an
+            # (un)restricted calculation.
+            if 'calculation will be' in line:
+                if ' restricted' in line:
+                    self.unrestricted = False
+                if 'unrestricted' in line:
                     self.unrestricted = True
-                    self.is_rohf = True
+                if hasattr(self, 'nalpha') and hasattr(self, 'nbeta'):
+                    if self.nalpha != self.nbeta:
+                        self.unrestricted = True
+                        self.is_rohf = True
 
-        # Section with SCF iterations goes like this:
-        #
-        # SCF converges when DIIS error is below 1.0E-05
-        # ---------------------------------------
-        #  Cycle       Energy         DIIS Error
-        # ---------------------------------------
-        #    1    -381.9238072190      1.39E-01
-        #    2    -382.2937212775      3.10E-03
-        #    3    -382.2939780242      3.37E-03
-        # ...
-        #
-        scf_success_messages = (
-            'Convergence criterion met',
-            'corrected energy'
-        )
-        scf_failure_messages = (
-            'SCF failed to converge',
-            'Convergence failure'
-        )
-        if 'SCF converges when ' in line:
-            if not hasattr(self, 'scftargets'):
-                self.scftargets = []
-            target = float(line.split()[-1])
-            self.scftargets.append([target])
+            # Section with SCF iterations goes like this:
+            #
+            # SCF converges when DIIS error is below 1.0E-05
+            # ---------------------------------------
+            #  Cycle       Energy         DIIS Error
+            # ---------------------------------------
+            #    1    -381.9238072190      1.39E-01
+            #    2    -382.2937212775      3.10E-03
+            #    3    -382.2939780242      3.37E-03
+            # ...
+            #
+            scf_success_messages = (
+                'Convergence criterion met',
+                'corrected energy'
+            )
+            scf_failure_messages = (
+                'SCF failed to converge',
+                'Convergence failure'
+            )
+            if 'SCF converges when ' in line:
+                if not hasattr(self, 'scftargets'):
+                    self.scftargets = []
+                target = float(line.split()[-1])
+                self.scftargets.append([target])
 
-            # We should have the header between dashes now,
-            # but sometimes there are lines before the first dashes.
-            while not 'Cycle       Energy' in line:
+                # We should have the header between dashes now,
+                # but sometimes there are lines before the first dashes.
+                while not 'Cycle       Energy' in line:
+                    line = next(inputfile)
+                self.skip_line(inputfile, 'd')
+
+                values = []
+                iter_counter = 1
                 line = next(inputfile)
-            self.skip_line(inputfile, 'd')
+                while not any(message in line for message in scf_success_messages):
 
-            values = []
-            iter_counter = 1
-            line = next(inputfile)
-            while not any(message in line for message in scf_success_messages):
+                    # Some trickery to avoid a lot of printing that can occur
+                    # between each SCF iteration.
+                    entry = line.split()
+                    if len(entry) > 0:
+                        if entry[0] == str(iter_counter):
+                            # Q-Chem only outputs one error metric.
+                            error = float(entry[2])
+                            values.append([error])
+                            iter_counter += 1
+                    line = next(inputfile)
 
-                # Some trickery to avoid a lot of printing that can occur
-                # between each SCF iteration.
-                entry = line.split()
-                if len(entry) > 0:
-                    if entry[0] == str(iter_counter):
-                        # Q-Chem only outputs one error metric.
+                    # We've converged, but still need the last iteration.
+                    if any(message in line for message in scf_success_messages):
+                        entry = line.split()
                         error = float(entry[2])
                         values.append([error])
                         iter_counter += 1
+
+                    # This is printed in regression QChem4.2/dvb_sp_unconverged.out
+                    # so use it to bail out when convergence fails.
+                    if any(message in line for message in scf_failure_messages):
+                        break
+
+                if not hasattr(self, 'scfvalues'):
+                    self.scfvalues = []
+                self.scfvalues.append(numpy.array(values))
+
+            # Molecular orbital coefficients.
+
+            # Try parsing them from this block (which comes from
+            # `scf_final_print = 2``) rather than the combined
+            # aonames/mocoeffs/moenergies block (which comes from
+            # `print_orbitals = true`).
+            if 'Final Alpha MO Coefficients' in line:
+                if not hasattr(self, 'mocoeffs'):
+                    self.mocoeffs = []
+                mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_alpha))
+                self.parse_matrix(inputfile, mocoeffs)
+                self.mocoeffs.append(mocoeffs.transpose())
+
+            if 'Final Beta MO Coefficients' in line:
+                mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta))
+                self.parse_matrix(inputfile, mocoeffs)
+                self.mocoeffs.append(mocoeffs.transpose())
+
+            if 'Total energy in the final basis set' in line:
+                if not hasattr(self, 'scfenergies'):
+                    self.scfenergies = []
+                scfenergy = float(line.split()[-1])
+                self.scfenergies.append(utils.convertor(scfenergy, 'hartree', 'eV'))
+
+            # Geometry optimization.
+
+            if 'Maximum     Tolerance    Cnvgd?' in line:
+                line_g = list(map(float, next(inputfile).split()[1:3]))
+                line_d = list(map(float, next(inputfile).split()[1:3]))
+                line_e = next(inputfile).split()[2:4]
+
+                if not hasattr(self, 'geotargets'):
+                    self.geotargets = [line_g[1], line_d[1], self.float(line_e[1])]
+                if not hasattr(self, 'geovalues'):
+                    self.geovalues = []
+                try:
+                    ediff = abs(self.float(line_e[0]))
+                except ValueError:
+                    ediff = numpy.nan
+                geovalues = [line_g[0], line_d[0], ediff]
+                self.geovalues.append(geovalues)
+
+            if '**  OPTIMIZATION CONVERGED  **' in line:
+                if not hasattr(self, 'optdone'):
+                    self.optdone = []
+                self.optdone.append(len(self.atomcoords))
+
+            if '**  MAXIMUM OPTIMIZATION CYCLES REACHED  **' in line:
+                if not hasattr(self, 'optdone'):
+                    self.optdone = []
+
+            # Moller-Plesset corrections.
+
+            # There are multiple modules in Q-Chem for calculating MPn energies:
+            # cdman, ccman, and ccman2, all with different output.
+            #
+            # MP2, RI-MP2, and local MP2 all default to cdman, which has a simple
+            # block of output after the regular SCF iterations.
+            #
+            # MP3 is handled by ccman2.
+            #
+            # MP4 and variants are handled by ccman.
+
+            # This is the MP2/cdman case.
+            if 'MP2         total energy' in line:
+                if not hasattr(self, 'mpenergies'):
+                    self.mpenergies = []
+                mp2energy = float(line.split()[4])
+                mp2energy = utils.convertor(mp2energy, 'hartree', 'eV')
+                self.mpenergies.append([mp2energy])
+
+            # This is the MP3/ccman2 case.
+            if line[1:11] == 'MP2 energy' and line[12:19] != 'read as':
+                if not hasattr(self, 'mpenergies'):
+                    self.mpenergies = []
+                mpenergies = []
+                mp2energy = float(line.split()[3])
+                mpenergies.append(mp2energy)
                 line = next(inputfile)
-
-                # We've converged, but still need the last iteration.
-                if any(message in line for message in scf_success_messages):
-                    entry = line.split()
-                    error = float(entry[2])
-                    values.append([error])
-                    iter_counter += 1
-
-                # This is printed in regression QChem4.2/dvb_sp_unconverged.out
-                # so use it to bail out when convergence fails.
-                if any(message in line for message in scf_failure_messages):
-                    break
-
-            if not hasattr(self, 'scfvalues'):
-                self.scfvalues = []
-            self.scfvalues.append(numpy.array(values))
-
-        # Molecular orbital coefficients.
-
-        # Try parsing them from this block (which comes from
-        # `scf_final_print = 2``) rather than the combined
-        # aonames/mocoeffs/moenergies block (which comes from
-        # `print_orbitals = true`).
-        if 'Final Alpha MO Coefficients' in line:
-            if not hasattr(self, 'mocoeffs'):
-                self.mocoeffs = []
-            mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_alpha))
-            self.parse_matrix(inputfile, mocoeffs)
-            self.mocoeffs.append(mocoeffs.transpose())
-
-        if 'Final Beta MO Coefficients' in line:
-            mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta))
-            self.parse_matrix(inputfile, mocoeffs)
-            self.mocoeffs.append(mocoeffs.transpose())
-
-        if 'Total energy in the final basis set' in line:
-            if not hasattr(self, 'scfenergies'):
-                self.scfenergies = []
-            scfenergy = float(line.split()[-1])
-            self.scfenergies.append(utils.convertor(scfenergy, 'hartree', 'eV'))
-
-        # Geometry optimization.
-
-        if 'Maximum     Tolerance    Cnvgd?' in line:
-            line_g = list(map(float, next(inputfile).split()[1:3]))
-            line_d = list(map(float, next(inputfile).split()[1:3]))
-            line_e = next(inputfile).split()[2:4]
-
-            if not hasattr(self, 'geotargets'):
-                self.geotargets = [line_g[1], line_d[1], self.float(line_e[1])]
-            if not hasattr(self, 'geovalues'):
-                self.geovalues = []
-            try:
-                ediff = abs(self.float(line_e[0]))
-            except ValueError:
-                ediff = numpy.nan
-            geovalues = [line_g[0], line_d[0], ediff]
-            self.geovalues.append(geovalues)
-
-        if '**  OPTIMIZATION CONVERGED  **' in line:
-            if not hasattr(self, 'optdone'):
-                self.optdone = []
-            self.optdone.append(len(self.atomcoords))
-
-        if '**  MAXIMUM OPTIMIZATION CYCLES REACHED  **' in line:
-            if not hasattr(self, 'optdone'):
-                self.optdone = []
-
-        # Moller-Plesset corrections.
-
-        # There are multiple modules in Q-Chem for calculating MPn energies:
-        # cdman, ccman, and ccman2, all with different output.
-        #
-        # MP2, RI-MP2, and local MP2 all default to cdman, which has a simple
-        # block of output after the regular SCF iterations.
-        #
-        # MP3 is handled by ccman2.
-        #
-        # MP4 and variants are handled by ccman.
-
-        # This is the MP2/cdman case.
-        if 'MP2         total energy' in line:
-            if not hasattr(self, 'mpenergies'):
-                self.mpenergies = []
-            mp2energy = float(line.split()[4])
-            mp2energy = utils.convertor(mp2energy, 'hartree', 'eV')
-            self.mpenergies.append([mp2energy])
-
-        # This is the MP3/ccman2 case.
-        if line[1:11] == 'MP2 energy' and line[12:19] != 'read as':
-            if not hasattr(self, 'mpenergies'):
-                self.mpenergies = []
-            mpenergies = []
-            mp2energy = float(line.split()[3])
-            mpenergies.append(mp2energy)
-            line = next(inputfile)
-            line = next(inputfile)
-            # Just a safe check.
-            if 'MP3 energy' in line:
-                mp3energy = float(line.split()[3])
-                mpenergies.append(mp3energy)
-            mpenergies = [utils.convertor(mpe, 'hartree', 'eV')
-                          for mpe in mpenergies]
-            self.mpenergies.append(mpenergies)
-
-        # This is the MP4/ccman case.
-        if 'EHF' in line:
-            if not hasattr(self, 'mpenergies'):
-                self.mpenergies = []
-            mpenergies = []
-
-            while list(set(line.strip())) != ['-']:
-
-                if 'EMP2' in line:
-                    mp2energy = float(line.split()[2])
-                    mpenergies.append(mp2energy)
-                if 'EMP3' in line:
-                    mp3energy = float(line.split()[2])
+                line = next(inputfile)
+                # Just a safe check.
+                if 'MP3 energy' in line:
+                    mp3energy = float(line.split()[3])
                     mpenergies.append(mp3energy)
-                if 'EMP4SDQ' in line:
-                    mp4sdqenergy = float(line.split()[2])
-                    mpenergies.append(mp4sdqenergy)
-                # This is really MP4SD(T)Q.
-                if 'EMP4 ' in line:
-                    mp4sdtqenergy = float(line.split()[2])
-                    mpenergies.append(mp4sdtqenergy)
+                mpenergies = [utils.convertor(mpe, 'hartree', 'eV')
+                              for mpe in mpenergies]
+                self.mpenergies.append(mpenergies)
 
-                line = next(inputfile)
+            # This is the MP4/ccman case.
+            if 'EHF' in line:
+                if not hasattr(self, 'mpenergies'):
+                    self.mpenergies = []
+                mpenergies = []
 
-            mpenergies = [utils.convertor(mpe, 'hartree', 'eV')
-                          for mpe in mpenergies]
-            self.mpenergies.append(mpenergies)
+                while list(set(line.strip())) != ['-']:
 
-        # Coupled cluster corrections.
-        # Hopefully we only have to deal with ccman2 here.
+                    if 'EMP2' in line:
+                        mp2energy = float(line.split()[2])
+                        mpenergies.append(mp2energy)
+                    if 'EMP3' in line:
+                        mp3energy = float(line.split()[2])
+                        mpenergies.append(mp3energy)
+                    if 'EMP4SDQ' in line:
+                        mp4sdqenergy = float(line.split()[2])
+                        mpenergies.append(mp4sdqenergy)
+                    # This is really MP4SD(T)Q.
+                    if 'EMP4 ' in line:
+                        mp4sdtqenergy = float(line.split()[2])
+                        mpenergies.append(mp4sdtqenergy)
 
-        if 'CCD total energy' in line:
-            if not hasattr(self, 'ccenergies'):
-                self.ccenergies = []
-            ccdenergy = float(line.split()[-1])
-            ccdenergy = utils.convertor(ccdenergy, 'hartree', 'eV')
-            self.ccenergies.append(ccdenergy)
-        if 'CCSD total energy' in line:
-            has_triples = False
-            if not hasattr(self, 'ccenergies'):
-                self.ccenergies = []
-            ccsdenergy = float(line.split()[-1])
-            # Make sure we aren't actually doing CCSD(T).
-            line = next(inputfile)
-            line = next(inputfile)
-            if 'CCSD(T) total energy' in line:
-                has_triples = True
-                ccsdtenergy = float(line.split()[-1])
-                ccsdtenergy = utils.convertor(ccsdtenergy, 'hartree', 'eV')
-                self.ccenergies.append(ccsdtenergy)
-            if not has_triples:
-                ccsdenergy = utils.convertor(ccsdenergy, 'hartree', 'eV')
-                self.ccenergies.append(ccsdenergy)
-
-        # Electronic transitions. Works for both CIS and TDDFT.
-        if 'Excitation Energies' in line:
-
-            # Restricted:
-            # ---------------------------------------------------
-            #         TDDFT/TDA Excitation Energies
-            # ---------------------------------------------------
-            #
-            # Excited state   1: excitation energy (eV) =    3.6052
-            #    Total energy for state   1:   -382.167872200685
-            #    Multiplicity: Triplet
-            #    Trans. Mom.:  0.0000 X   0.0000 Y   0.0000 Z
-            #    Strength   :  0.0000
-            #    D( 33) --> V(  3) amplitude =  0.2618
-            #    D( 34) --> V(  2) amplitude =  0.2125
-            #    D( 35) --> V(  1) amplitude =  0.9266
-            #
-            # Unrestricted:
-            # Excited state   2: excitation energy (eV) =    2.3156
-            #    Total energy for state   2:   -381.980177630969
-            #    <S**2>     :  0.7674
-            #    Trans. Mom.: -2.7680 X  -0.1089 Y   0.0000 Z
-            #    Strength   :  0.4353
-            #    S(  1) --> V(  1) amplitude = -0.3105 alpha
-            #    D( 34) --> S(  1) amplitude =  0.9322 beta
-
-            self.skip_lines(inputfile, ['dashes', 'blank'])
-            line = next(inputfile)
-
-            etenergies = []
-            etsyms = []
-            etoscs = []
-            etsecs = []
-            spinmap = {'alpha': 0, 'beta': 1}
-
-            while list(set(line.strip())) != ['-']:
-
-                # Take the total energy for the state and subtract from the
-                # ground state energy, rather than just the EE;
-                # this will be more accurate.
-                if 'Total energy for state' in line:
-                    energy = utils.convertor(float(line.split()[-1]), 'hartree', 'cm-1')
-                    etenergy = energy - utils.convertor(self.scfenergies[-1], 'eV', 'cm-1')
-                    etenergies.append(etenergy)
-                # if 'excitation energy' in line:
-                #     etenergy = utils.convertor(float(line.split()[-1]), 'eV', 'cm-1')
-                #     etenergies.append(etenergy)
-                if 'Multiplicity' in line:
-                    etsym = line.split()[1]
-                    etsyms.append(etsym)
-                if 'Strength' in line:
-                    strength = float(line.split()[-1])
-                    etoscs.append(strength)
-
-                # This is the list of transitions.
-                if 'amplitude' in line:
-                    sec = []
-                    while line.strip() != '':
-                        if self.unrestricted:
-                            spin = spinmap[line[42:47].strip()]
-                        else:
-                            spin = 0
-
-                        # There is a subtle difference between TDA and RPA calcs,
-                        # because in the latter case each transition line is
-                        # preceeded by the type of vector: X or Y, name excitation
-                        # or deexcitation (see #154 for details). For deexcitations,
-                        # we will need to reverse the MO indices. Note also that Q-Chem
-                        # starts reindexing virtual orbitals at 1.
-                        if line[5] == '(':
-                            ttype = 'X'
-                            startidx = int(line[6:9]) - 1
-                            endidx = int(line[17:20]) - 1 + self.nalpha
-                            contrib = float(line[34:41].strip())
-                        else:
-                            assert line[5] == ":"
-                            ttype = line[4]
-                            startidx = int(line[9:12]) - 1
-                            endidx = int(line[20:23]) - 1 + self.nalpha
-                            contrib = float(line[37:44].strip())
-
-                        start = (startidx, spin)
-                        end = (endidx, spin)
-                        if ttype == 'X':
-                            sec.append([start, end, contrib])
-                        elif ttype == 'Y':
-                            sec.append([end, start, contrib])
-                        else:
-                            raise ValueError('Unknown transition type: %s' % ttype)
-                        line = next(inputfile)
-                    etsecs.append(sec)
-
-                line = next(inputfile)
-
-            self.set_attribute('etenergies', etenergies)
-            self.set_attribute('etsyms', etsyms)
-            self.set_attribute('etoscs', etoscs)
-            self.set_attribute('etsecs', etsecs)
-
-        # Molecular orbital energies and symmetries.
-        if 'Orbital Energies (a.u.) and Symmetries' in line:
-
-            #  --------------------------------------------------------------
-            #              Orbital Energies (a.u.) and Symmetries
-            #  --------------------------------------------------------------
-            #
-            #  Alpha MOs, Restricted
-            #  -- Occupied --
-            # -10.018 -10.018 -10.008 -10.008 -10.007 -10.007 -10.006 -10.005
-            #   1 Bu    1 Ag    2 Bu    2 Ag    3 Bu    3 Ag    4 Bu    4 Ag
-            #  -9.992  -9.992  -0.818  -0.755  -0.721  -0.704  -0.670  -0.585
-            #   5 Ag    5 Bu    6 Ag    6 Bu    7 Ag    7 Bu    8 Bu    8 Ag
-            #  -0.561  -0.532  -0.512  -0.462  -0.439  -0.410  -0.400  -0.397
-            #   9 Ag    9 Bu   10 Ag   11 Ag   10 Bu   11 Bu   12 Bu   12 Ag
-            #  -0.376  -0.358  -0.349  -0.330  -0.305  -0.295  -0.281  -0.263
-            #  13 Bu   14 Bu   13 Ag    1 Au   15 Bu   14 Ag   15 Ag    1 Bg
-            #  -0.216  -0.198  -0.160
-            #   2 Au    2 Bg    3 Bg
-            #  -- Virtual --
-            #   0.050   0.091   0.116   0.181   0.280   0.319   0.330   0.365
-            #   3 Au    4 Au    4 Bg    5 Au    5 Bg   16 Ag   16 Bu   17 Bu
-            #   0.370   0.413   0.416   0.422   0.446   0.469   0.496   0.539
-            #  17 Ag   18 Bu   18 Ag   19 Bu   19 Ag   20 Bu   20 Ag   21 Ag
-            #   0.571   0.587   0.610   0.627   0.646   0.693   0.743   0.806
-            #  21 Bu   22 Ag   22 Bu   23 Bu   23 Ag   24 Ag   24 Bu   25 Ag
-            #   0.816
-            #  25 Bu
-            #
-            #  Beta MOs, Restricted
-            #  -- Occupied --
-            # -10.018 -10.018 -10.008 -10.008 -10.007 -10.007 -10.006 -10.005
-            #   1 Bu    1 Ag    2 Bu    2 Ag    3 Bu    3 Ag    4 Bu    4 Ag
-            #  -9.992  -9.992  -0.818  -0.755  -0.721  -0.704  -0.670  -0.585
-            #   5 Ag    5 Bu    6 Ag    6 Bu    7 Ag    7 Bu    8 Bu    8 Ag
-            #  -0.561  -0.532  -0.512  -0.462  -0.439  -0.410  -0.400  -0.397
-            #   9 Ag    9 Bu   10 Ag   11 Ag   10 Bu   11 Bu   12 Bu   12 Ag
-            #  -0.376  -0.358  -0.349  -0.330  -0.305  -0.295  -0.281  -0.263
-            #  13 Bu   14 Bu   13 Ag    1 Au   15 Bu   14 Ag   15 Ag    1 Bg
-            #  -0.216  -0.198  -0.160
-            #   2 Au    2 Bg    3 Bg
-            #  -- Virtual --
-            #   0.050   0.091   0.116   0.181   0.280   0.319   0.330   0.365
-            #   3 Au    4 Au    4 Bg    5 Au    5 Bg   16 Ag   16 Bu   17 Bu
-            #   0.370   0.413   0.416   0.422   0.446   0.469   0.496   0.539
-            #  17 Ag   18 Bu   18 Ag   19 Bu   19 Ag   20 Bu   20 Ag   21 Ag
-            #   0.571   0.587   0.610   0.627   0.646   0.693   0.743   0.806
-            #  21 Bu   22 Ag   22 Bu   23 Bu   23 Ag   24 Ag   24 Bu   25 Ag
-            #   0.816
-            #  25 Bu
-            #  --------------------------------------------------------------
-
-            self.skip_line(inputfile, 'dashes')
-            line = next(inputfile)
-            # Sometimes Q-Chem gets a little confused...
-            while 'Warning : Irrep of orbital' in line:
-                line = next(inputfile)
-            line = next(inputfile)
-            energies_alpha = []
-            symbols_alpha = []
-            if self.unrestricted:
-                energies_beta = []
-                symbols_beta = []
-            line = next(inputfile)
-
-            # The end of the block is either a blank line or only dashes.
-            while not self.re_dashes_and_spaces.search(line):
-                if 'Occupied' in line or 'Virtual' in line:
-                    # A nice trick to find where the HOMO is.
-                    if 'Virtual' in line:
-                        self.homos = [len(energies_alpha)-1]
                     line = next(inputfile)
-                # Parse the energies and symmetries in pairs of lines.
-                # energies = [utils.convertor(energy, 'hartree', 'eV')
-                #             for energy in map(float, line.split())]
-                # This convoluted bit handles '*******' when present.
-                energies = []
-                energy_line = line.split()
-                for e in energy_line:
-                    try:
-                        energy = utils.convertor(self.float(e), 'hartree', 'eV')
-                    except ValueError:
-                        energy = numpy.nan
-                    energies.append(energy)
-                energies_alpha.extend(energies)
+
+                mpenergies = [utils.convertor(mpe, 'hartree', 'eV')
+                              for mpe in mpenergies]
+                self.mpenergies.append(mpenergies)
+
+            # Coupled cluster corrections.
+            # Hopefully we only have to deal with ccman2 here.
+
+            if 'CCD total energy' in line:
+                if not hasattr(self, 'ccenergies'):
+                    self.ccenergies = []
+                ccdenergy = float(line.split()[-1])
+                ccdenergy = utils.convertor(ccdenergy, 'hartree', 'eV')
+                self.ccenergies.append(ccdenergy)
+            if 'CCSD total energy' in line:
+                has_triples = False
+                if not hasattr(self, 'ccenergies'):
+                    self.ccenergies = []
+                ccsdenergy = float(line.split()[-1])
+                # Make sure we aren't actually doing CCSD(T).
                 line = next(inputfile)
-                symbols = line.split()[1::2]
-                symbols_alpha.extend(symbols)
+                line = next(inputfile)
+                if 'CCSD(T) total energy' in line:
+                    has_triples = True
+                    ccsdtenergy = float(line.split()[-1])
+                    ccsdtenergy = utils.convertor(ccsdtenergy, 'hartree', 'eV')
+                    self.ccenergies.append(ccsdtenergy)
+                if not has_triples:
+                    ccsdenergy = utils.convertor(ccsdenergy, 'hartree', 'eV')
+                    self.ccenergies.append(ccsdenergy)
+
+            # Electronic transitions. Works for both CIS and TDDFT.
+            if 'Excitation Energies' in line:
+
+                # Restricted:
+                # ---------------------------------------------------
+                #         TDDFT/TDA Excitation Energies
+                # ---------------------------------------------------
+                #
+                # Excited state   1: excitation energy (eV) =    3.6052
+                #    Total energy for state   1:   -382.167872200685
+                #    Multiplicity: Triplet
+                #    Trans. Mom.:  0.0000 X   0.0000 Y   0.0000 Z
+                #    Strength   :  0.0000
+                #    D( 33) --> V(  3) amplitude =  0.2618
+                #    D( 34) --> V(  2) amplitude =  0.2125
+                #    D( 35) --> V(  1) amplitude =  0.9266
+                #
+                # Unrestricted:
+                # Excited state   2: excitation energy (eV) =    2.3156
+                #    Total energy for state   2:   -381.980177630969
+                #    <S**2>     :  0.7674
+                #    Trans. Mom.: -2.7680 X  -0.1089 Y   0.0000 Z
+                #    Strength   :  0.4353
+                #    S(  1) --> V(  1) amplitude = -0.3105 alpha
+                #    D( 34) --> S(  1) amplitude =  0.9322 beta
+
+                self.skip_lines(inputfile, ['dashes', 'blank'])
                 line = next(inputfile)
 
-            line = next(inputfile)
-            # Only look at the second block if doing an unrestricted calculation.
-            # This might be a problem for ROHF/ROKS.
-            if self.unrestricted:
-                assert 'Beta MOs' in line
-                self.skip_line(inputfile, '-- Occupied --')
+                etenergies = []
+                etsyms = []
+                etoscs = []
+                etsecs = []
+                spinmap = {'alpha': 0, 'beta': 1}
+
+                while list(set(line.strip())) != ['-']:
+
+                    # Take the total energy for the state and subtract from the
+                    # ground state energy, rather than just the EE;
+                    # this will be more accurate.
+                    if 'Total energy for state' in line:
+                        energy = utils.convertor(float(line.split()[-1]), 'hartree', 'cm-1')
+                        etenergy = energy - utils.convertor(self.scfenergies[-1], 'eV', 'cm-1')
+                        etenergies.append(etenergy)
+                    # if 'excitation energy' in line:
+                    #     etenergy = utils.convertor(float(line.split()[-1]), 'eV', 'cm-1')
+                    #     etenergies.append(etenergy)
+                    if 'Multiplicity' in line:
+                        etsym = line.split()[1]
+                        etsyms.append(etsym)
+                    if 'Strength' in line:
+                        strength = float(line.split()[-1])
+                        etoscs.append(strength)
+
+                    # This is the list of transitions.
+                    if 'amplitude' in line:
+                        sec = []
+                        while line.strip() != '':
+                            if self.unrestricted:
+                                spin = spinmap[line[42:47].strip()]
+                            else:
+                                spin = 0
+
+                            # There is a subtle difference between TDA and RPA calcs,
+                            # because in the latter case each transition line is
+                            # preceeded by the type of vector: X or Y, name excitation
+                            # or deexcitation (see #154 for details). For deexcitations,
+                            # we will need to reverse the MO indices. Note also that Q-Chem
+                            # starts reindexing virtual orbitals at 1.
+                            if line[5] == '(':
+                                ttype = 'X'
+                                startidx = int(line[6:9]) - 1
+                                endidx = int(line[17:20]) - 1 + self.nalpha
+                                contrib = float(line[34:41].strip())
+                            else:
+                                assert line[5] == ":"
+                                ttype = line[4]
+                                startidx = int(line[9:12]) - 1
+                                endidx = int(line[20:23]) - 1 + self.nalpha
+                                contrib = float(line[37:44].strip())
+
+                            start = (startidx, spin)
+                            end = (endidx, spin)
+                            if ttype == 'X':
+                                sec.append([start, end, contrib])
+                            elif ttype == 'Y':
+                                sec.append([end, start, contrib])
+                            else:
+                                raise ValueError('Unknown transition type: %s' % ttype)
+                            line = next(inputfile)
+                        etsecs.append(sec)
+
+                    line = next(inputfile)
+
+                self.set_attribute('etenergies', etenergies)
+                self.set_attribute('etsyms', etsyms)
+                self.set_attribute('etoscs', etoscs)
+                self.set_attribute('etsecs', etsecs)
+
+            # Molecular orbital energies and symmetries.
+            if 'Orbital Energies (a.u.) and Symmetries' in line:
+
+                #  --------------------------------------------------------------
+                #              Orbital Energies (a.u.) and Symmetries
+                #  --------------------------------------------------------------
+                #
+                #  Alpha MOs, Restricted
+                #  -- Occupied --
+                # -10.018 -10.018 -10.008 -10.008 -10.007 -10.007 -10.006 -10.005
+                #   1 Bu    1 Ag    2 Bu    2 Ag    3 Bu    3 Ag    4 Bu    4 Ag
+                #  -9.992  -9.992  -0.818  -0.755  -0.721  -0.704  -0.670  -0.585
+                #   5 Ag    5 Bu    6 Ag    6 Bu    7 Ag    7 Bu    8 Bu    8 Ag
+                #  -0.561  -0.532  -0.512  -0.462  -0.439  -0.410  -0.400  -0.397
+                #   9 Ag    9 Bu   10 Ag   11 Ag   10 Bu   11 Bu   12 Bu   12 Ag
+                #  -0.376  -0.358  -0.349  -0.330  -0.305  -0.295  -0.281  -0.263
+                #  13 Bu   14 Bu   13 Ag    1 Au   15 Bu   14 Ag   15 Ag    1 Bg
+                #  -0.216  -0.198  -0.160
+                #   2 Au    2 Bg    3 Bg
+                #  -- Virtual --
+                #   0.050   0.091   0.116   0.181   0.280   0.319   0.330   0.365
+                #   3 Au    4 Au    4 Bg    5 Au    5 Bg   16 Ag   16 Bu   17 Bu
+                #   0.370   0.413   0.416   0.422   0.446   0.469   0.496   0.539
+                #  17 Ag   18 Bu   18 Ag   19 Bu   19 Ag   20 Bu   20 Ag   21 Ag
+                #   0.571   0.587   0.610   0.627   0.646   0.693   0.743   0.806
+                #  21 Bu   22 Ag   22 Bu   23 Bu   23 Ag   24 Ag   24 Bu   25 Ag
+                #   0.816
+                #  25 Bu
+                #
+                #  Beta MOs, Restricted
+                #  -- Occupied --
+                # -10.018 -10.018 -10.008 -10.008 -10.007 -10.007 -10.006 -10.005
+                #   1 Bu    1 Ag    2 Bu    2 Ag    3 Bu    3 Ag    4 Bu    4 Ag
+                #  -9.992  -9.992  -0.818  -0.755  -0.721  -0.704  -0.670  -0.585
+                #   5 Ag    5 Bu    6 Ag    6 Bu    7 Ag    7 Bu    8 Bu    8 Ag
+                #  -0.561  -0.532  -0.512  -0.462  -0.439  -0.410  -0.400  -0.397
+                #   9 Ag    9 Bu   10 Ag   11 Ag   10 Bu   11 Bu   12 Bu   12 Ag
+                #  -0.376  -0.358  -0.349  -0.330  -0.305  -0.295  -0.281  -0.263
+                #  13 Bu   14 Bu   13 Ag    1 Au   15 Bu   14 Ag   15 Ag    1 Bg
+                #  -0.216  -0.198  -0.160
+                #   2 Au    2 Bg    3 Bg
+                #  -- Virtual --
+                #   0.050   0.091   0.116   0.181   0.280   0.319   0.330   0.365
+                #   3 Au    4 Au    4 Bg    5 Au    5 Bg   16 Ag   16 Bu   17 Bu
+                #   0.370   0.413   0.416   0.422   0.446   0.469   0.496   0.539
+                #  17 Ag   18 Bu   18 Ag   19 Bu   19 Ag   20 Bu   20 Ag   21 Ag
+                #   0.571   0.587   0.610   0.627   0.646   0.693   0.743   0.806
+                #  21 Bu   22 Ag   22 Bu   23 Bu   23 Ag   24 Ag   24 Bu   25 Ag
+                #   0.816
+                #  25 Bu
+                #  --------------------------------------------------------------
+
+                self.skip_line(inputfile, 'dashes')
                 line = next(inputfile)
+                # Sometimes Q-Chem gets a little confused...
+                while 'Warning : Irrep of orbital' in line:
+                    line = next(inputfile)
+                line = next(inputfile)
+                energies_alpha = []
+                symbols_alpha = []
+                if self.unrestricted:
+                    energies_beta = []
+                    symbols_beta = []
+                line = next(inputfile)
+
+                # The end of the block is either a blank line or only dashes.
                 while not self.re_dashes_and_spaces.search(line):
                     if 'Occupied' in line or 'Virtual' in line:
-                        # This will definitely exist, thanks to the above block.
+                        # A nice trick to find where the HOMO is.
                         if 'Virtual' in line:
-                            if len(self.homos) == 1:
-                                self.homos.append(len(energies_beta)-1)
+                            self.homos = [len(energies_alpha)-1]
                         line = next(inputfile)
+                    # Parse the energies and symmetries in pairs of lines.
+                    # energies = [utils.convertor(energy, 'hartree', 'eV')
+                    #             for energy in map(float, line.split())]
+                    # This convoluted bit handles '*******' when present.
                     energies = []
                     energy_line = line.split()
                     for e in energy_line:
@@ -727,101 +707,104 @@ class QChem(logfileparser.Logfile):
                         except ValueError:
                             energy = numpy.nan
                         energies.append(energy)
-                    energies_beta.extend(energies)
+                    energies_alpha.extend(energies)
                     line = next(inputfile)
                     symbols = line.split()[1::2]
-                    symbols_beta.extend(symbols)
+                    symbols_alpha.extend(symbols)
                     line = next(inputfile)
 
-            # For now, only keep the last set of MO energies, even though it is
-            # printed at every step of geometry optimizations and fragment jobs.
-            self.moenergies = [[]]
-            self.mosyms = [[]]
-            self.moenergies[0] = numpy.array(energies_alpha)
-            self.mosyms[0] = symbols_alpha
-            if self.unrestricted:
-                self.moenergies.append([])
-                self.mosyms.append([])
-                self.moenergies[1] = numpy.array(energies_beta)
-                self.mosyms[1] = symbols_beta
-
-            self.set_attribute('nmo', len(self.moenergies[0]))
-
-        # Molecular orbital energies, no symmetries.
-
-        if line.strip() == 'Orbital Energies (a.u.)':
-
-            # In the case of no orbital symmetries, the beta spin block is not
-            # present for restricted calculations.
-
-            #  --------------------------------------------------------------
-            #                     Orbital Energies (a.u.)
-            #  --------------------------------------------------------------
-            #
-            #  Alpha MOs
-            #  -- Occupied --
-            # ******* -38.595 -34.580 -34.579 -34.578 -19.372 -19.372 -19.364
-            # -19.363 -19.362 -19.362  -4.738  -3.252  -3.250  -3.250  -1.379
-            #  -1.371  -1.369  -1.365  -1.364  -1.362  -0.859  -0.855  -0.849
-            #  -0.846  -0.840  -0.836  -0.810  -0.759  -0.732  -0.729  -0.704
-            #  -0.701  -0.621  -0.610  -0.595  -0.587  -0.584  -0.578  -0.411
-            #  -0.403  -0.355  -0.354  -0.352
-            #  -- Virtual --
-            #  -0.201  -0.117  -0.099  -0.086   0.020   0.031   0.055   0.067
-            #   0.075   0.082   0.086   0.092   0.096   0.105   0.114   0.148
-            #
-            #  Beta MOs
-            #  -- Occupied --
-            # ******* -38.561 -34.550 -34.549 -34.549 -19.375 -19.375 -19.367
-            # -19.367 -19.365 -19.365  -4.605  -3.105  -3.103  -3.102  -1.385
-            #  -1.376  -1.376  -1.371  -1.370  -1.368  -0.863  -0.858  -0.853
-            #  -0.849  -0.843  -0.839  -0.818  -0.765  -0.738  -0.737  -0.706
-            #  -0.702  -0.624  -0.613  -0.600  -0.591  -0.588  -0.585  -0.291
-            #  -0.291  -0.288  -0.275
-            #  -- Virtual --
-            #  -0.139  -0.122  -0.103   0.003   0.014   0.049   0.049   0.059
-            #   0.061   0.070   0.076   0.081   0.086   0.090   0.098   0.106
-            #   0.138
-            #  --------------------------------------------------------------
-
-            self.skip_lines(inputfile, ['dashes', 'blank'])
-            line = next(inputfile)
-            energies_alpha = []
-            if self.unrestricted:
-                energies_beta = []
-            line = next(inputfile)
-
-            # The end of the block is either a blank line or only dashes.
-            while not self.re_dashes_and_spaces.search(line):
-                if 'Occupied' in line or 'Virtual' in line:
-                    # A nice trick to find where the HOMO is.
-                    if 'Virtual' in line:
-                        self.homos = [len(energies_alpha)-1]
+                line = next(inputfile)
+                # Only look at the second block if doing an unrestricted calculation.
+                # This might be a problem for ROHF/ROKS.
+                if self.unrestricted:
+                    assert 'Beta MOs' in line
+                    self.skip_line(inputfile, '-- Occupied --')
                     line = next(inputfile)
-                energies = []
-                energy_line = line.split()
-                for e in energy_line:
-                    try:
-                        energy = utils.convertor(self.float(e), 'hartree', 'eV')
-                    except ValueError:
-                        energy = numpy.nan
-                    energies.append(energy)
-                energies_alpha.extend(energies)
+                    while not self.re_dashes_and_spaces.search(line):
+                        if 'Occupied' in line or 'Virtual' in line:
+                            # This will definitely exist, thanks to the above block.
+                            if 'Virtual' in line:
+                                if len(self.homos) == 1:
+                                    self.homos.append(len(energies_beta)-1)
+                            line = next(inputfile)
+                        energies = []
+                        energy_line = line.split()
+                        for e in energy_line:
+                            try:
+                                energy = utils.convertor(self.float(e), 'hartree', 'eV')
+                            except ValueError:
+                                energy = numpy.nan
+                            energies.append(energy)
+                        energies_beta.extend(energies)
+                        line = next(inputfile)
+                        symbols = line.split()[1::2]
+                        symbols_beta.extend(symbols)
+                        line = next(inputfile)
+
+                # For now, only keep the last set of MO energies, even though it is
+                # printed at every step of geometry optimizations and fragment jobs.
+                self.moenergies = [[]]
+                self.mosyms = [[]]
+                self.moenergies[0] = numpy.array(energies_alpha)
+                self.mosyms[0] = symbols_alpha
+                if self.unrestricted:
+                    self.moenergies.append([])
+                    self.mosyms.append([])
+                    self.moenergies[1] = numpy.array(energies_beta)
+                    self.mosyms[1] = symbols_beta
+
+                self.set_attribute('nmo', len(self.moenergies[0]))
+
+            # Molecular orbital energies, no symmetries.
+
+            if line.strip() == 'Orbital Energies (a.u.)':
+
+                # In the case of no orbital symmetries, the beta spin block is not
+                # present for restricted calculations.
+
+                #  --------------------------------------------------------------
+                #                     Orbital Energies (a.u.)
+                #  --------------------------------------------------------------
+                #
+                #  Alpha MOs
+                #  -- Occupied --
+                # ******* -38.595 -34.580 -34.579 -34.578 -19.372 -19.372 -19.364
+                # -19.363 -19.362 -19.362  -4.738  -3.252  -3.250  -3.250  -1.379
+                #  -1.371  -1.369  -1.365  -1.364  -1.362  -0.859  -0.855  -0.849
+                #  -0.846  -0.840  -0.836  -0.810  -0.759  -0.732  -0.729  -0.704
+                #  -0.701  -0.621  -0.610  -0.595  -0.587  -0.584  -0.578  -0.411
+                #  -0.403  -0.355  -0.354  -0.352
+                #  -- Virtual --
+                #  -0.201  -0.117  -0.099  -0.086   0.020   0.031   0.055   0.067
+                #   0.075   0.082   0.086   0.092   0.096   0.105   0.114   0.148
+                #
+                #  Beta MOs
+                #  -- Occupied --
+                # ******* -38.561 -34.550 -34.549 -34.549 -19.375 -19.375 -19.367
+                # -19.367 -19.365 -19.365  -4.605  -3.105  -3.103  -3.102  -1.385
+                #  -1.376  -1.376  -1.371  -1.370  -1.368  -0.863  -0.858  -0.853
+                #  -0.849  -0.843  -0.839  -0.818  -0.765  -0.738  -0.737  -0.706
+                #  -0.702  -0.624  -0.613  -0.600  -0.591  -0.588  -0.585  -0.291
+                #  -0.291  -0.288  -0.275
+                #  -- Virtual --
+                #  -0.139  -0.122  -0.103   0.003   0.014   0.049   0.049   0.059
+                #   0.061   0.070   0.076   0.081   0.086   0.090   0.098   0.106
+                #   0.138
+                #  --------------------------------------------------------------
+
+                self.skip_lines(inputfile, ['dashes', 'blank'])
+                line = next(inputfile)
+                energies_alpha = []
+                if self.unrestricted:
+                    energies_beta = []
                 line = next(inputfile)
 
-            line = next(inputfile)
-            # Only look at the second block if doing an unrestricted calculation.
-            # This might be a problem for ROHF/ROKS.
-            if self.unrestricted:
-                assert 'Beta MOs' in line
-                self.skip_line(inputfile, '-- Occupied --')
-                line = next(inputfile)
+                # The end of the block is either a blank line or only dashes.
                 while not self.re_dashes_and_spaces.search(line):
                     if 'Occupied' in line or 'Virtual' in line:
-                        # This will definitely exist, thanks to the above block.
+                        # A nice trick to find where the HOMO is.
                         if 'Virtual' in line:
-                            if len(self.homos) == 1:
-                                self.homos.append(len(energies_beta)-1)
+                            self.homos = [len(energies_alpha)-1]
                         line = next(inputfile)
                     energies = []
                     energy_line = line.split()
@@ -831,348 +814,373 @@ class QChem(logfileparser.Logfile):
                         except ValueError:
                             energy = numpy.nan
                         energies.append(energy)
-                    energies_beta.extend(energies)
+                    energies_alpha.extend(energies)
                     line = next(inputfile)
 
-            # For now, only keep the last set of MO energies, even though it is
-            # printed at every step of geometry optimizations and fragment jobs.
-            self.moenergies = [[]]
-            self.moenergies[0] = numpy.array(energies_alpha)
-            if self.unrestricted:
-                self.moenergies.append([])
-                self.moenergies[1] = numpy.array(energies_beta)
-            self.set_attribute('nmo', len(self.moenergies[0]))
+                line = next(inputfile)
+                # Only look at the second block if doing an unrestricted calculation.
+                # This might be a problem for ROHF/ROKS.
+                if self.unrestricted:
+                    assert 'Beta MOs' in line
+                    self.skip_line(inputfile, '-- Occupied --')
+                    line = next(inputfile)
+                    while not self.re_dashes_and_spaces.search(line):
+                        if 'Occupied' in line or 'Virtual' in line:
+                            # This will definitely exist, thanks to the above block.
+                            if 'Virtual' in line:
+                                if len(self.homos) == 1:
+                                    self.homos.append(len(energies_beta)-1)
+                            line = next(inputfile)
+                        energies = []
+                        energy_line = line.split()
+                        for e in energy_line:
+                            try:
+                                energy = utils.convertor(self.float(e), 'hartree', 'eV')
+                            except ValueError:
+                                energy = numpy.nan
+                            energies.append(energy)
+                        energies_beta.extend(energies)
+                        line = next(inputfile)
 
-        # If we've asked to display more virtual orbitals than there
-        # are MOs present in the molecule, fix that now.
-        if hasattr(self, 'nmo') and hasattr(self, 'nalpha') and hasattr(self, 'nbeta'):
-            if self.norbdisp_alpha_aonames > self.nmo:
-                self.norbdisp_alpha_aonames = self.nmo
-            if self.norbdisp_beta_aonames > self.nmo:
-                self.norbdisp_beta_aonames = self.nmo
+                # For now, only keep the last set of MO energies, even though it is
+                # printed at every step of geometry optimizations and fragment jobs.
+                self.moenergies = [[]]
+                self.moenergies[0] = numpy.array(energies_alpha)
+                if self.unrestricted:
+                    self.moenergies.append([])
+                    self.moenergies[1] = numpy.array(energies_beta)
+                self.set_attribute('nmo', len(self.moenergies[0]))
 
-        # Molecular orbital coefficients.
+            # If we've asked to display more virtual orbitals than there
+            # are MOs present in the molecule, fix that now.
+            if hasattr(self, 'nmo') and hasattr(self, 'nalpha') and hasattr(self, 'nbeta'):
+                if self.norbdisp_alpha_aonames > self.nmo:
+                    self.norbdisp_alpha_aonames = self.nmo
+                if self.norbdisp_beta_aonames > self.nmo:
+                    self.norbdisp_beta_aonames = self.nmo
 
-        # This block comes from `print_orbitals = true/{int}`. Less
-        # precision than `scf_final_print >= 2` for `mocoeffs`, but
-        # important for `aonames` and `atombasis`.
+            # Molecular orbital coefficients.
 
-        if any(header in line
-               for header in self.alpha_mo_coefficient_headers):
+            # This block comes from `print_orbitals = true/{int}`. Less
+            # precision than `scf_final_print >= 2` for `mocoeffs`, but
+            # important for `aonames` and `atombasis`.
 
-            if not hasattr(self, 'mocoeffs'):
-                self.mocoeffs = []
-            if not hasattr(self, 'atombasis'):
-                self.atombasis = []
-                for n in range(self.natom):
-                    self.atombasis.append([])
-            if not hasattr(self, 'aonames'):
-                self.aonames = []
-            # We could also attempt to parse `moenergies` here, but
-            # nothing is gained by it.
+            if any(header in line
+                   for header in self.alpha_mo_coefficient_headers):
 
-            mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_alpha_aonames))
-            self.parse_matrix_aonames(inputfile, mocoeffs)
-            # Only use these MO coefficients if we don't have them
-            # from `scf_final_print`.
-            if len(self.mocoeffs) == 0:
-                self.mocoeffs.append(mocoeffs.transpose())
+                if not hasattr(self, 'mocoeffs'):
+                    self.mocoeffs = []
+                if not hasattr(self, 'atombasis'):
+                    self.atombasis = []
+                    for n in range(self.natom):
+                        self.atombasis.append([])
+                if not hasattr(self, 'aonames'):
+                    self.aonames = []
+                # We could also attempt to parse `moenergies` here, but
+                # nothing is gained by it.
 
-            # Go back through `aonames` to create `atombasis`.
-            assert len(self.aonames) == self.nbasis
-            for aoindex, aoname in enumerate(self.aonames):
-                atomindex = int(self.re_atomindex.search(aoname).groups()[0]) - 1
-                self.atombasis[atomindex].append(aoindex)
-            assert len(self.atombasis) == len(self.atomnos)
+                mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_alpha_aonames))
+                self.parse_matrix_aonames(inputfile, mocoeffs)
+                # Only use these MO coefficients if we don't have them
+                # from `scf_final_print`.
+                if len(self.mocoeffs) == 0:
+                    self.mocoeffs.append(mocoeffs.transpose())
 
-        if 'BETA  MOLECULAR ORBITAL COEFFICIENTS' in line:
+                # Go back through `aonames` to create `atombasis`.
+                assert len(self.aonames) == self.nbasis
+                for aoindex, aoname in enumerate(self.aonames):
+                    atomindex = int(self.re_atomindex.search(aoname).groups()[0]) - 1
+                    self.atombasis[atomindex].append(aoindex)
+                assert len(self.atombasis) == len(self.atomnos)
 
-            mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta_aonames))
-            self.parse_matrix_aonames(inputfile, mocoeffs)
-            if len(self.mocoeffs) == 1:
-                self.mocoeffs.append(mocoeffs.transpose())
+            if 'BETA  MOLECULAR ORBITAL COEFFICIENTS' in line:
 
-        # Population analysis.
+                mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta_aonames))
+                self.parse_matrix_aonames(inputfile, mocoeffs)
+                if len(self.mocoeffs) == 1:
+                    self.mocoeffs.append(mocoeffs.transpose())
 
-        if 'Ground-State Mulliken Net Atomic Charges' in line:
-            self.parse_charge_section(inputfile, 'mulliken')
-        if 'Hirshfeld Atomic Charges' in line:
-            self.parse_charge_section(inputfile, 'hirshfeld')
-        if 'Ground-State ChElPG Net Atomic Charges' in line:
-            self.parse_charge_section(inputfile, 'chelpg')
+            # Population analysis.
 
-        # Multipole moments are not printed in lexicographical order,
-        # so we need to parse and sort them. The units seem OK, but there
-        # is some uncertainty about the reference point and whether it
-        # can be changed.
-        #
-        # Notice how the letter/coordinate labels change to coordinate ranks
-        # after hexadecapole moments, and need to be translated. Additionally,
-        # after 9-th order moments the ranks are not necessarily single digits
-        # and so there are spaces between them.
-        #
-        # -----------------------------------------------------------------
-        #                    Cartesian Multipole Moments
-        #                  LMN = < X^L Y^M Z^N >
-        # -----------------------------------------------------------------
-        #    Charge (ESU x 10^10)
-        #                 0.0000
-        #    Dipole Moment (Debye)
-        #         X       0.0000      Y       0.0000      Z       0.0000
-        #       Tot       0.0000
-        #    Quadrupole Moments (Debye-Ang)
-        #        XX     -50.9647     XY      -0.1100     YY     -50.1441
-        #        XZ       0.0000     YZ       0.0000     ZZ     -58.5742
-        # ...
-        #    5th-Order Moments (Debye-Ang^4)
-        #       500       0.0159    410      -0.0010    320       0.0005
-        #       230       0.0000    140       0.0005    050       0.0012
-        # ...
-        # -----------------------------------------------------------------
-        #
-        if "Cartesian Multipole Moments" in line:
+            if 'Ground-State Mulliken Net Atomic Charges' in line:
+                self.parse_charge_section(inputfile, 'mulliken')
+            if 'Hirshfeld Atomic Charges' in line:
+                self.parse_charge_section(inputfile, 'hirshfeld')
+            if 'Ground-State ChElPG Net Atomic Charges' in line:
+                self.parse_charge_section(inputfile, 'chelpg')
 
-            # This line appears not by default, but only when
-            # `multipole_order` > 4:
-            line = inputfile.next()
-            if 'LMN = < X^L Y^M Z^N >' in line:
+            # Multipole moments are not printed in lexicographical order,
+            # so we need to parse and sort them. The units seem OK, but there
+            # is some uncertainty about the reference point and whether it
+            # can be changed.
+            #
+            # Notice how the letter/coordinate labels change to coordinate ranks
+            # after hexadecapole moments, and need to be translated. Additionally,
+            # after 9-th order moments the ranks are not necessarily single digits
+            # and so there are spaces between them.
+            #
+            # -----------------------------------------------------------------
+            #                    Cartesian Multipole Moments
+            #                  LMN = < X^L Y^M Z^N >
+            # -----------------------------------------------------------------
+            #    Charge (ESU x 10^10)
+            #                 0.0000
+            #    Dipole Moment (Debye)
+            #         X       0.0000      Y       0.0000      Z       0.0000
+            #       Tot       0.0000
+            #    Quadrupole Moments (Debye-Ang)
+            #        XX     -50.9647     XY      -0.1100     YY     -50.1441
+            #        XZ       0.0000     YZ       0.0000     ZZ     -58.5742
+            # ...
+            #    5th-Order Moments (Debye-Ang^4)
+            #       500       0.0159    410      -0.0010    320       0.0005
+            #       230       0.0000    140       0.0005    050       0.0012
+            # ...
+            # -----------------------------------------------------------------
+            #
+            if "Cartesian Multipole Moments" in line:
+
+                # This line appears not by default, but only when
+                # `multipole_order` > 4:
                 line = inputfile.next()
-
-            # The reference point is always the origin, although normally the molecule
-            # is moved so that the center of charge is at the origin.
-            self.reference = [0.0, 0.0, 0.0]
-            self.moments = [self.reference]
-
-            # Watch out! This charge is in statcoulombs without the exponent!
-            # We should expect very good agreement, however Q-Chem prints
-            # the charge only with 5 digits, so expect 1e-4 accuracy.
-            charge_header = inputfile.next()
-            assert charge_header.split()[0] == "Charge"
-            charge = float(inputfile.next().strip())
-            charge = utils.convertor(charge, 'statcoulomb', 'e') * 1e-10
-            # Allow this to change until fragment jobs are properly implemented.
-            # assert abs(charge - self.charge) < 1e-4
-
-            # This will make sure Debyes are used (not sure if it can be changed).
-            line = inputfile.next()
-            assert line.strip() == "Dipole Moment (Debye)"
-
-            while "-----" not in line:
-
-                # The current multipole element will be gathered here.
-                multipole = []
-
-                line = inputfile.next()
-                while ("-----" not in line) and ("Moment" not in line):
-
-                    cols = line.split()
-
-                    # The total (norm) is printed for dipole but not other multipoles.
-                    if cols[0] == 'Tot':
-                        line = inputfile.next()
-                        continue
-
-                    # Find and replace any 'stars' with NaN before moving on.
-                    for i in range(len(cols)):
-                        if '***' in cols[i]:
-                            cols[i] = numpy.nan
-
-                    # The moments come in pairs (label followed by value) up to the 9-th order,
-                    # although above hexadecapoles the labels are digits representing the rank
-                    # in each coordinate. Above the 9-th order, ranks are not always single digits,
-                    # so there are spaces between them, which means moments come in quartets.
-                    if len(self.moments) < 5:
-                        for i in range(len(cols)//2):
-                            lbl = cols[2*i]
-                            m = cols[2*i + 1]
-                            multipole.append([lbl, m])
-                    elif len(self.moments) < 10:
-                        for i in range(len(cols)//2):
-                            lbl = cols[2*i]
-                            lbl = 'X'*int(lbl[0]) + 'Y'*int(lbl[1]) + 'Z'*int(lbl[2])
-                            m = cols[2*i + 1]
-                            multipole.append([lbl, m])
-                    else:
-                        for i in range(len(cols)//4):
-                            lbl = 'X'*int(cols[4*i]) + 'Y'*int(cols[4*i + 1]) + 'Z'*int(cols[4*i + 2])
-                            m = cols[4*i + 3]
-                            multipole.append([lbl, m])
-
+                if 'LMN = < X^L Y^M Z^N >' in line:
                     line = inputfile.next()
 
-                # Sort should use the first element when sorting lists,
-                # so this should simply work, and afterwards we just need
-                # to extract the second element in each list (the actual moment).
-                multipole.sort()
-                multipole = [m[1] for m in multipole]
-                self.moments.append(multipole)
+                # The reference point is always the origin, although normally the molecule
+                # is moved so that the center of charge is at the origin.
+                self.reference = [0.0, 0.0, 0.0]
+                self.moments = [self.reference]
 
-        # For `method = force` or geometry optimizations,
-        # the gradient is printed.
-        if 'Gradient of SCF Energy' in line:
-            if not hasattr(self, 'grads'):
-                self.grads = []
-            grad = numpy.empty(shape=(3, self.natom))
-            self.parse_matrix(inputfile, grad)
-            self.grads.append(grad.T)
+                # Watch out! This charge is in statcoulombs without the exponent!
+                # We should expect very good agreement, however Q-Chem prints
+                # the charge only with 5 digits, so expect 1e-4 accuracy.
+                charge_header = inputfile.next()
+                assert charge_header.split()[0] == "Charge"
+                charge = float(inputfile.next().strip())
+                charge = utils.convertor(charge, 'statcoulomb', 'e') * 1e-10
+                # Allow this to change until fragment jobs are properly implemented.
+                # assert abs(charge - self.charge) < 1e-4
 
-        # For IR-related jobs, the Hessian is printed (dim: 3*natom, 3*natom).
-        # Note that this is *not* the mass-weighted Hessian.
-        if 'Hessian of the SCF Energy' in line:
-            if not hasattr(self, 'hessian'):
-                dim = 3*self.natom
-                self.hessian = numpy.empty(shape=(dim, dim))
-                self.parse_matrix(inputfile, self.hessian)
+                # This will make sure Debyes are used (not sure if it can be changed).
+                line = inputfile.next()
+                assert line.strip() == "Dipole Moment (Debye)"
 
-        # Start of the IR/Raman frequency section.
-        if 'VIBRATIONAL ANALYSIS' in line:
+                while "-----" not in line:
 
-            while 'STANDARD THERMODYNAMIC QUANTITIES' not in line:
-                ## IR, optional Raman:
-                #
-                # **********************************************************************
-                # **                                                                  **
-                # **                       VIBRATIONAL ANALYSIS                       **
-                # **                       --------------------                       **
-                # **                                                                  **
-                # **        VIBRATIONAL FREQUENCIES (CM**-1) AND NORMAL MODES         **
-                # **     FORCE CONSTANTS (mDYN/ANGSTROM) AND REDUCED MASSES (AMU)     **
-                # **                  INFRARED INTENSITIES (KM/MOL)                   **
-                ##** RAMAN SCATTERING ACTIVITIES (A**4/AMU) AND DEPOLARIZATION RATIOS **
-                # **                                                                  **
-                # **********************************************************************
-                #
-                #
-                # Mode:                 1                      2                      3
-                # Frequency:      -106.88                -102.91                 161.77
-                # Force Cnst:      0.0185                 0.0178                 0.0380
-                # Red. Mass:       2.7502                 2.8542                 2.4660
-                # IR Active:          NO                     YES                    YES
-                # IR Intens:        0.000                  0.000                  0.419
-                # Raman Active:       YES                    NO                     NO
-                ##Raman Intens:     2.048                  0.000                  0.000
-                ##Depolar:          0.750                  0.000                  0.000
-                #               X      Y      Z        X      Y      Z        X      Y      Z
-                # C          0.000  0.000 -0.100   -0.000  0.000 -0.070   -0.000 -0.000 -0.027
-                # C          0.000  0.000  0.045   -0.000  0.000 -0.074    0.000 -0.000 -0.109
-                # C          0.000  0.000  0.148   -0.000 -0.000 -0.074    0.000  0.000 -0.121
-                # C          0.000  0.000  0.100   -0.000 -0.000 -0.070    0.000  0.000 -0.027
-                # C          0.000  0.000 -0.045    0.000 -0.000 -0.074   -0.000 -0.000 -0.109
-                # C          0.000  0.000 -0.148    0.000  0.000 -0.074   -0.000 -0.000 -0.121
-                # H         -0.000  0.000  0.086   -0.000  0.000 -0.082    0.000 -0.000 -0.102
-                # H          0.000  0.000  0.269   -0.000 -0.000 -0.091    0.000  0.000 -0.118
-                # H          0.000  0.000 -0.086    0.000 -0.000 -0.082   -0.000  0.000 -0.102
-                # H         -0.000  0.000 -0.269    0.000  0.000 -0.091   -0.000 -0.000 -0.118
-                # C          0.000 -0.000  0.141   -0.000 -0.000 -0.062   -0.000  0.000  0.193
-                # C         -0.000 -0.000 -0.160    0.000  0.000  0.254   -0.000  0.000  0.043
-                # H          0.000 -0.000  0.378   -0.000  0.000 -0.289    0.000  0.000  0.519
-                # H         -0.000 -0.000 -0.140    0.000  0.000  0.261   -0.000 -0.000  0.241
-                # H         -0.000 -0.000 -0.422    0.000  0.000  0.499   -0.000  0.000 -0.285
-                # C          0.000 -0.000 -0.141    0.000  0.000 -0.062   -0.000 -0.000  0.193
-                # C         -0.000 -0.000  0.160   -0.000 -0.000  0.254    0.000  0.000  0.043
-                # H          0.000 -0.000 -0.378    0.000 -0.000 -0.289   -0.000  0.000  0.519
-                # H         -0.000 -0.000  0.140   -0.000 -0.000  0.261    0.000  0.000  0.241
-                # H         -0.000 -0.000  0.422   -0.000 -0.000  0.499    0.000  0.000 -0.285
-                # TransDip   0.000 -0.000 -0.000    0.000 -0.000 -0.000   -0.000  0.000  0.021
-                #
-                # Mode:                 4                      5                      6
-                # ...
-                #
-                # There isn't any symmetry information for normal modes present
-                # in Q-Chem.
-                # if not hasattr(self, 'vibsyms'):
-                #     self.vibsyms = []
-                if 'Frequency:' in line:
-                    if not hasattr(self, 'vibfreqs'):
-                        self.vibfreqs = []
-                    vibfreqs = map(float, line.split()[1:])
-                    self.vibfreqs.extend(vibfreqs)
+                    # The current multipole element will be gathered here.
+                    multipole = []
 
-                if 'IR Intens:' in line:
-                    if not hasattr(self, 'vibirs'):
-                        self.vibirs = []
-                    vibirs = map(float, line.split()[2:])
-                    self.vibirs.extend(vibirs)
+                    line = inputfile.next()
+                    while ("-----" not in line) and ("Moment" not in line):
 
-                if 'Raman Intens:' in line:
-                    if not hasattr(self, 'vibramans'):
-                        self.vibramans = []
-                    vibramans = map(float, line.split()[2:])
-                    self.vibramans.extend(vibramans)
+                        cols = line.split()
 
-                # This is the start of the displacement block.
-                if line.split()[0:3] == ['X', 'Y', 'Z']:
-                    if not hasattr(self, 'vibdisps'):
-                        self.vibdisps = []
-                    disps = []
-                    for k in range(self.natom):
-                        line = next(inputfile)
-                        numbers = list(map(float, line.split()[1:]))
-                        N = len(numbers) // 3
-                        if not disps:
+                        # The total (norm) is printed for dipole but not other multipoles.
+                        if cols[0] == 'Tot':
+                            line = inputfile.next()
+                            continue
+
+                        # Find and replace any 'stars' with NaN before moving on.
+                        for i in range(len(cols)):
+                            if '***' in cols[i]:
+                                cols[i] = numpy.nan
+
+                        # The moments come in pairs (label followed by value) up to the 9-th order,
+                        # although above hexadecapoles the labels are digits representing the rank
+                        # in each coordinate. Above the 9-th order, ranks are not always single digits,
+                        # so there are spaces between them, which means moments come in quartets.
+                        if len(self.moments) < 5:
+                            for i in range(len(cols)//2):
+                                lbl = cols[2*i]
+                                m = cols[2*i + 1]
+                                multipole.append([lbl, m])
+                        elif len(self.moments) < 10:
+                            for i in range(len(cols)//2):
+                                lbl = cols[2*i]
+                                lbl = 'X'*int(lbl[0]) + 'Y'*int(lbl[1]) + 'Z'*int(lbl[2])
+                                m = cols[2*i + 1]
+                                multipole.append([lbl, m])
+                        else:
+                            for i in range(len(cols)//4):
+                                lbl = 'X'*int(cols[4*i]) + 'Y'*int(cols[4*i + 1]) + 'Z'*int(cols[4*i + 2])
+                                m = cols[4*i + 3]
+                                multipole.append([lbl, m])
+
+                        line = inputfile.next()
+
+                    # Sort should use the first element when sorting lists,
+                    # so this should simply work, and afterwards we just need
+                    # to extract the second element in each list (the actual moment).
+                    multipole.sort()
+                    multipole = [m[1] for m in multipole]
+                    self.moments.append(multipole)
+
+            # For `method = force` or geometry optimizations,
+            # the gradient is printed.
+            if 'Gradient of SCF Energy' in line:
+                if not hasattr(self, 'grads'):
+                    self.grads = []
+                grad = numpy.empty(shape=(3, self.natom))
+                self.parse_matrix(inputfile, grad)
+                self.grads.append(grad.T)
+
+            # For IR-related jobs, the Hessian is printed (dim: 3*natom, 3*natom).
+            # Note that this is *not* the mass-weighted Hessian.
+            if 'Hessian of the SCF Energy' in line:
+                if not hasattr(self, 'hessian'):
+                    dim = 3*self.natom
+                    self.hessian = numpy.empty(shape=(dim, dim))
+                    self.parse_matrix(inputfile, self.hessian)
+
+            # Start of the IR/Raman frequency section.
+            if 'VIBRATIONAL ANALYSIS' in line:
+
+                while 'STANDARD THERMODYNAMIC QUANTITIES' not in line:
+                    ## IR, optional Raman:
+                    #
+                    # **********************************************************************
+                    # **                                                                  **
+                    # **                       VIBRATIONAL ANALYSIS                       **
+                    # **                       --------------------                       **
+                    # **                                                                  **
+                    # **        VIBRATIONAL FREQUENCIES (CM**-1) AND NORMAL MODES         **
+                    # **     FORCE CONSTANTS (mDYN/ANGSTROM) AND REDUCED MASSES (AMU)     **
+                    # **                  INFRARED INTENSITIES (KM/MOL)                   **
+                    ##** RAMAN SCATTERING ACTIVITIES (A**4/AMU) AND DEPOLARIZATION RATIOS **
+                    # **                                                                  **
+                    # **********************************************************************
+                    #
+                    #
+                    # Mode:                 1                      2                      3
+                    # Frequency:      -106.88                -102.91                 161.77
+                    # Force Cnst:      0.0185                 0.0178                 0.0380
+                    # Red. Mass:       2.7502                 2.8542                 2.4660
+                    # IR Active:          NO                     YES                    YES
+                    # IR Intens:        0.000                  0.000                  0.419
+                    # Raman Active:       YES                    NO                     NO
+                    ##Raman Intens:     2.048                  0.000                  0.000
+                    ##Depolar:          0.750                  0.000                  0.000
+                    #               X      Y      Z        X      Y      Z        X      Y      Z
+                    # C          0.000  0.000 -0.100   -0.000  0.000 -0.070   -0.000 -0.000 -0.027
+                    # C          0.000  0.000  0.045   -0.000  0.000 -0.074    0.000 -0.000 -0.109
+                    # C          0.000  0.000  0.148   -0.000 -0.000 -0.074    0.000  0.000 -0.121
+                    # C          0.000  0.000  0.100   -0.000 -0.000 -0.070    0.000  0.000 -0.027
+                    # C          0.000  0.000 -0.045    0.000 -0.000 -0.074   -0.000 -0.000 -0.109
+                    # C          0.000  0.000 -0.148    0.000  0.000 -0.074   -0.000 -0.000 -0.121
+                    # H         -0.000  0.000  0.086   -0.000  0.000 -0.082    0.000 -0.000 -0.102
+                    # H          0.000  0.000  0.269   -0.000 -0.000 -0.091    0.000  0.000 -0.118
+                    # H          0.000  0.000 -0.086    0.000 -0.000 -0.082   -0.000  0.000 -0.102
+                    # H         -0.000  0.000 -0.269    0.000  0.000 -0.091   -0.000 -0.000 -0.118
+                    # C          0.000 -0.000  0.141   -0.000 -0.000 -0.062   -0.000  0.000  0.193
+                    # C         -0.000 -0.000 -0.160    0.000  0.000  0.254   -0.000  0.000  0.043
+                    # H          0.000 -0.000  0.378   -0.000  0.000 -0.289    0.000  0.000  0.519
+                    # H         -0.000 -0.000 -0.140    0.000  0.000  0.261   -0.000 -0.000  0.241
+                    # H         -0.000 -0.000 -0.422    0.000  0.000  0.499   -0.000  0.000 -0.285
+                    # C          0.000 -0.000 -0.141    0.000  0.000 -0.062   -0.000 -0.000  0.193
+                    # C         -0.000 -0.000  0.160   -0.000 -0.000  0.254    0.000  0.000  0.043
+                    # H          0.000 -0.000 -0.378    0.000 -0.000 -0.289   -0.000  0.000  0.519
+                    # H         -0.000 -0.000  0.140   -0.000 -0.000  0.261    0.000  0.000  0.241
+                    # H         -0.000 -0.000  0.422   -0.000 -0.000  0.499    0.000  0.000 -0.285
+                    # TransDip   0.000 -0.000 -0.000    0.000 -0.000 -0.000   -0.000  0.000  0.021
+                    #
+                    # Mode:                 4                      5                      6
+                    # ...
+                    #
+                    # There isn't any symmetry information for normal modes present
+                    # in Q-Chem.
+                    # if not hasattr(self, 'vibsyms'):
+                    #     self.vibsyms = []
+                    if 'Frequency:' in line:
+                        if not hasattr(self, 'vibfreqs'):
+                            self.vibfreqs = []
+                        vibfreqs = map(float, line.split()[1:])
+                        self.vibfreqs.extend(vibfreqs)
+
+                    if 'IR Intens:' in line:
+                        if not hasattr(self, 'vibirs'):
+                            self.vibirs = []
+                        vibirs = map(float, line.split()[2:])
+                        self.vibirs.extend(vibirs)
+
+                    if 'Raman Intens:' in line:
+                        if not hasattr(self, 'vibramans'):
+                            self.vibramans = []
+                        vibramans = map(float, line.split()[2:])
+                        self.vibramans.extend(vibramans)
+
+                    # This is the start of the displacement block.
+                    if line.split()[0:3] == ['X', 'Y', 'Z']:
+                        if not hasattr(self, 'vibdisps'):
+                            self.vibdisps = []
+                        disps = []
+                        for k in range(self.natom):
+                            line = next(inputfile)
+                            numbers = list(map(float, line.split()[1:]))
+                            N = len(numbers) // 3
+                            if not disps:
+                                for n in range(N):
+                                    disps.append([])
                             for n in range(N):
-                                disps.append([])
-                        for n in range(N):
-                            disps[n].append(numbers[3*n:(3*n)+3])
-                    self.vibdisps.extend(disps)
+                                disps[n].append(numbers[3*n:(3*n)+3])
+                        self.vibdisps.extend(disps)
 
+                    line = next(inputfile)
+
+                    # Anharmonic vibrational analysis.
+                    # Q-Chem includes 3 theories: VPT2, TOSH, and VCI.
+                    # For now, just take the VPT2 results.
+
+                    # if 'VIBRATIONAL ANHARMONIC ANALYSIS' in line:
+
+                    #     while list(set(line.strip())) != ['=']:
+                    #         if 'VPT2' in line:
+                    #             if not hasattr(self, 'vibanharms'):
+                    #                 self.vibanharms = []
+                    #             self.vibanharms.append(float(line.split()[-1]))
+                    #         line = next(inputfile)
+
+            if 'STANDARD THERMODYNAMIC QUANTITIES AT' in line:
+
+                if not hasattr(self, 'temperature'):
+                    self.temperature = float(line.split()[4])
+                # Not supported yet.
+                if not hasattr(self, 'pressure'):
+                    self.pressure = float(line.split()[7])
+                self.skip_lines(inputfile, ['blank', 'Imaginary'])
                 line = next(inputfile)
+                # Not supported yet.
+                if 'Zero point vibrational energy' in line:
+                    if not hasattr(self, 'zpe'):
+                        # Convert from kcal/mol to Hartree/particle.
+                        self.zpe = utils.convertor(float(line.split()[4]),
+                                                   'kcal', 'hartree')
 
-                # Anharmonic vibrational analysis.
-                # Q-Chem includes 3 theories: VPT2, TOSH, and VCI.
-                # For now, just take the VPT2 results.
+                atommasses = []
 
-                # if 'VIBRATIONAL ANHARMONIC ANALYSIS' in line:
+                while 'Archival summary' not in line:
 
-                #     while list(set(line.strip())) != ['=']:
-                #         if 'VPT2' in line:
-                #             if not hasattr(self, 'vibanharms'):
-                #                 self.vibanharms = []
-                #             self.vibanharms.append(float(line.split()[-1]))
-                #         line = next(inputfile)
+                    if 'Has Mass' in line:
+                        atommass = float(line.split()[6])
+                        atommasses.append(atommass)
 
-        if 'STANDARD THERMODYNAMIC QUANTITIES AT' in line:
+                    if 'Total Enthalpy' in line:
+                        if not hasattr(self, 'enthalpy'):
+                            enthalpy = float(line.split()[2])
+                            self.enthalpy = utils.convertor(enthalpy,
+                                                            'kcal', 'hartree')
+                    if 'Total Entropy' in line:
+                        if not hasattr(self, 'entropy'):
+                            entropy = float(line.split()[2]) * self.temperature / 1000
+                            # This is the *temperature dependent* entropy.
+                            self.entropy = utils.convertor(entropy,
+                                                           'kcal', 'hartree')
+                        if not hasattr(self, 'freeenergy'):
+                            self.freeenergy = self.enthalpy - self.entropy
 
-            if not hasattr(self, 'temperature'):
-                self.temperature = float(line.split()[4])
-            # Not supported yet.
-            if not hasattr(self, 'pressure'):
-                self.pressure = float(line.split()[7])
-            self.skip_lines(inputfile, ['blank', 'Imaginary'])
-            line = next(inputfile)
-            # Not supported yet.
-            if 'Zero point vibrational energy' in line:
-                if not hasattr(self, 'zpe'):
-                    # Convert from kcal/mol to Hartree/particle.
-                    self.zpe = utils.convertor(float(line.split()[4]),
-                                               'kcal', 'hartree')
+                    line = next(inputfile)
 
-            atommasses = []
-
-            while 'Archival summary' not in line:
-
-                if 'Has Mass' in line:
-                    atommass = float(line.split()[6])
-                    atommasses.append(atommass)
-
-                if 'Total Enthalpy' in line:
-                    if not hasattr(self, 'enthalpy'):
-                        enthalpy = float(line.split()[2])
-                        self.enthalpy = utils.convertor(enthalpy,
-                                                        'kcal', 'hartree')
-                if 'Total Entropy' in line:
-                    if not hasattr(self, 'entropy'):
-                        entropy = float(line.split()[2]) * self.temperature / 1000
-                        # This is the *temperature dependent* entropy.
-                        self.entropy = utils.convertor(entropy,
-                                                       'kcal', 'hartree')
-                    if not hasattr(self, 'freeenergy'):
-                        self.freeenergy = self.enthalpy - self.entropy
-
-                line = next(inputfile)
-
-            if not hasattr(self, 'atommasses'):
-                self.atommasses = numpy.array(atommasses)
+                if not hasattr(self, 'atommasses'):
+                    self.atommasses = numpy.array(atommasses)
 
         # TODO:
         # 'enthalpy' (incorrect)

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -12,6 +12,7 @@
 
 """Parser for Q-Chem output files"""
 
+from __future__ import division
 from __future__ import print_function
 
 import re
@@ -51,6 +52,17 @@ class QChem(logfileparser.Logfile):
         # Keep track of whether or not this is a fragment calculation,
         # so that only the supersystem is parsed.
         self.is_fragment_section = False
+        # These headers identify when a fragment section is
+        # entered/exited.
+        self.fragment_section_headers = (
+            'Guess MOs from converged MOs on fragments',
+            'CP correction for fragment',
+        )
+        self.supersystem_section_headers = (
+            'Done with SCF on isolated fragments',
+            'Done with counterpoise correction on fragments',
+        )
+
 
         # Compile the dashes-and-or-spaces-only regex.
         self.re_dashes_and_spaces = re.compile('^[\s-]+$')
@@ -135,18 +147,9 @@ class QChem(logfileparser.Logfile):
         """Extract information from the file object inputfile."""
 
         # Disable/enable parsing for fragment sections.
-        fragment_section_headers = (
-            'Guess MOs from converged MOs on fragments',
-            'CP correction for fragment',
-        )
-        supersystem_section_headers = (
-            'Done with SCF on isolated fragments',
-            'Done with counterpoise correction on fragments',
-        )
-
-        if any(message in line for message in fragment_section_headers):
+        if any(message in line for message in self.fragment_section_headers):
             self.is_fragment_section = True
-        if any(message in line for message in supersystem_section_headers):
+        if any(message in line for message in self.supersystem_section_headers):
             self.is_fragment_section = False
 
         if not self.is_fragment_section:


### PR DESCRIPTION
This fixes a bug where two-part calculations (like a frequency calculation after a geometry optimization) failed, because a shortcut for using the last geometry from the previous job was used:

```
$molecule
0 1
<coordinates>
$end

@@@@

$molecule
read
$end
```

and the charge/multiplicity were read from the echoed user input. This bugfix calculates the charge and multiplicity from the number of electrons and the atomic numbers, since the aren't echoed anywhere else.

However, for this to work, as a side effect, I had to finally fix the fragment parsing too so that even if individual fragment sections (SCF, MP/CC, TDDFT, etc.) are echoed back, they're ignored.

See https://github.com/cclib/cclib-data/pull/20 for the regression tests, which needed to be altered so that fragment calculations only considered the supersystem.

Unfortunately, GitHub thinks I've changed the entire file because of their diff settings; `git diff --color-words --ignore-all-space` will show a much better diff. This is because I added a "guard" check at the top of the `extract()` block and indented everything below it a level.