### PR TITLE
Fix syntax error in MOPAC parser

### DIFF
--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 import re
+import math
 
 import numpy
 
@@ -191,7 +192,7 @@ class MOPAC(logfileparser.Logfile):
 
             # get the vib symmetry
             if len(line.split()) >= 3:
-                sym = line.split[2]
+                sym = (line.split())[2]
                 if not hasattr(self, 'vibsyms'):
                     self.vibsyms = []
                 self.vibsyms.append(sym)


### PR DESCRIPTION
While running a script to parse all ```.out``` files in cclib/data repository, noticed that ```MOPAC/h2o-force.out``` fails.
Running the following code will show the error :
```python
from cclib.parser import *
file_path = "./data/MOPAC/h2o-force.out"
p = MOPAC(file_path)
parsed_data = p.parse()
```
Fixes #346 