### PR TITLE
Replace NaN's with null to form valid json files

### DIFF
--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -324,13 +324,16 @@ class CJSON(filewriter.Writer):
 
 
 class NumpyAwareJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
+    """A encoder for numpy.ndarray's obtained from the cclib attributes.
+       For all other types the json default encoder is called.
+    """
+    def numpy_ndarray_encoder(self, obj):
         if isinstance(obj, np.ndarray):
             if obj.ndim == 1:
                 nan_list = obj.tolist()
                 return [None if np.isnan(x) else x for x in nan_list]
             else:
-                return [self.default(obj[i]) for i in range(obj.shape[0])]
+                return [self.numpy_ndarray_encoder(obj[i]) for i in range(obj.shape[0])]
         return json.JSONEncoder.default(self, obj)
 
 

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -327,7 +327,8 @@ class NumpyAwareJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             if obj.ndim == 1:
-                return obj.tolist()
+                nan_list = obj.tolist()
+                return [None if np.isnan(x) else x for x in nan_list]
             else:
                 return [self.default(obj[i]) for i in range(obj.shape[0])]
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Previously in files containing orbital coefficients, a few values were not discernible and represented as NaN. While dumping the json from such output files the NaN's, being of the float type, would keep the NaN's as is. This resulted in the generated json being invalid, as NaN's are not a valid json type.

This commit converts the NaN's in the numpy ndarray into None, which the default json encoder converts into the json 'null' type resulting in valid json output files.