### PR TITLE
Movement of a few attributes in the cjson format

### DIFF
--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -113,7 +113,7 @@ class ccData(object):
        "fooverlaps":       Attribute( numpy.ndarray,    'orbital overlap'),
        "fragnames":        Attribute( list,             'names'),
        "frags":            Attribute( list,             'atom indices'),
-       "gbasis":           Attribute( list,             'TBD'),
+       "gbasis":           Attribute( list,             'basis functions'),
        "geotargets":       Attribute( numpy.ndarray,    'geometric targets'),
        "geovalues":        Attribute( numpy.ndarray,    'geometric values'),
        "grads":            Attribute( numpy.ndarray,    'TBD'),

--- a/src/cclib/writer/cjsonwriter.py
+++ b/src/cclib/writer/cjsonwriter.py
@@ -26,7 +26,6 @@ from cclib.parser import ccData
 
 class CJSON(filewriter.Writer):
     """A writer for chemical JSON (CJSON) files."""
-    
     def __init__(self, ccdata, terse=False, *args, **kwargs):
         """Initialize the chemical JSON writer object.
 
@@ -50,7 +49,6 @@ class CJSON(filewriter.Writer):
         """Generate the CJSON representation of the logfile data"""
 
         cjson_dict = dict()
-        
         # Need to decide on a number format
         cjson_dict['chemical json'] = 0
         if self.jobfilename is not None:
@@ -62,7 +60,6 @@ class CJSON(filewriter.Writer):
             cjson_dict['inchi'] = self.pbmol.write('inchi')
             cjson_dict['inchikey'] = self.pbmol.write('inchikey')
             cjson_dict['formula'] = self.pbmol.formula
-            
         # Incorporate Unit Cell into the chemical JSON
 
         # Helpers functions which use properties provided by cclib
@@ -199,7 +196,8 @@ class CJSON(filewriter.Writer):
                 a) 3d                    
             3) Orbitals
                 a) Names
-                b) Indices
+                b) basis functions
+                c) Indices
             4) Coreelectrons
             5) Mass
             6) Spins

--- a/src/cclib/writer/cjsonwriter.py
+++ b/src/cclib/writer/cjsonwriter.py
@@ -139,6 +139,8 @@ class CJSON(filewriter.Writer):
                iii) Overlaps 
                 iv) Symmetry 
                  v) Coeffs
+                 vi) Basis number
+                 vii) MO number
         """
         cjson_dict['properties'] = dict()
         
@@ -180,8 +182,8 @@ class CJSON(filewriter.Writer):
         if hasattr(self.ccdata, 'atomcharges'):
             cjson_dict['properties']['partial charges'] = dict()
             cjson_dict['properties']['partial charges'] = self.ccdata.atomcharges
-        
-        orbital_attr = ['homos', 'moenergies', 'aooverlaps', 'mosyms', 'mocoeffs']
+
+        orbital_attr = ['homos', 'moenergies', 'aooverlaps', 'mosyms', 'mocoeffs', 'nbasis', 'nmo']
         if self.has_data(orbital_attr):
             cjson_dict['properties']['orbitals'] = dict()
             self.set_JSON_attribute(cjson_dict['properties']['orbitals'], orbital_attr)
@@ -228,22 +230,20 @@ class CJSON(filewriter.Writer):
                 2) Status  
                 3) Geometric Targets 
                 4) Geometric Values 
-                5) Basis number 
-                6) MO number 
-                7) SCF 
+                5) SCF
                     a) Energies 
                     b) Targets 
                     c) Values 
-                8) Scan 
+                6) Scan
                     a) Step Geometry 
                     b) Potential Energy Surface - energies     
                     c) Variable names 
                     d) PES Parameter Values 
         """
-        opti_attr = ['optdone', 'geotargets', 'nbasis', 'nmo', 'scfenergies', 'scancoords', 'scannames']
+        opti_attr = ['optdone', 'geotargets', 'scfenergies', 'scancoords', 'scannames']
         if self.has_data(opti_attr):
             cjson_dict['optimization'] = dict()
-            attr_list = ['optdone', 'optstatus', 'geotargets', 'geovalues', 'nbasis', 'nmo']
+            attr_list = ['optdone', 'optstatus', 'geotargets', 'geovalues']
             self.set_JSON_attribute(cjson_dict['optimization'], attr_list)
 
             # assumption: If SCFenergies exist, then scftargets will also exist


### PR DESCRIPTION
The Basis number and MO number attributes have been moved from the Optimization object to the Properties object

Reason: The nmo and nbasis attributes make more logical sense in the Orbitals object within Properties, and are also required while incorporating the molecular orbitals properties within Avogadro2

The previously unaccounted for gbasis attribute has been incorporated.