### PR TITLE
Psi4: latest version changes header line

### DIFF
--- a/src/cclib/parser/ccio.py
+++ b/src/cclib/parser/ccio.py
@@ -80,7 +80,7 @@ def guess_filetype(inputfile):
     filetype = None
     for line in inputfile:
         for parser, phrases, do_break in triggers:
-            if all([line.find(p) >= 0 for p in phrases]):
+            if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
                 filetype = parser
                 if do_break:
                     return filetype

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -68,7 +68,7 @@ class Psi(logfileparser.Logfile):
         # The version should always be detected.
         if "PSI3: An Open-Source Ab Initio" in line:
             self.version = 3
-        if "PSI4: An Open-Source Ab Initio" in line:
+        if "PSI4: An Open-Source Ab Initio".lower() in line.lower():
             self.version = 4
 
         # This will automatically change the section attribute for Psi4, when encountering
@@ -141,7 +141,7 @@ class Psi(logfileparser.Logfile):
             elements = []
             coords = []
             while line.strip():
-                el, x, y, z = line.split()
+                el, x, y, z = line.split()[:4]
                 elements.append(el)
                 coords.append([float(x), float(y), float(z)])
                 line = next(inputfile)


### PR DESCRIPTION
The first element block also includes an extra column with atomic masses.

See https://github.com/cclib/cclib-data/pull/22.