### PR TITLE
GAMESS-US/Firefly: fix geometry optimization warning and outdated Firefly crash

### DIFF
--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -911,6 +911,11 @@ class GAMESS(logfileparser.Logfile):
                 while not line.strip():
                     line = next(inputfile)
 
+                # Geometry optimizations don't have END OF RHF/DFT
+                # CALCULATION, they head right into the next section.
+                if "--------" in line:
+                    break
+
                 # Eigenvalues for these orbitals (in hartrees).
                 try:
                     self.moenergies[0].extend([utils.convertor(float(x), "hartree", "eV") for x in line.split()])
@@ -1024,7 +1029,7 @@ class GAMESS(logfileparser.Logfile):
                         line = next(inputfile)
                         line = next(inputfile)
                     line = next(inputfile)
-                    if "PROPERTIES" in line:
+                    if "properties" in line.lower():
                         break
                     self.moenergies[1].extend([utils.convertor(float(x), "hartree", "eV") for x in line.split()])
                     line = next(inputfile)


### PR DESCRIPTION
See https://github.com/cclib/cclib/issues/228.

This currently fixes the "MO section found but could not be parsed!" warning (that also appears for the current test suite geometry optimizations). Waiting on the files that would help fix "WARNING! THIS VERSION OF FIREFLY IS PROBABLY OUTDATED!"

- [x] Ready to go