### PR TITLE
Cjson writer test suite

### DIFF
--- a/src/cclib/io/__init__.py
+++ b/src/cclib/io/__init__.py
@@ -7,7 +7,7 @@
 
 """Contains all writers for standard chemical representations"""
 
-from .cjsonwriter import CJSON
+from .cjsonwriter import CJSON as CJSONWriter
 from .cmlwriter import CML
 from .xyzwriter import XYZ
 from .cjsonreader import CJSON as CJSONReader

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -1,12 +1,9 @@
-# This file is part of cclib (http://cclib.github.io), a library for parsing
-# and interpreting the results of computational chemistry packages.
+# -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016, the cclib development team
+# Copyright (c) 2016, the cclib development team
 #
-# The library is free software, distributed under the terms of
-# the GNU Lesser General Public version 2.1 or later. You should have
-# received a copy of the license along with cclib. You can also access
-# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 """Unit tests for writer cjsonwriter module."""
 

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -1,0 +1,53 @@
+# This file is part of cclib (http://cclib.github.io), a library for parsing
+# and interpreting the results of computational chemistry packages.
+#
+# Copyright (C) 2015-2016, the cclib development team
+#
+# The library is free software, distributed under the terms of
+# the GNU Lesser General Public version 2.1 or later. You should have
+# received a copy of the license along with cclib. You can also access
+# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+
+"""Unit tests for writer cjsonwriter module."""
+
+import os
+import unittest
+import json
+
+import cclib
+
+
+__filedir__ = os.path.dirname(__file__)
+__filepath__ = os.path.realpath(__filedir__)
+__datadir__ = os.path.join(__filepath__, "..", "..")
+
+
+class CJSONTest(unittest.TestCase):
+
+    def setUp(self):
+        self.CJSON = cclib.io.CJSON
+
+    def test_init(self):
+        """Does the class initialize correctly?"""
+        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        data = cclib.io.ccopen(fpath).parse()
+        cjson = cclib.io.cjsonwriter.CJSON(data)
+
+        # The object should keep the ccData instance passed to its constructor.
+        self.assertEqual(cjson.ccdata, data)
+
+    def test_cjson_generation(self):
+        """Does the CJSON format get dumped properly"""
+        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        data = cclib.io.ccopen(fpath).parse()
+
+        cjson = cclib.io.cjsonwriter.CJSON(data).generate_repr()
+
+        # if the cjson is generated properly, the data available in the cjson and ccdata
+        # object should be same
+        json_data = json.loads(cjson)
+        number_of_atoms = json_data['properties']['number of atoms']
+        self.assertEqual(number_of_atoms, data.natom)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -22,7 +22,7 @@ __datadir__ = os.path.join(__filepath__, "..", "..")
 class CJSONTest(unittest.TestCase):
 
     def setUp(self):
-        self.CJSON = cclib.io.CJSON
+        self.CJSON = cclib.io.CJSONWriter
 
     def test_init(self):
         """Does the class initialize correctly?"""

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -34,14 +34,13 @@ class CJSONTest(unittest.TestCase):
         self.assertEqual(cjson.ccdata, data)
 
     def test_cjson_generation(self):
-        """Does the CJSON format get dumped properly"""
+        """Does the CJSON format get generated properly?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
         data = cclib.io.ccopen(fpath).parse()
 
         cjson = cclib.io.cjsonwriter.CJSON(data).generate_repr()
 
-        # if the cjson is generated properly, the data available in the cjson and ccdata
-        # object should be same
+        # The data available in the cjson and ccdata objects should be equal.
         json_data = json.loads(cjson)
         number_of_atoms = json_data['properties']['number of atoms']
         self.assertEqual(number_of_atoms, data.natom)

--- a/test/io/testfilewriter.py
+++ b/test/io/testfilewriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Unit tests for writer xyzwriter module."""
+"""Unit tests for writer filewriter module."""
 
 import os
 import unittest

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -15,6 +15,8 @@ from testccio import *
 from testfilewriter import *
 from testxyzwriter import *
 from testcjsonreader import *
+from testcjsonwriter import *
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Test cases for the cjson writer implemented during GSOC-2016. 2 test cases:

1. test initialization of the cjson writer
2. test whether the cjson is being dumped in the right manner