### PR TITLE
Test for StopIteration during incomplete SCF

### DIFF
--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -581,7 +581,11 @@ class DALTON(logfileparser.Logfile):
 
             while not converged:
 
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF!')
+                    break
 
                 # each iteration is bracketed by "-------------"
                 if "-------------------" in line:
@@ -592,8 +596,8 @@ class DALTON(logfileparser.Logfile):
                 strcompare = "@{0:>3d}".format(iteration)
                 if strcompare in line:
                     temp = line.split()
-                    val = self.float(temp[3])
-                    values.append([val])
+                    error_norm = self.float(temp[3])
+                    values.append([error_norm])
 
                 if line[0] == "@" and "converged in" in line:
                     converged = True

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -547,7 +547,11 @@ class GAMESS(logfileparser.Logfile):
                     pass
                 else:
                     values.append([float(line.split()[self.scf_valcol])])
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF!')
+                    break
             self.scfvalues.append(values)
 
         # Sometimes, only the first SCF cycle has the banner parsed for above,

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -335,10 +335,14 @@ class GAMESSUK(logfileparser.Logfile):
             scfvalues = []
             line = next(inputfile)
             while line.strip():
+                # e.g. **** recalulation of fock matrix on iteration  4 (examples/chap12/pyridine.out)
                 if line[2:6] != "****":
-            # e.g. **** recalulation of fock matrix on iteration  4 (examples/chap12/pyridine.out)
                     scfvalues.append([float(line[tester-5:tester+6])])
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF! Last tester: {}'.format(line.split()[5]))
+                    break
             self.scfvalues.append(scfvalues)
 
         if line[10:22] == "total energy" and len(line.split()) == 3:

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -479,6 +479,7 @@ class Gaussian(logfileparser.Logfile):
                     line = next(inputfile)
                 # May be interupted by EOF.
                 except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF!')
                     break
 
             self.scfvalues.append(scfvalues)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -297,7 +297,11 @@ class Jaguar(logfileparser.Logfile):
                     values.append([denergy, ddensity])
                 else:
                     values.append([ddensity])
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(maxdiiserr))
+                    break
             self.scfvalues.append(values)
 
         # MO energies and symmetries.

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -272,10 +272,12 @@ class Molpro(logfileparser.Logfile):
             energy = 0.0
             scfvalues = []
             while line.strip() != "":
-                if line.split()[0].isdigit():
+                chomp = line.split()
+                if chomp[0].isdigit():
 
-                    ddiff = float(line.split()[1].replace('D', 'E'))
-                    newenergy = float(line.split()[3])
+                    ddiff = float(chomp[1].replace('D', 'E'))
+                    grad = float(chomp[2].replace('D', 'E'))
+                    newenergy = float(chomp[3])
                     ediff = newenergy - energy
                     energy = newenergy
 
@@ -290,7 +292,11 @@ class Molpro(logfileparser.Logfile):
                             values[n] = ddiff
                     scfvalues.append(values)
 
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF! Last gradient: {}'.format(grad))
+                    break
             self.scfvalues.append(numpy.array(scfvalues))
 
         # SCF result - RHF/UHF and DFT (RKS) energies.

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -374,12 +374,22 @@ class NWChem(logfileparser.Logfile):
                         it, energy, gnorm, gmax, time = line.split()
                         gnorm = float(gnorm.replace('D', 'E'))
                         values.append([gnorm])
-                        line = next(inputfile)
+                        try:
+                            line = next(inputfile)
+                        # Is this the end of the file for some reason?
+                        except StopIteration:
+                            self.logger.warning('File terminated before end of last SCF! Last gradient norm: {}'.format(gnorm))
+                            break
                     if not hasattr(self, 'scfvalues'):
                         self.scfvalues = []
                     self.scfvalues.append(values)
 
-                line = next(inputfile)
+                # this is totally and utterly broken right now
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('blech')
+                    break
 
         # The SCF for DFT does not use the same algorithm as Hartree-Fock, but always
         # seems to use the following format to report SCF convergence:
@@ -418,7 +428,12 @@ class NWChem(logfileparser.Logfile):
                     val_gradient = float(diis.replace('D', 'E'))
                     values.append([val_energy, val_density, val_gradient])
 
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                # Is this the end of the file for some reason?
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(diis))
+                    break
 
             if not hasattr(self, 'scfvalues'):
                 self.scfvalues = []

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -803,7 +803,11 @@ class ORCA(logfileparser.Logfile):
                 maxDP = float(line[5])
                 rmsDP = float(line[6])
                 self.scfvalues[-1].append([deltaE, maxDP, rmsDP])
-            line = next(inputfile).split()
+            try:
+                line = next(inputfile).split()
+            except StopIteration:
+                self.logger.warning('File terminated before end of last SCF! Last Max-DP: {}'.format(maxDP))
+                break
 
     def parse_scf_expanded_format(self, inputfile, line):
         """ Parse SCF convergence when in expanded format. """
@@ -854,7 +858,11 @@ class ORCA(logfileparser.Logfile):
 
         line = "Foo"  # dummy argument to enter loop
         while line.find("******") < 0:
-            line = next(inputfile)
+            try:
+                line = next(inputfile)
+            except StopIteration:
+                self.logger.warning('File terminated before end of last SCF!')
+                break
             info = line.split()
             if len(info) > 1 and info[1] == "ITERATION":
                 dashes = next(inputfile)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -458,7 +458,11 @@ class Psi(logfileparser.Logfile):
                     denergy = float(line.split()[4])
                     ddensity = float(line.split()[5])
                     scfvals.append([denergy, ddensity])
-                line = next(inputfile)
+                try:
+                    line = next(inputfile)
+                except StopIteration:
+                    self.logger.warning('File terminated before end of last SCF! Last density err: {}'.format(ddensity))
+                    break
             self.section = "Post-Iterations"
             self.scfvalues.append(scfvals)
 

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -367,7 +367,13 @@ class QChem(logfileparser.Logfile):
                             error = float(entry[2])
                             values.append([error])
                             iter_counter += 1
-                    line = next(inputfile)
+
+                    try:
+                        line = next(inputfile)
+                    # Is this the end of the file for some reason?
+                    except StopIteration:
+                        self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(error))
+                        break
 
                     # We've converged, but still need the last iteration.
                     if any(message in line for message in scf_success_messages):


### PR DESCRIPTION
See https://github.com/cclib/cclib/issues/206 for the original issue and https://github.com/cclib/cclib-data/pull/21 for the regression tests.

This handles the `StopIteration` exception that occurs if the SCF is terminated early. Currently implemented for at least one version of all parsers except ADF, since I'm not sure of the ideal place to "cut" the `dvb_sp.adfout` file, and there are multiple versions of the file as well.