### PR TITLE
Tests for filewriters

### DIFF
--- a/src/cclib/io/__init__.py
+++ b/src/cclib/io/__init__.py
@@ -10,7 +10,7 @@
 from .cjsonwriter import CJSON as CJSONWriter
 from .cmlwriter import CML
 from .xyzwriter import XYZ
-from .moldenwriter import MOLDEN
+from .moldenwriter import MoldenWriter
 from .cjsonreader import CJSON as CJSONReader
 
 # This allows users to type:

--- a/src/cclib/io/ccio.py
+++ b/src/cclib/io/ccio.py
@@ -106,7 +106,7 @@ outputclasses = {
     'json': cjsonwriter.CJSON,
     'cml': cmlwriter.CML,
     'xyz': xyzwriter.XYZ,
-    'molden': moldenwriter.MOLDEN
+    'molden': moldenwriter.MoldenWriter
 }
 
 

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -26,9 +26,6 @@ class MissingAttributeError(Exception):
 
 class Writer(object):
     """Abstract class for writer objects.
-
-    Subclasses defined by cclib:
-        CJSON, CML, XYZ, MOLDEN
     """
 
     def __init__(self, ccdata, jobfilename=None, terse=False,
@@ -48,7 +45,10 @@ class Writer(object):
         self.terse = terse
 
         self.pt = PeriodicTable()
-        self.elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
+
+        # Check if required attributes are present.
+        if hasattr(self, 'required_attrs'):
+            self._check_required_attributes()
 
         # Open Babel isn't necessarily present.
         if has_openbabel:
@@ -92,6 +92,12 @@ class Writer(object):
                                         obbond.GetEndAtom().GetIndex(),
                                         obbond.GetBondOrder()))
         return bond_connectivities
+
+    def _check_required_attributes(self):
+        """Check if required attributes are present in ccdata."""
+        missing = ', '.join([x for x in self.required_attrs if not hasattr(self.ccdata, x)])
+        if len(missing) > 0:
+            raise MissingAttributeError('Could not parse required attributes to write file: ' + missing)
 
 
 if __name__ == "__main__":

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016, the cclib development team
+# Copyright (c) 2017, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -18,6 +18,10 @@ except ImportError:
 from math import sqrt
 
 from cclib.parser.utils import PeriodicTable
