### PR TITLE
Moving elements list calculation from init to individual filewriters.

### DIFF
--- a/src/cclib/io/cmlwriter.py
+++ b/src/cclib/io/cmlwriter.py
@@ -43,16 +43,17 @@ class CML(filewriter.Writer):
         if self.jobfilename is not None:
             d['id'] = self.jobfilename
         _set_attrs(molecule, d)
-
+        
         # Form the listing of all the atoms present.
         atomArray = ET.SubElement(molecule, 'atomArray')
-        if hasattr(self.ccdata, 'atomcoords'):
+        if hasattr(self.ccdata, 'atomcoords') and hasattr(self.ccdata, 'atomnos'):
+            elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
             for atomid in range(self.ccdata.natom):
                 atom = ET.SubElement(atomArray, 'atom')
                 x, y, z = self.ccdata.atomcoords[-1][atomid].tolist()
                 d = {
                     'id': 'a{}'.format(atomid + 1),
-                    'elementType': self.elements[atomid],
+                    'elementType': elements[atomid],
                     'x3': '{:.10f}'.format(x),
                     'y3': '{:.10f}'.format(y),
                     'z3': '{:.10f}'.format(z),

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -44,7 +44,6 @@ class Writer(object):
         self.terse = terse
 
         self.pt = PeriodicTable()
-        self.elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
 
         # Open Babel isn't necessarily present.
         if has_openbabel:

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -23,7 +23,7 @@ class MOLDEN(filewriter.Writer):
 
     def _coords_from_ccdata(self, index):
         """Create [Atoms] section using geometry at the given index."""
-
+        elements = [self.pt.element[Z] for Z in self.ccdata.atomnos]
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos
         nos = range(self.ccdata.natom)
@@ -31,7 +31,7 @@ class MOLDEN(filewriter.Writer):
         # element_name number atomic_number x y z
         atom_template = '{:2s} {:5d} {:2d} {:12.6f} {:12.6f} {:12.6f}'
         lines = []
-        for element, no, atomno, (x, y, z) in zip(self.elements, nos, atomnos,
+        for element, no, atomno, (x, y, z) in zip(elements, nos, atomnos,
                                                   atomcoords):
             lines.append(atom_template.format(element, no + 1, atomno,
                                               x, y, z))


### PR DESCRIPTION
Calculations based on `ccData` should be done in respective filewriters. 

This would help with testing filewriters with empty `ccData` objects (Ref. https://github.com/cclib/cclib/pull/388#pullrequestreview-44604158), 
and better handling required attributes at filewriter level (Ref. https://github.com/cclib/cclib/pull/388#pullrequestreview-44602730).