### PR TITLE
Add testall script, and minor clenaups

### DIFF
--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -23,9 +23,9 @@ from cclib.parser import Gaussian
 
 
 def main(log=True):
-    data1, logfile1 = getdatafile(Gaussian, "CDA", "BH3CO-sp.log")
-    data2, logfile2 = getdatafile(Gaussian, "CDA", "BH3.log")
-    data3, logfile3 = getdatafile(Gaussian, "CDA", "CO.log")
+    data1, logfile1 = getdatafile(Gaussian, "CDA", ["BH3CO-sp.log"])
+    data2, logfile2 = getdatafile(Gaussian, "CDA", ["BH3.log"])
+    data3, logfile3 = getdatafile(Gaussian, "CDA", ["CO.log"])
     fa = CDA(data1)
     if not log:
         fa.logger.setLevel(logging.ERROR)

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -27,7 +27,7 @@ class MBOTest(unittest.TestCase):
     def test_mbo_sp(self):
         """Testing Mayer bond orders for restricted single point."""
 
-        data, logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_sp.out")
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["dvb_sp.out"])
         mbo = MBO(data)
         mbo.logger.setLevel(logging.ERROR)
         mbo.calculate()
@@ -39,7 +39,7 @@ class MBOTest(unittest.TestCase):
     def test_mbo_un_sp(self):
         """Testing Mayer bond orders for unrestricted single point."""
 
-        data, logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_un_sp.log")
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["dvb_un_sp.log"])
         mbo = MBO(data)
         mbo.logger.setLevel(logging.ERROR)
         mbo.calculate()

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -29,7 +29,7 @@ class NuclearTest(unittest.TestCase):
     def test_nre(self):
         """Testing nuclear repulsion energy for one logfile where it is printed."""
 
-        data, logfile = getdatafile(QChem, "basicQChem4.2", "water_mp4sdq.out")
+        data, logfile = getdatafile(QChem, "basicQChem4.2", ["water_mp4sdq.out"])
         nuclear = Nuclear(data)
         nuclear.logger.setLevel(logging.ERROR)
 

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -26,7 +26,7 @@ class GaussianMPATest(unittest.TestCase):
     """Mulliken Population Analysis test"""
 
     def setUp(self):
-        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", "dvb_un_sp.out")
+        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", ["dvb_un_sp.out"])
         self.analysis = MPA(self.data)
         self.analysis.logger.setLevel(0)
         self.analysis.calculate()
@@ -48,7 +48,7 @@ class GaussianLPATest(unittest.TestCase):
     """Lowdin Population Analysis test"""
 
     def setUp(self):
-        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", "dvb_un_sp.out")
+        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", ["dvb_un_sp.out"])
         self.analysis = LPA(self.data)
         self.analysis.logger.setLevel(0)
         self.analysis.calculate()
@@ -70,7 +70,7 @@ class GaussianCSPATest(unittest.TestCase):
     """C-squared Population Analysis test"""
 
     def setUp(self):
-        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", "dvb_un_sp.out")
+        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian03", ["dvb_un_sp.out"])
         self.analysis = CSPA(self.data)
         self.analysis.logger.setLevel(0)
         self.analysis.calculate()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -10,9 +10,9 @@
 import sys
 import unittest
 
+sys.path.append("bridge")
+from testopenbabel import *
+
 
 if __name__ == "__main__":
-
-    sys.path.append("bridge")
-    from testopenbabel import *
     unittest.main()

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -10,12 +10,12 @@
 import sys
 import unittest
 
+sys.path.append("method")
+from testcda import *
+from testmbo import *
+from testnuclear import *
+from testpopulation import *
+
 
 if __name__ == "__main__":
-
-    sys.path.append("method")
-    from testcda import *
-    from testmbo import *
-    from testnuclear import *
-    from testpopulation import *
     unittest.main()

--- a/test/testall.py
+++ b/test/testall.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Run all unit tests for cclib."""
+
+import unittest
+
+import test_data
+
+from test_bridge import *
+from test_io import *
+from test_method import *
+from test_parser import *
+
+
+if __name__ == "__main__":
+	print "Running unit tests for data..."
+	test_data.test_all(silent=True, summary=False, visual_tests=False)
+	print "Running all other unit tests..."
+	unittest.main()


### PR DESCRIPTION
Besides adding the testall script, which runs test_data in silent mode, this includes some minor cleanups:
1. Use argv only at bottom
2. Make arguments in getdatafile simpler