+
+
+class MissingAttributeError(Exception):
+    pass
 
 
 class Writer(object):

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -24,7 +24,7 @@ class Writer(object):
     """Abstract class for writer objects.
 
     Subclasses defined by cclib:
-        CJSON, CML, XYZ
+        CJSON, CML, XYZ, MOLDEN
     """
 
     def __init__(self, ccdata, jobfilename=None, terse=False,

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -10,19 +10,11 @@
 import os.path
 
 from . import filewriter
-from .filewriter import MissingAttributeError
 from cclib.parser import utils
 
 
 class MOLDEN(filewriter.Writer):
     """A writer for MOLDEN files."""
-
-    def _check_required_attributes(self, required):
-        """Check if required attributes are present in ccdata"""
-        missing = [ x for x in required if not hasattr(self.ccdata, x) ]
-        if len(missing) > 0:
-            missing = ' '.join(missing)
-            raise MissingAttributeError('Could not parse required outputs to write molden file: ' + missing)
 
     def _title(self, path):
         """Return filename without extension to be used as title."""
@@ -32,7 +24,8 @@ class MOLDEN(filewriter.Writer):
     def _coords_from_ccdata(self, index):
         """Create [Atoms] section using geometry at the given index."""
         self._check_required_attributes(['atomcoords', 'atomnos', 'natom'])
-
+        
+        elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos
         nos = range(self.ccdata.natom)
@@ -40,7 +33,7 @@ class MOLDEN(filewriter.Writer):
         # element_name number atomic_number x y z
         atom_template = '{:2s} {:5d} {:2d} {:12.6f} {:12.6f} {:12.6f}'
         lines = []
-        for element, no, atomno, (x, y, z) in zip(self.elements, nos, atomnos,
+        for element, no, atomno, (x, y, z) in zip(elements, nos, atomnos,
                                                   atomcoords):
             lines.append(atom_template.format(element, no + 1, atomno,
                                               x, y, z))

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -10,6 +10,7 @@
 import os.path
 
 from . import filewriter
+from .filewriter import MissingAttributeError
 from cclib.parser import utils
 
 
@@ -23,6 +24,11 @@ class MOLDEN(filewriter.Writer):
 
     def _coords_from_ccdata(self, index):
         """Create [Atoms] section using geometry at the given index."""
+
+        if not (hasattr(self.ccdata, 'atomcoords') and
+                hasattr(self.ccdata, 'atomnos') and
+                hasattr(self.ccdata, 'natom')):
+                raise MissingAttributeError('Could not parse necessary outputs to write molden file.')
 
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos
@@ -127,8 +133,9 @@ class MOLDEN(filewriter.Writer):
         molden_lines = ['[Molden Format]']
 
         # Title of file.
-        molden_lines.append('[Title]')
-        molden_lines.append(self._title(self.jobfilename))
+        if self.jobfilename is not None:
+            molden_lines.append('[Title]')
+            molden_lines.append(self._title(self.jobfilename))
 
         # Coordinates for the Electron Density/Molecular orbitals.
         # [Atoms] (Angs|AU)

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""A writer for MOLDEN format files."""
+"""A writer for Molden format files."""
 
 import os.path
 
@@ -13,8 +13,8 @@ from . import filewriter
 from cclib.parser import utils
 
 
-class MOLDEN(filewriter.Writer):
-    """A writer for MOLDEN files."""
+class MoldenWriter(filewriter.Writer):
+    """A writer for Molden files."""
 
     required_attrs = ['atomcoords', 'atomnos', 'natom']
 
@@ -124,7 +124,7 @@ class MOLDEN(filewriter.Writer):
         return lines
 
     def generate_repr(self):
-        """Generate the MOLDEN representation of the logfile data."""
+        """Generate the Molden representation of the logfile data."""
 
         molden_lines = ['[Molden Format]']
 

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -17,6 +17,13 @@ from cclib.parser import utils
 class MOLDEN(filewriter.Writer):
     """A writer for MOLDEN files."""
 
+    def _check_required_attributes(self, required):
+        """Check if required attributes are present in ccdata"""
+        missing = [ x for x in required if not hasattr(self.ccdata, x) ]
+        if len(missing) > 0:
+            missing = ' '.join(missing)
+            raise MissingAttributeError('Could not parse required outputs to write molden file: ' + missing)
+
     def _title(self, path):
         """Return filename without extension to be used as title."""
         title = os.path.basename(os.path.splitext(path)[0])
@@ -24,11 +31,7 @@ class MOLDEN(filewriter.Writer):
 
     def _coords_from_ccdata(self, index):
         """Create [Atoms] section using geometry at the given index."""
-
-        if not (hasattr(self.ccdata, 'atomcoords') and
-                hasattr(self.ccdata, 'atomnos') and
-                hasattr(self.ccdata, 'natom')):
-                raise MissingAttributeError('Could not parse necessary outputs to write molden file.')
+        self._check_required_attributes(['atomcoords', 'atomnos', 'natom'])
 
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -16,6 +16,8 @@ from cclib.parser import utils
 class MOLDEN(filewriter.Writer):
     """A writer for MOLDEN files."""
 
+    required_attrs = ['atomcoords', 'atomnos', 'natom']
+
     def _title(self, path):
         """Return filename without extension to be used as title."""
         title = os.path.basename(os.path.splitext(path)[0])
@@ -23,8 +25,6 @@ class MOLDEN(filewriter.Writer):
 
     def _coords_from_ccdata(self, index):
         """Create [Atoms] section using geometry at the given index."""
-        self._check_required_attributes(['atomcoords', 'atomnos', 'natom'])
-        
         elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos
@@ -104,8 +104,8 @@ class MOLDEN(filewriter.Writer):
             has_syms = True
             syms = self.ccdata.mosyms
 
+        spin = 'Alpha'
         for i in range(mult):
-            spin = 'Alpha'
             for j in range(len(moenergies[i])):
                 if has_syms:
                     lines.append(' Sym= %s' % syms[i][j])

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016, the cclib development team
+# Copyright (c) 2017, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -22,6 +22,7 @@ class MOLDENTest(unittest.TestCase):
 
     def setUp(self):
         self.molden = cclib.io.MOLDEN
+        self.MissingAttributeError = cclib.io.filewriter.MissingAttributeError
 
     def test_init(self):
         """Does the class initialize correctly?"""
@@ -32,6 +33,17 @@ class MOLDENTest(unittest.TestCase):
 
         # The object should keep the ccData instance passed to its constructor.
         self.assertEqual(molden.ccdata, data)
+
+    def test_missing_attributes(self):
+        """Check if MissingAttributeError is raised as expected."""
+        fpath = os.path.join(__datadir__,
+                             "data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        data = cclib.io.ccopen(fpath).parse()
+        del data.atomcoords
+
+        # Molden files cannot be wriiten if atomcoords are missing.
+        with self.assertRaises(self.MissingAttributeError):
+            cclib.io.moldenwriter.MOLDEN(data).generate_repr()
 
 
 if __name__ == "__main__":

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Unit tests for writer moldenwriter module."""
+
+import os
+import unittest
+
+import cclib
+
+
+__filedir__ = os.path.dirname(__file__)
+__filepath__ = os.path.realpath(__filedir__)
+__datadir__ = os.path.join(__filepath__, "..", "..")
+
+
+class MOLDENTest(unittest.TestCase):
+
+    def setUp(self):
+        self.molden = cclib.io.MOLDEN
+
+    def test_init(self):
+        """Does the class initialize correctly?"""
+        fpath = os.path.join(__datadir__,
+                             "data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        data = cclib.io.ccopen(fpath).parse()
+        molden = cclib.io.moldenwriter.MOLDEN(data)
+
+        # The object should keep the ccData instance passed to its constructor.
+        self.assertEqual(molden.ccdata, data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -11,7 +11,7 @@ import os
 import unittest
 
 import cclib
-
+from cclib.io.filewriter import MissingAttributeError
 
 __filedir__ = os.path.dirname(__file__)
 __filepath__ = os.path.realpath(__filedir__)
@@ -19,20 +19,6 @@ __datadir__ = os.path.join(__filepath__, "..", "..")
 
 
 class MOLDENTest(unittest.TestCase):
-
-    def setUp(self):
-        self.molden = cclib.io.MOLDEN
-        self.MissingAttributeError = cclib.io.filewriter.MissingAttributeError
-
-    def test_init(self):
-        """Does the class initialize correctly?"""
-        fpath = os.path.join(__datadir__,
-                             "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
-        molden = cclib.io.moldenwriter.MOLDEN(data)
-
-        # The object should keep the ccData instance passed to its constructor.
-        self.assertEqual(molden.ccdata, data)
 
     def test_missing_attributes(self):
         """Check if MissingAttributeError is raised as expected."""
@@ -42,7 +28,7 @@ class MOLDENTest(unittest.TestCase):
         del data.atomcoords
 
         # Molden files cannot be wriiten if atomcoords are missing.
-        with self.assertRaises(self.MissingAttributeError):
+        with self.assertRaises(MissingAttributeError):
             cclib.io.moldenwriter.MOLDEN(data).generate_repr()
 
 

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -18,7 +18,7 @@ __filepath__ = os.path.realpath(__filedir__)
 __datadir__ = os.path.join(__filepath__, "..", "..")
 
 
-class MOLDENTest(unittest.TestCase):
+class MoldenWriterTest(unittest.TestCase):
 
     def test_missing_attributes(self):
         """Check if MissingAttributeError is raised as expected."""
@@ -31,7 +31,7 @@ class MOLDENTest(unittest.TestCase):
 
         # Molden files cannot be wriiten if atomcoords are missing.
         with self.assertRaises(MissingAttributeError):
-            cclib.io.moldenwriter.MOLDEN(data)
+            cclib.io.moldenwriter.MoldenWriter(data)
 
 
 if __name__ == "__main__":

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -26,10 +26,12 @@ class MOLDENTest(unittest.TestCase):
                              "data/ADF/basicADF2007.01/dvb_gopt.adfout")
         data = cclib.io.ccopen(fpath).parse()
         del data.atomcoords
+        del data.atomnos
+        del data.natom
 
         # Molden files cannot be wriiten if atomcoords are missing.
         with self.assertRaises(MissingAttributeError):
-            cclib.io.moldenwriter.MOLDEN(data).generate_repr()
+            cclib.io.moldenwriter.MOLDEN(data)
 
 
 if __name__ == "__main__":

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -16,7 +16,7 @@ from testfilewriter import *
 from testxyzwriter import *
 from testcjsonreader import *
 from testcjsonwriter import *
-
+from testmoldenwriter import *
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes made:
1. Added a custom exception `MissingAttributeError` in `io.filewriter`. This ensures a sane error is raised in the absence of some critical attribute. 

Try running `ccwrite xyz data/MOPAC/h2o.out` with the current build. It currently fails with 
`AttributeError: 'ccData_optdone_bool' object has no attribute 'atomnos'`,
and with this update the following exception is raised
`cclib.io.filewriter.MissingAttributeError: Could not parse necessary attributes to write file.`

2. Added basic tests for `moldenwriter`. (More would be added).
3. Made changes in `moldenwriter.py` class to raise exceptions if some critical attribute is missing.