### PR TITLE
Extracting atomic masses in GAMESS parser

### DIFF
--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -71,6 +71,7 @@ class GAMESS(logfileparser.Logfile):
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
+        
         if line[1:12] == "INPUT CARD>":
             return
 
@@ -634,6 +635,7 @@ class GAMESS(logfileparser.Logfile):
         # PLEASE VERIFY THE PROGRAM'S DECISION MANUALLY!
         #
         if "NORMAL COORDINATE ANALYSIS IN THE HARMONIC APPROXIMATION" in line:
+            
             self.vibfreqs = []
             self.vibirs = []
             self.vibdisps = []
@@ -643,6 +645,7 @@ class GAMESS(logfileparser.Logfile):
             # Pass the warnings to the logger if they are there.
             while not "MODES" in line:
                 self.updateprogress(inputfile, "Frequency Information")
+                
                 line = next(inputfile)
                 
                 # Typical Atomic Masses section printed in GAMESS

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -71,7 +71,6 @@ class GAMESS(logfileparser.Logfile):
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
-
         if line[1:12] == "INPUT CARD>":
             return
 
@@ -635,7 +634,6 @@ class GAMESS(logfileparser.Logfile):
         # PLEASE VERIFY THE PROGRAM'S DECISION MANUALLY!
         #
         if "NORMAL COORDINATE ANALYSIS IN THE HARMONIC APPROXIMATION" in line:
-
             self.vibfreqs = []
             self.vibirs = []
             self.vibdisps = []
@@ -645,8 +643,25 @@ class GAMESS(logfileparser.Logfile):
             # Pass the warnings to the logger if they are there.
             while not "MODES" in line:
                 self.updateprogress(inputfile, "Frequency Information")
-
                 line = next(inputfile)
+                
+                # Typical Atomic Masses section printed in GAMESS
+                #               ATOMIC WEIGHTS (AMU)
+                #
+                # 1     O                15.99491
+                # 2     H                 1.00782
+                # 3     H                 1.00782
+                if "ATOMIC WEIGHTS" in line:
+                    atommasses = []
+                    self.skip_line(inputfile,['b'])
+                    # There is a blank line after ATOMIC WEIGHTS
+                    line = next(inputfile)
+                    while line.strip():
+                        temp = line.strip().split()
+                        atommasses.append(float(temp[2]))
+                        line = next(inputfile)
+                    self.set_attribute('atommasses', atommasses)
+
                 if "THIS IS NOT A STATIONARY POINT" in line:
                     msg = "\n   This is not a stationary point on the molecular PES"
                     msg += "\n   The vibrational analysis is not valid!!!"

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -111,6 +111,15 @@ class QChemIRTest(GenericIRTest):
     def testhessian(self):
         """Do the frequencies from the Hessian match the printed frequencies?"""
 
+class GamessIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+    # Molecular mass of DVB in mD.
+    molecularmass = 130078.25
+
+    def testatommasses(self):
+        """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
+        mm = 1000*sum(self.data.atommasses)
+        self.assertAlmostEqual(mm, 130078.25, delta=0.1, msg = "Molecule mass: %f not 130078 +- 0.1mD" % mm)
 
 class GenericIRimgTest(unittest.TestCase):
     """Generic imaginary vibrational frequency unittest"""

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -111,6 +111,7 @@ class QChemIRTest(GenericIRTest):
     def testhessian(self):
         """Do the frequencies from the Hessian match the printed frequencies?"""
 
+
 class GamessIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
     # Molecular mass of DVB in mD.
@@ -120,6 +121,7 @@ class GamessIRTest(GenericIRTest):
         """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
         mm = 1000*sum(self.data.atommasses)
         self.assertAlmostEqual(mm, 130078.25, delta=0.1, msg = "Molecule mass: %f not 130078 +- 0.1mD" % mm)
+
 
 class GenericIRimgTest(unittest.TestCase):
     """Generic imaginary vibrational frequency unittest"""

--- a/test/testdata
+++ b/test/testdata
@@ -235,7 +235,7 @@ vib       DALTON      GenericIRTest         basicDALTON-2015      dvb_ir.out
 vib       GAMESSUK    GenericIRTest         basicGAMESS-UK7.0     dvb_ir.out
 vib       GAMESSUK    GenericIRTest         basicGAMESS-UK8.0     dvb_ir.out
 vib       GAMESS      FireflyIRTest         basicFirefly8.0       dvb_ir.out
-vib       GAMESS      GenericIRTest         basicGAMESS-US2012    dvb_ir.out
+vib       GAMESS      GamessIRTest          basicGAMESS-US2012    dvb_ir.out
 vib       Gaussian    GaussianIRTest        basicGaussian03       dvb_ir.out
 vib       Gaussian    GaussianIRTest        basicGaussian09       dvb_ir.out
 vib       Jaguar      JaguarIRTest          basicJaguar7.0        dvb_ir.out


### PR DESCRIPTION
GAMESS prints Atomic Weights after
 `NORMAL COORDINATE ANALYSIS IN THE HARMONIC APPROXIMATION` 
in certain runtypes (Hessian, IRC or DRC) after the line
`ATOMIC WEIGHTS (AMU)`

I added code to extract this information in `gamessparser.py`. I am attaching a logfile for demonstration purposes.
[heavywater.txt](https://github.com/cclib/cclib/files/169760/heavywater.txt)

Ref. Issue #247