### PR TITLE
QChem: new section for polarizabilities

### DIFF
--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -799,33 +799,19 @@ class QChem(logfileparser.Logfile):
             if 'Polarizability (a.u.)' in line:
                 if not hasattr(self, 'polarizabilities'):
                     self.polarizabilities = []
-                polarizability = []
                 while 'Full Tensor' not in line:
                     line = next(inputfile)
                 self.skip_line(inputfile, 'blank')
-                for _ in range(3):
-                    line = next(inputfile)
-                    polarizability.append(line.split())
+                polarizability = [next(inputfile).split() for _ in range(3)]
                 self.polarizabilities.append(numpy.array(polarizability))
 
-            # Static polarizability from finite difference.
-            if line.strip() == 'Static polarizability tensor [a.u.]':
+            # Static polarizability from finite difference or
+            # responseman.
+            if line.strip() in ('Static polarizability tensor [a.u.]',
+                                'Polarizability tensor      [a.u.]'):
                 if not hasattr(self, 'polarizabilities'):
                     self.polarizabilities = []
-                polarizability = []
-                for _ in range(3):
-                    line = next(inputfile)
-                    polarizability.append(line.split())
-                self.polarizabilities.append(numpy.array(polarizability))
-
-            # Polarizability from responseman.
-            if line.strip() == 'Polarizability tensor      [a.u.]':
-                if not hasattr(self, 'polarizabilities'):
-                    self.polarizabilities = []
-                polarizability = []
-                for _ in range(3):
-                    line = next(inputfile)
-                    polarizability.append(line.split())
+                polarizability = [next(inputfile).split() for _ in range(3)]
                 self.polarizabilities.append(numpy.array(polarizability))
 
             # Molecular orbital energies and symmetries.

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -100,8 +100,12 @@ class QChem(logfileparser.Logfile):
             'Final Hessian.',
         )
 
-        self.wfn_method = ['HF', 'MP2', 'RI-MP2', 'LOCAL_MP2', 'MP4', 'CCD', 'CCSD', \
-                                      'CCSD(T)', 'QCISD', 'QCISD(T)']
+        self.wfn_method = [
+            'HF',
+            'MP2', 'RI-MP2', 'LOCAL_MP2', 'MP4',
+            'CCD', 'CCSD', 'CCSD(T)',
+            'QCISD', 'QCISD(T)'
+        ]
 
     def after_parsing(self):
 
@@ -799,6 +803,26 @@ class QChem(logfileparser.Logfile):
                 while 'Full Tensor' not in line:
                     line = next(inputfile)
                 self.skip_line(inputfile, 'blank')
+                for _ in range(3):
+                    line = next(inputfile)
+                    polarizability.append(line.split())
+                self.polarizabilities.append(numpy.array(polarizability))
+
+            # Static polarizability from finite difference.
+            if line.strip() == 'Static polarizability tensor [a.u.]':
+                if not hasattr(self, 'polarizabilities'):
+                    self.polarizabilities = []
+                polarizability = []
+                for _ in range(3):
+                    line = next(inputfile)
+                    polarizability.append(line.split())
+                self.polarizabilities.append(numpy.array(polarizability))
+
+            # Polarizability from responseman.
+            if line.strip() == 'Polarizability tensor      [a.u.]':
+                if not hasattr(self, 'polarizabilities'):
+                    self.polarizabilities = []
+                polarizability = []
                 for _ in range(3):
                     line = next(inputfile)
                     polarizability.append(line.split())


### PR DESCRIPTION
I added some new polarizability code to Q-Chem so naturally I would like to parse it :)

It also fixes the case (that only now appears) where calculations on a single atom print thermodynamic information, and that section would prevent parsing of anything that came afterward.

This needs to be merged *before* https://github.com/cclib/cclib-data/pull/53.