### PR TITLE
fixes for Python 3.6 and latest NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.7
   - 3.2
-  - 3.5
+  - 3.6
 before_install:
   - sudo apt-get update
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy; fi

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -1455,9 +1455,9 @@ class Gaussian(logfileparser.Logfile):
                     for j in range(0, len(part), 10):
                         temp.append(float(part[j:j+10]))
                     if beta:
-                        self.mocoeffs[1][base:base + len(part) / 10, i] = temp
+                        self.mocoeffs[1][base:base + len(part) // 10, i] = temp
                     else:
-                        mocoeffs[0][base:base + len(part) / 10, i] = temp
+                        mocoeffs[0][base:base + len(part) // 10, i] = temp
 
                 if base == 0 and not beta:  # Do the last update of atombasis
                     self.atombasis.append(atombasis)
@@ -1527,7 +1527,7 @@ class Gaussian(logfileparser.Logfile):
                     for j in range(0, len(part), 10):
                         temp.append(float(part[j:j+10]))
 
-                    nocoeffs[base:base + len(part) / 10, i] = temp
+                    nocoeffs[base:base + len(part) // 10, i] = temp
 
                 # Do the last update of atombasis.
                 if base == 0:


### PR DESCRIPTION
* The DeprecationWarning about NumPy indexing with floats is now an error
* I think we should test against Python 3.6 even if we cannot write 3.6-specific code.