### PR TITLE
Separate possibly unspaced polarizability tensor elements

### DIFF
--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -10,8 +10,6 @@
 
 from __future__ import print_function
 
-import re
-
 import numpy
 
 from . import logfileparser
@@ -1076,7 +1074,7 @@ class DALTON(logfileparser.Logfile):
                 line = next(inputfile)
                 # Separate possibly unspaced huge negative polarizability tensor
                 # element and the left adjacent column from each other.
-                line = re.sub(r'(\d)-', r'\1 -', line)
+                line = line.replace('-', ' -')
                 polarizability.append(line.split()[1:])
             self.polarizabilities.append(numpy.array(polarizability))
 
@@ -1088,7 +1086,6 @@ class DALTON(logfileparser.Logfile):
             self.skip_lines(inputfile, ['d', 'directions', 'b'])
             for _ in range(3):
                 line = next(inputfile)
-                line = re.sub(r'(\d)-', r'\1 -', line)
                 polarizability.append(line.split()[1:])
             self.polarizabilities.append(numpy.array(polarizability))
 

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -10,8 +10,9 @@
 
 from __future__ import print_function
 
-import numpy
+import re
 
+import numpy
 
 from . import logfileparser
 from . import utils
@@ -1073,6 +1074,9 @@ class DALTON(logfileparser.Logfile):
             self.skip_lines(inputfile, ['d', 'b', 'directions', 'b'])
             for _ in range(3):
                 line = next(inputfile)
+                # Separate possibly unspaced huge negative polarizability tensor
+                # element and the left adjacent column from each other.
+                line = re.sub(r'(\d)-', r'\1 -', line)
                 polarizability.append(line.split()[1:])
             self.polarizabilities.append(numpy.array(polarizability))
 
@@ -1084,6 +1088,7 @@ class DALTON(logfileparser.Logfile):
             self.skip_lines(inputfile, ['d', 'directions', 'b'])
             for _ in range(3):
                 line = next(inputfile)
+                line = re.sub(r'(\d)-', r'\1 -', line)
                 polarizability.append(line.split()[1:])
             self.polarizabilities.append(numpy.array(polarizability))
 


### PR DESCRIPTION
In some rare cases DALTON yields huge negative polarizability values. ABACUS module prints to the output file following:

```
                           Static polarizabilities (au)
. . .
            Ey       0.000000-7211.390426    0.000000
```

Since here _xy_ and _yy_ tensor elements are stack together, with no spaces, calling parse() method causes `ValueError: setting an array element with a sequence` as expected.

With these changes in place, not only spacing but also minus sign is used to spit elements. Regexp helps us to distinguish between a real number and the exponent when polarizabilities are [written](https://github.com/cclib/cclib-data/blob/master/DALTON/DALTON-2015/trithiolane_polar_abalnr.out#L1183) in E-notation.