### PR TITLE
Fix crash on multi-job Gaussian output with different orbitals #243.

### DIFF
--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -796,12 +796,8 @@ class Gaussian(logfileparser.Logfile):
                 if line.split()[1] == "virt." and HOMO == -2:
 
                     # If there aren't any symmetries, this is a good way to find the HOMO.
-                    # Also, check for consistency if homos was already parsed.
                     HOMO = len(self.moenergies[0])-1
-                    if hasattr(self, "homos"):
-                        assert HOMO == self.homos[0]
-                    else:
-                        self.homos = numpy.array([HOMO], "i")
+                    self.homos = numpy.array([HOMO], "i")
 
                 # Convert to floats and append to moenergies, but sometimes Gaussian
                 #  doesn't print correctly so test for ValueError (bug 1756789).
@@ -833,11 +829,8 @@ class Gaussian(logfileparser.Logfile):
                     # If there aren't any symmetries, this is a good way to find the HOMO.
                     # Also, check for consistency if homos was already parsed.
                     HOMO = len(self.moenergies[1])-1
-                    if len(self.homos) == 2:
-                        assert HOMO == self.homos[1]
-                    else:
-                        self.homos.resize([2])
-                        self.homos[1] = HOMO
+                    self.homos.resize([2])
+                    self.homos[1] = HOMO
 
                 part = line[28:]
                 i = 0


### PR DESCRIPTION
Instead of an assertion failure if the HOMO doesn't match, simply
reset the HOMOs.

Fixes issue #243 