### PR TITLE
print full numpy arrays in ccget

### DIFF
--- a/src/scripts/ccget
+++ b/src/scripts/ccget
@@ -16,6 +16,7 @@ import glob
 import logging
 import os.path
 import sys
+import numpy
 
 from cclib.parser import ccData
 from cclib.io import ccread, URL_PATTERN
@@ -38,12 +39,13 @@ To parse multiple files as one input stream, use --multi (or -m):
     ccget --multi <attr> [<attr>]  <cclogfile> <cclogfile> [<cclogfile>]
 Additional options:
     -v or --verbose: more verbose parsing output (only errors by default)
-    -u or --future: use experimental features (currently optdone_as_list)\
+    -u or --future: use experimental features (currently optdone_as_list)
+    -f or --full: toggle full print behaviour for attributes\
 """
 
 # These are the options ccget accepts and their one letter versions.
-OPTS_LONG = ["help", "list", "json", "multi", "verbose", "future"]
-OPTS_SHORT = "hljmvu"
+OPTS_LONG = ["help", "list", "json", "multi", "verbose", "future", "full"]
+OPTS_SHORT = "hljmvuf"
 
 
 def ccget():
@@ -62,6 +64,7 @@ def ccget():
     cjsonfile = False
     multifile = False
     verbose = False
+    full = False
     for opt, arg in optlist:
         if opt in ("-h", "--help"):
             print(MSG_USAGE_LONG)
@@ -76,6 +79,12 @@ def ccget():
             verbose = True
         if opt in ("-u", "--future"):
             future = True
+        if opt in ("-f", "--full"):
+            full = True
+
+    # Toggle full print behaviour for numpy arrays.
+    if full:
+        numpy.set_printoptions(threshold=numpy.nan)
 
     # We need at least one attribute and the filename, so two arguments, or
     # just one filename if we want to list attributes that can be extracted.
@@ -179,7 +188,14 @@ def ccget():
                         continue
                 else:
                     if hasattr(data, attr):
-                        print("%s:\n%s" % (attr, getattr(data, attr)))
+                        print(attr)
+                        attr_val = getattr(data, attr)
+                        # List of attributes to be printed with new lines
+                        if attr in data._listsofarrays and full:
+                            for val in attr_val:
+                                print(val)
+                        else:
+                            print(attr_val)
                         continue
 
                 print("Could not parse %s from this file." % attr)


### PR DESCRIPTION
`ccget` should print complete numpy arrays.

Current behaviour:
```
$ ccget atomcoords test.log 
Attempting to read test.log
atomcoords:
[[[ -4.33324600e+00   9.10045000e-01  -7.53550000e-02]
  [ -2.93414200e+00   1.07099600e+00  -8.93920000e-02]
  [ -2.47200400e+00   2.21427000e+00  -1.65896000e-01]
  ..., 
  [ -3.12395000e-01   1.81784000e-01   6.86140000e-02]
  [ -5.73509000e-01   2.43046100e+00   1.56000000e-03]
  [  5.31937700e+00   1.26332300e+00  -4.27340000e-02]]
```

Updated behaviour:
```
$ ccget atomcoords test.log 
Attempting to read test.log
atomcoords:
[[[ -4.33324600e+00   9.10045000e-01  -7.53550000e-02]
  [ -2.93414200e+00   1.07099600e+00  -8.93920000e-02]
  [ -2.47200400e+00   2.21427000e+00  -1.65896000e-01]
  [ -2.17206900e+00  -6.67560000e-02  -1.61680000e-02]
  [ -2.75023300e+00  -1.27528700e+00   3.83240000e-02]
  [  8.09408000e-01  -2.04095900e+00  -1.18060000e-02]
  [  7.25601000e-01   2.61055000e-01   6.55380000e-02]
  [  1.28700700e+00   1.51942200e+00   9.08540000e-02]
  [  4.16561000e-01   2.56126800e+00   2.36973000e-01]
  [  2.59166300e+00   1.75378800e+00   4.22100000e-02]
  [  3.29796200e+00   5.92065000e-01  -8.66000000e-03]
  [  5.99910600e+00  -1.21776400e+00  -1.12221000e-01]
  [  8.23951000e-01   3.46285500e+00   1.38120000e-02]
  [ -3.12395000e-01   1.81784000e-01   6.86140000e-02]
  [ -5.73509000e-01   2.43046100e+00   1.56000000e-03]
  [  5.31937700e+00   1.26332300e+00  -4.27340000e-02]]
```