### PR TITLE
Add point group detection

### DIFF
--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -105,9 +105,6 @@ class ADF(logfileparser.Logfile):
         SCFCNV, SCFCNV2 = list(range(2))  # used to index self.scftargets[]
         maxelem, norm = list(range(2))  # used to index scf.values
 
-    def after_parsing(self):
-        super(ADF, self).after_parsing()
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -146,10 +146,13 @@ class ADF(logfileparser.Logfile):
             info = line.split()
             if info[1] == "NOSYM":
                 self.nosymflag = True
-                point_group = "c1"
+                point_group_full = "c1"
             else:
-                point_group = info[1].replace('(', '').replace(')', '').lower()
-            self.metadata['symmetry_full'] = point_group
+                point_group_full = info[1].replace('(', '').replace(')', '').lower()
+            # TODO
+            point_group_abelian = point_group_full
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # Use this to read the subspecies of irreducible representations.
         # It will be a list, with each element representing one irrep.

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -106,7 +106,7 @@ class ADF(logfileparser.Logfile):
         maxelem, norm = list(range(2))  # used to index scf.values
 
     def after_parsing(self):
-        super().after_parsing()
+        super(ADF, self).after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -140,6 +140,8 @@ class ADF(logfileparser.Logfile):
             info = line.split()
             if info[1] == "NOSYM":
                 self.nosymflag = True
+            else:
+                point_group = info[1].replace('(', '').replace(')', '').lower()
 
         # Use this to read the subspecies of irreducible representations.
         # It will be a list, with each element representing one irrep.

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -105,6 +105,9 @@ class ADF(logfileparser.Logfile):
         SCFCNV, SCFCNV2 = list(range(2))  # used to index self.scftargets[]
         maxelem, norm = list(range(2))  # used to index scf.values
 
+    def after_parsing(self):
+        super().after_parsing()
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
@@ -136,12 +139,17 @@ class ADF(logfileparser.Logfile):
             while line[:5] != "title":
                 line = inputfile.next()
 
+        if "Amsterdam Density Functional" in line:
+            self.metadata['package_version'] = line.split()[5]
+
         if line[1:10] == "Symmetry:":
             info = line.split()
             if info[1] == "NOSYM":
                 self.nosymflag = True
+                point_group = "c1"
             else:
                 point_group = info[1].replace('(', '').replace(')', '').lower()
+            self.metadata['symmetry_full'] = point_group
 
         # Use this to read the subspecies of irreducible representations.
         # It will be a list, with each element representing one irrep.

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -56,7 +56,7 @@ class DALTON(logfileparser.Logfile):
         self.basislibrary = True
 
     def after_parsing(self):
-        super().after_parsing()
+        super(DALTON, self).after_parsing()
 
     def parse_geometry(self, lines):
         """Parse DALTON geometry lines into an atomcoords array."""

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -55,9 +55,6 @@ class DALTON(logfileparser.Logfile):
         # when the first line is BASIS, false for INTGRL/ATOMBASIS.
         self.basislibrary = True
 
-    def after_parsing(self):
-        super(DALTON, self).after_parsing()
-
     def parse_geometry(self, lines):
         """Parse DALTON geometry lines into an atomcoords array."""
 

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -130,7 +130,7 @@ class DALTON(logfileparser.Logfile):
             self.skip_lines(inputfile, ['d', 'b'])
             line = next(inputfile)
             if 'Point group:' in line:
-                point_group_full = line.split()[3].lower()
+                point_group_full = line.split()[-1].lower()
                 point_group_abelian = point_group_full
             else:
                 assert 'Full point group is:' in line

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -48,7 +48,7 @@ class DALTON(logfileparser.Logfile):
         # would like to use as triggers.
         self.section = None
 
-        # If there is no symmetry, assume this.
+        # If there is no symmetry (point group is C1), assume this.
         self.symlabels = ['Ag']
 
         # Is the basis set from a single library file? This is true
@@ -122,6 +122,27 @@ class DALTON(logfileparser.Logfile):
 
             self.geotargets.append(target)
             self.geotargets_names.append(name)
+
+        # Main location of symmetry information (point group, ordering
+        # of irreducible representations).
+        if line.strip() == "SYMGRP: Point group information":
+
+            self.skip_lines(inputfile, ['d', 'b'])
+            line = next(inputfile)
+            if 'Point group:' in line:
+                point_group_full = line.split()[3].lower()
+                point_group_abelian = point_group_full
+            else:
+                assert 'Full point group is:' in line
+                point_group_full = line.split()[-1].replace('(', '').replace(')', '').lower()
+                line = next(inputfile)
+                assert 'Represented as:' in line
+                point_group_abelian = line.split()[-1].lower()
+                self.skip_line(inputfile, 'b')
+                line = next(inputfile)
+                if 'The irrep name for each symmetry:' in line:
+                    irreps = [self.normalisesym(irrep) for irrep in line.split()[8:][1::2]]
+                    self.symlabels = irreps
 
         # This is probably the first place where atomic symmetry labels are printed,
         # somewhere afer the SYMGRP point group information section. We need to know

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -55,6 +55,8 @@ class DALTON(logfileparser.Logfile):
         # when the first line is BASIS, false for INTGRL/ATOMBASIS.
         self.basislibrary = True
 
+    def after_parsing(self):
+        super().after_parsing()
 
     def parse_geometry(self, lines):
         """Parse DALTON geometry lines into an atomcoords array."""
@@ -143,6 +145,9 @@ class DALTON(logfileparser.Logfile):
                 if 'The irrep name for each symmetry:' in line:
                     irreps = [self.normalisesym(irrep) for irrep in line.split()[8:][1::2]]
                     self.symlabels = irreps
+
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # This is probably the first place where atomic symmetry labels are printed,
         # somewhere afer the SYMGRP point group information section. We need to know

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -89,7 +89,7 @@ class GAMESS(logfileparser.Logfile):
         self.scftype = "none"  # Type of SCF calculation: BLYP, RHF, ROHF, etc.
 
     def after_parsing(self):
-        super().after_parsing()
+        super(GAMESS, self).after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -91,7 +91,8 @@ class GAMESS(logfileparser.Logfile):
         
         # extract the version number first
         if line.find("GAMESS VERSION") >= 0:
-            self.metadata["package_version"] = line.split()[4] + line.split()[5] + line.split()[6]
+            tokens = line.split()
+            self.metadata["package_version"] = ''.join(tokens[4:7])
 
         if line[1:12] == "INPUT CARD>":
             return
@@ -167,6 +168,18 @@ class GAMESS(logfileparser.Logfile):
                                 self.metadata["basis_set"] = "6-311G**"
                     if line.split()[2] == "6" and line.split()[3] == "POLAR=NONE":
                         self.metadata["basis_set"] = "6-311G"
+
+        # Symmetry: point group
+        if " THE POINT GROUP OF THE MOLECULE IS" in line:
+            pg = line.split()[-1]
+            line = next(inputfile)
+            order = line.split()[-1]
+            point_group = pg.replace('N', order)
+
+        # Symmetry: ordering of irreducible representations
+        if line.strip() == "DIMENSIONS OF THE SYMMETRY SUBSPACES ARE":
+            line = next(inputfile)
+            symlabels = [self.normalisesym(label) for label in line.split()[::3]]
 
         # We are looking for this line:
         #           PARAMETERS CONTROLLING GEOMETRY SEARCH ARE

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -179,8 +179,11 @@ class GAMESS(logfileparser.Logfile):
             pg = line.split()[-1]
             line = next(inputfile)
             order = line.split()[-1]
-            point_group = pg.replace('N', order)
-            self.metadata['symmetry_full'] = point_group
+            point_group_full = pg.replace('N', order).lower()
+            # TODO
+            point_group_abelian = point_group_full
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # Symmetry: ordering of irreducible representations
         if line.strip() == "DIMENSIONS OF THE SYMMETRY SUBSPACES ARE":

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -88,9 +88,6 @@ class GAMESS(logfileparser.Logfile):
         self.cihamtyp = "none"  # Type of CI Hamiltonian: saps or dets.
         self.scftype = "none"  # Type of SCF calculation: BLYP, RHF, ROHF, etc.
 
-    def after_parsing(self):
-        super(GAMESS, self).after_parsing()
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
         

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -25,28 +25,26 @@ class GAMESS(logfileparser.Logfile):
     SCFRMS, SCFMAX, SCFENERGY = list(range(3))
 
     # Used to extact Dunning basis set names.
-    dunningbas = {
-        'CCD': 'cc-pVDZ', 
-        'CCT': 'cc-pVTZ', 
-        'CCQ': 'cc-pVQZ', 
-        'CC5': 'cc-pV5Z', 
-        'CC6': 'cc-pV6Z', 
-        'ACCD': 'aug-cc-pVDZ', 
-        'ACCT': 'aug-cc-pVTZ', 
-        'ACCQ': 'aug-cc-pVQZ', 
-        'ACC5': 'aug-cc-pV5Z', 
-        'ACC6': 'aug-cc-pV6Z', 
-        'CCDC': 'cc-pCVDZ', 
-        'CCTC': 'cc-pCVTZ', 
-        'CCQC': 'cc-pCVQZ', 
-        'CC5C': 'cc-pCV5Z', 
-        'CC6C': 'cc-pCV6Z', 
-        'ACCDC': 'aug-cc-pCVDZ', 
-        'ACCTC': 'aug-cc-pCVTZ', 
-        'ACCQC': 'aug-cc-pCVQZ', 
-        'ACC5C': 'aug-cc-pCV5Z', 
-        'ACC6C': 'aug-cc-pCV6Z'
-    }
+    dunningbas = {'CCD': 'cc-pVDZ', \
+            'CCT': 'cc-pVTZ', \
+            'CCQ': 'cc-pVQZ', \
+            'CC5': 'cc-pV5Z', \
+            'CC6': 'cc-pV6Z', \
+            'ACCD': 'aug-cc-pVDZ', \
+            'ACCT': 'aug-cc-pVTZ', \
+            'ACCQ': 'aug-cc-pVQZ', \
+            'ACC5': 'aug-cc-pV5Z', \
+            'ACC6': 'aug-cc-pV6Z', \
+            'CCDC': 'cc-pCVDZ', \
+            'CCTC': 'cc-pCVTZ', \
+            'CCQC': 'cc-pCVQZ', \
+            'CC5C': 'cc-pCV5Z', \
+            'CC6C': 'cc-pCV6Z', \
+            'ACCDC': 'aug-cc-pCVDZ', \
+            'ACCTC': 'aug-cc-pCVTZ', \
+            'ACCQC': 'aug-cc-pCVQZ', \
+            'ACC5C': 'aug-cc-pCV5Z', \
+            'ACC6C': 'aug-cc-pCV6Z'}
 
     def __init__(self, *args, **kwargs):
 

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -91,8 +91,7 @@ class GAMESS(logfileparser.Logfile):
         
         # extract the version number first
         if line.find("GAMESS VERSION") >= 0:
-            tokens = line.split()
-            self.metadata["package_version"] = ''.join(tokens[4:7])
+            self.metadata["package_version"] = ''.join(line.split()[4:7])
 
         if line[1:12] == "INPUT CARD>":
             return

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -25,26 +25,28 @@ class GAMESS(logfileparser.Logfile):
     SCFRMS, SCFMAX, SCFENERGY = list(range(3))
 
     # Used to extact Dunning basis set names.
-    dunningbas = {'CCD': 'cc-pVDZ', \
-            'CCT': 'cc-pVTZ', \
-            'CCQ': 'cc-pVQZ', \
-            'CC5': 'cc-pV5Z', \
-            'CC6': 'cc-pV6Z', \
-            'ACCD': 'aug-cc-pVDZ', \
-            'ACCT': 'aug-cc-pVTZ', \
-            'ACCQ': 'aug-cc-pVQZ', \
-            'ACC5': 'aug-cc-pV5Z', \
-            'ACC6': 'aug-cc-pV6Z', \
-            'CCDC': 'cc-pCVDZ', \
-            'CCTC': 'cc-pCVTZ', \
-            'CCQC': 'cc-pCVQZ', \
-            'CC5C': 'cc-pCV5Z', \
-            'CC6C': 'cc-pCV6Z', \
-            'ACCDC': 'aug-cc-pCVDZ', \
-            'ACCTC': 'aug-cc-pCVTZ', \
-            'ACCQC': 'aug-cc-pCVQZ', \
-            'ACC5C': 'aug-cc-pCV5Z', \
-            'ACC6C': 'aug-cc-pCV6Z'}
+    dunningbas = {
+        'CCD': 'cc-pVDZ', 
+        'CCT': 'cc-pVTZ', 
+        'CCQ': 'cc-pVQZ', 
+        'CC5': 'cc-pV5Z', 
+        'CC6': 'cc-pV6Z', 
+        'ACCD': 'aug-cc-pVDZ', 
+        'ACCT': 'aug-cc-pVTZ', 
+        'ACCQ': 'aug-cc-pVQZ', 
+        'ACC5': 'aug-cc-pV5Z', 
+        'ACC6': 'aug-cc-pV6Z', 
+        'CCDC': 'cc-pCVDZ', 
+        'CCTC': 'cc-pCVTZ', 
+        'CCQC': 'cc-pCVQZ', 
+        'CC5C': 'cc-pCV5Z', 
+        'CC6C': 'cc-pCV6Z', 
+        'ACCDC': 'aug-cc-pCVDZ', 
+        'ACCTC': 'aug-cc-pCVTZ', 
+        'ACCQC': 'aug-cc-pCVQZ', 
+        'ACC5C': 'aug-cc-pCV5Z', 
+        'ACC6C': 'aug-cc-pCV6Z'
+    }
 
     def __init__(self, *args, **kwargs):
 
@@ -85,6 +87,9 @@ class GAMESS(logfileparser.Logfile):
         self.firststdorient = True  # Used to decide whether to wipe the atomcoords clean
         self.cihamtyp = "none"  # Type of CI Hamiltonian: saps or dets.
         self.scftype = "none"  # Type of SCF calculation: BLYP, RHF, ROHF, etc.
+
+    def after_parsing(self):
+        super().after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
@@ -175,6 +180,7 @@ class GAMESS(logfileparser.Logfile):
             line = next(inputfile)
             order = line.split()[-1]
             point_group = pg.replace('N', order)
+            self.metadata['symmetry_full'] = point_group
 
         # Symmetry: ordering of irreducible representations
         if line.strip() == "DIMENSIONS OF THE SYMMETRY SUBSPACES ARE":

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -54,7 +54,7 @@ class GAMESSUK(logfileparser.Logfile):
         self.betamosyms = self.betamoenergies = self.betamocoeffs = False
 
     def after_parsing(self):
-        super().after_parsing()
+        super(GAMESSUK, self).after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -53,8 +53,14 @@ class GAMESSUK(logfileparser.Logfile):
         # used for determining whether to add a second mosyms, etc.
         self.betamosyms = self.betamoenergies = self.betamocoeffs = False
 
+    def after_parsing(self):
+        super().after_parsing()
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
+
+        if all(token in line for token in ("version", "===")):
+            self.metadata["package_version"] = line.split()[4]
 
         if line[1:22] == "total number of atoms":
             natom = int(line.split()[-1])
@@ -97,6 +103,7 @@ class GAMESSUK(logfileparser.Logfile):
             assert "order of principal axis" in line
             naxis = line.split()[-1]
             point_group = pg.replace('n', naxis)
+            self.metadata['symmetry_full'] = point_group
 
         # This is the only place coordinates are printed in single point calculations. Note that
         # in the following fragment, the basis set selection is not always printed:
@@ -595,8 +602,8 @@ class GAMESSUK(logfileparser.Logfile):
         #
         if line.strip() == "dipole moments":
 
-            # In older version there is only one blank line before the header,
-            # and newer version there are two.
+            # In older versions there is only one blank line before
+            # the header, and newer versions there are two.
             self.skip_line(inputfile, 'blank')
             line = next(inputfile)
             if not line.strip():

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -53,9 +53,6 @@ class GAMESSUK(logfileparser.Logfile):
         # used for determining whether to add a second mosyms, etc.
         self.betamosyms = self.betamoenergies = self.betamocoeffs = False
 
-    def after_parsing(self):
-        super(GAMESSUK, self).after_parsing()
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -88,6 +88,16 @@ class GAMESSUK(logfileparser.Logfile):
             if not self.geotargets:
                 self.geotargets = geotargets
 
+        if line.strip() == "molecular symmetry":
+            self.skip_lines(inputfile, ['s', 'b'])
+            line = next(inputfile)
+            assert "molecular point group" in line
+            pg = line.split()[-1]
+            line = next(inputfile)
+            assert "order of principal axis" in line
+            naxis = line.split()[-1]
+            point_group = pg.replace('n', naxis)
+
         # This is the only place coordinates are printed in single point calculations. Note that
         # in the following fragment, the basis set selection is not always printed:
         #
@@ -462,6 +472,11 @@ class GAMESSUK(logfileparser.Logfile):
                 self.mosysms = [mosyms, mosyms]
             else:
                 self.mosyms = [mosyms]
+
+        if line.strip() == "Number of orbitals belonging to irreps of this group":
+            self.skip_line(inputfile, 'd')
+            line = next(inputfile)
+            irreps = [self.normalisesym(irrep) for irrep in line.split()[::2]]
 
         if line[50:62] == "eigenvectors":
         # Mocoeffs...can get evalues from here too

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -102,8 +102,11 @@ class GAMESSUK(logfileparser.Logfile):
             line = next(inputfile)
             assert "order of principal axis" in line
             naxis = line.split()[-1]
-            point_group = pg.replace('n', naxis)
-            self.metadata['symmetry_full'] = point_group
+            point_group_full = pg.replace('n', naxis)
+            # TODO
+            point_group_abelian = point_group_full
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # This is the only place coordinates are printed in single point calculations. Note that
         # in the following fragment, the basis set selection is not always printed:

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -88,7 +88,7 @@ class Gaussian(logfileparser.Logfile):
         self.hp_polarizabilities = False
 
     def after_parsing(self):
-        super().after_parsing()
+        super(Gaussian, self).after_parsing()
 
         # Correct the percent values in the etsecs in the case of
         # a restricted calculation. The following has the

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -507,6 +507,8 @@ class Gaussian(logfileparser.Logfile):
                     point_group_abelian = line.split()[3].lower()
             else:
                 point_group_abelian = "c1"
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # Symmetry: ordering of irreducible representations
         if "symmetry adapted cartesian basis functions" in line:

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -88,6 +88,7 @@ class Gaussian(logfileparser.Logfile):
         self.hp_polarizabilities = False
 
     def after_parsing(self):
+        super().after_parsing()
 
         # Correct the percent values in the etsecs in the case of
         # a restricted calculation. The following has the

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -486,6 +486,21 @@ class Gaussian(logfileparser.Logfile):
                     self.atommasses.extend(list(map(float, line.split()[1:])))
                 line = next(inputfile)
 
+        # Symmetry: point group
+        if "Full point group" in line:
+            point_group_full = line.split()[3].lower()
+            line = next(inputfile)
+            line = next(inputfile)
+            assert "Largest Abelian subgroup" in line
+            point_group_abelian = line.split()[3].lower()
+
+        # Symmetry: ordering of irreducible representations
+        if "symmetry adapted cartesian basis functions" in line:
+            if not hasattr(self, 'symlabels'):
+                self.symlabels = []
+            irrep = self.normalisesym(line.split()[-2])
+            self.symlabels.append(irrep)
+
         # Extract the atomic numbers and coordinates of the atoms.
         if line.strip() == "Standard orientation:":
 

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -202,9 +202,8 @@ class Jaguar(logfileparser.Logfile):
 
         if "Molecular Point Group:" in line:
             point_group_full = line.split()[3].lower()
-            self.skip_lines(inputfile, ['comment', 'comment'])
-            line = next(inputfile)
-            assert "Point Group used:" in line
+            while "Point Group used:" not in line:
+                line = next(inputfile)
             point_group_abelian = line.split()[3].lower()
 
         if line[2:14] == "new geometry" or line[1:21] == "Symmetrized geometry" or line.find("Input geometry") > 0:

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -56,7 +56,7 @@ class Jaguar(logfileparser.Logfile):
         self.geoopt = False
 
     def after_parsing(self):
-        super().after_parsing()
+        super(Jaguar, self).after_parsing()
 
         # This is to make sure we always have optdone after geometry optimizations,
         # even if it is to be empty for unconverged runs. We have yet to test this

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -200,6 +200,13 @@ class Jaguar(logfileparser.Logfile):
                     self.coreelectrons.append(int(line.split()[1]))
                 line = next(inputfile)
 
+        if "Molecular Point Group:" in line:
+            point_group_full = line.split()[3].lower()
+            self.skip_lines(inputfile, ['comment', 'comment'])
+            line = next(inputfile)
+            assert "Point Group used:" in line
+            point_group_abelian = line.split()[3].lower()
+
         if line[2:14] == "new geometry" or line[1:21] == "Symmetrized geometry" or line.find("Input geometry") > 0:
         # Get the atom coordinates
             if not hasattr(self, "atomcoords") or line[1:21] == "Symmetrized geometry":

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -56,6 +56,7 @@ class Jaguar(logfileparser.Logfile):
         self.geoopt = False
 
     def after_parsing(self):
+        super().after_parsing()
 
         # This is to make sure we always have optdone after geometry optimizations,
         # even if it is to be empty for unconverged runs. We have yet to test this
@@ -205,6 +206,8 @@ class Jaguar(logfileparser.Logfile):
             while "Point Group used:" not in line:
                 line = next(inputfile)
             point_group_abelian = line.split()[3].lower()
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         if line[2:14] == "new geometry" or line[1:21] == "Symmetrized geometry" or line.find("Input geometry") > 0:
         # Get the atom coordinates

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -232,7 +232,7 @@ class Logfile(object):
             self.metadata = {}
             self.metadata["package"] = self.logname
             self.metadata["methods"] = []
-
+            self.metadata["basis_set"] = ""
 
         # Periodic table of elements.
         self.table = utils.PeriodicTable()
@@ -360,7 +360,11 @@ class Logfile(object):
 
     def after_parsing(self):
         """Correct data or do parser-specific validation after parsing is finished."""
-        pass
+
+        if "symmetry_full" not in self.metadata:
+            assert "symmetry_abelian" not in self.metadata
+            self.metadata['symmetry_full'] = "c1"
+            self.metadata['symmetry_abelian'] = "c1"
 
     def updateprogress(self, inputfile, msg, xupdate=0.05):
         """Update progress."""

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -271,8 +271,11 @@ class Molpro(logfileparser.Logfile):
             self.metadata["package_version"] = line.split()[1]
 
         if line[1:12] == "Point group":
-            point_group_full = line.split()[-1]
+            point_group_full = line.split()[-1].lower()
+            # TODO
+            point_group_abelian = point_group_full
             self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         if line[1:19] == "ATOMIC COORDINATES":
 

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -269,6 +269,9 @@ class Molpro(logfileparser.Logfile):
         if "Version" in line:
             self.metadata["package_version"] = line.split()[1]
 
+        if line[1:12] == "Point group":
+            point_group_full = line.split()[-1]
+
         if line[1:19] == "ATOMIC COORDINATES":
 
             if not hasattr(self, "atomcoords"):

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -75,6 +75,7 @@ class Molpro(logfileparser.Logfile):
         self.insidescf = False
 
     def after_parsing(self):
+        super().after_parsing()
 
         # If optimization thresholds are default, they are normally not printed and we need
         # to set them to the default after parsing. Make sure to set them in the same order that
@@ -271,6 +272,7 @@ class Molpro(logfileparser.Logfile):
 
         if line[1:12] == "Point group":
             point_group_full = line.split()[-1]
+            self.metadata['symmetry_full'] = point_group_full
 
         if line[1:19] == "ATOMIC COORDINATES":
 

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -75,7 +75,7 @@ class Molpro(logfileparser.Logfile):
         self.insidescf = False
 
     def after_parsing(self):
-        super().after_parsing()
+        super(Molpro, self).after_parsing()
 
         # If optimization thresholds are default, they are normally not printed and we need
         # to set them to the default after parsing. Make sure to set them in the same order that

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -82,7 +82,7 @@ class MOPAC(logfileparser.Logfile):
                           'NONET': 9}
 
     def after_parsing(self):
-        super().after_parsing()
+        super(MOPAC, self).after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -81,6 +81,9 @@ class MOPAC(logfileparser.Logfile):
                           'OCTET': 8,
                           'NONET': 9}
 
+    def after_parsing(self):
+        super().after_parsing()
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -81,9 +81,6 @@ class MOPAC(logfileparser.Logfile):
                           'OCTET': 8,
                           'NONET': 9}
 
-    def after_parsing(self):
-        super(MOPAC, self).after_parsing()
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -88,6 +88,17 @@ class NWChem(logfileparser.Logfile):
 
             self.set_attribute('atomnos', atomnos)
 
+        if line.strip() == "Symmetry information":
+            self.skip_lines(inputfile, ['d', 'b'])
+            line = next(inputfile)
+            assert line[1:11] == "Group name"
+            point_group = line.split()[2]
+            line = next(inputfile)
+            assert line[1:13] == "Group number"
+            line = next(inputfile)
+            assert line[1:12] == "Group order"
+            self.pg_order = int(line.split()[2])
+
         # If the geometry is printed in XYZ format, it will have the number of atoms.
         if line[12:31] == "XYZ format geometry":
 
@@ -239,6 +250,14 @@ class NWChem(logfileparser.Logfile):
                     last = atombasis[-1][-1] + 1
 
                 self.set_attribute('atombasis', atombasis)
+
+        if line.strip() == "Symmetry analysis of basis":
+            self.skip_lines(inputfile, ['d', 'b'])
+            if not hasattr(self, 'symlabels'):
+                self.symlabels = []
+            for _ in range(self.pg_order):
+                line = next(inputfile)
+                self.symlabels.append(self.normalisesym(line.split()[0]))
 
         # This section contains general parameters for Hartree-Fock calculations,
         # which do not contain the 'General Information' section like most jobs.

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -1074,7 +1074,7 @@ class NWChem(logfileparser.Logfile):
 
         Currently, expands self.shells() into self.aonames.
         """
-        super().after_parsing()
+        super(NWChem, self).after_parsing()
 
         # setup a few necessary things, including a regular expression
         # for matching the shells

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -98,6 +98,7 @@ class NWChem(logfileparser.Logfile):
             line = next(inputfile)
             assert line[1:12] == "Group order"
             self.pg_order = int(line.split()[2])
+            self.metadata['symmetry_full'] = point_group
 
         # If the geometry is printed in XYZ format, it will have the number of atoms.
         if line[12:31] == "XYZ format geometry":
@@ -1073,6 +1074,7 @@ class NWChem(logfileparser.Logfile):
 
         Currently, expands self.shells() into self.aonames.
         """
+        super().after_parsing()
 
         # setup a few necessary things, including a regular expression
         # for matching the shells

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -92,13 +92,16 @@ class NWChem(logfileparser.Logfile):
             self.skip_lines(inputfile, ['d', 'b'])
             line = next(inputfile)
             assert line[1:11] == "Group name"
-            point_group = line.split()[2]
+            point_group_full = line.split()[2].lower()
             line = next(inputfile)
             assert line[1:13] == "Group number"
             line = next(inputfile)
             assert line[1:12] == "Group order"
             self.pg_order = int(line.split()[2])
-            self.metadata['symmetry_full'] = point_group
+            # TODO
+            point_group_abelian = point_group_full
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # If the geometry is printed in XYZ format, it will have the number of atoms.
         if line[12:31] == "XYZ format geometry":

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -60,6 +60,9 @@ class ORCA(logfileparser.Logfile):
         # Keep track of whether this is a relaxed scan calculation
         self.is_relaxed_scan = False
 
+    def after_parsing(self):
+        super().after_parsing()
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
@@ -83,12 +86,13 @@ class ORCA(logfileparser.Logfile):
             self.set_attribute('mult', mult)
 
         if line[1:18] == "Symmetry handling":
+
             line = next(inputfile)
             assert "Point group" in line
-            point_group_full = line.split()[3]
+            point_group_full = line.split()[3].lower()
             line = next(inputfile)
             assert "Used point group" in line
-            point_group_abelian = line.split()[4]
+            point_group_abelian = line.split()[4].lower()
             line = next(inputfile)
             assert "Number of irreps" in line
             nirrep = int(line.split()[4])
@@ -99,6 +103,9 @@ class ORCA(logfileparser.Logfile):
                 if not hasattr(self, 'symlabels'):
                     self.symlabels = []
                 self.symlabels.append(self.normalisesym(irrep))
+
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
 
         # SCF convergence output begins with:
         #

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -45,6 +45,11 @@ class ORCA(logfileparser.Logfile):
         >>> map(sym, labels)
         ['A1', 'Ag', 'A1g', 'sigma', 'pi', 'phi', 'delta', 'delta.u', 'sigma.g']
         """
+        # TODO
+        # 1. change docstring
+        # 2. implement?
+
+        return label
 
     def before_parsing(self):
 
@@ -76,6 +81,24 @@ class ORCA(logfileparser.Logfile):
 
             mult = int(line.split()[-1])
             self.set_attribute('mult', mult)
+
+        if line[1:18] == "Symmetry handling":
+            line = next(inputfile)
+            assert "Point group" in line
+            point_group_full = line.split()[3]
+            line = next(inputfile)
+            assert "Used point group" in line
+            point_group_abelian = line.split()[4]
+            line = next(inputfile)
+            assert "Number of irreps" in line
+            nirrep = int(line.split()[4])
+            for n in range(nirrep):
+                line = next(inputfile)
+                assert "symmetry adapted basis functions" in line
+                irrep = line[8:13]
+                if not hasattr(self, 'symlabels'):
+                    self.symlabels = []
+                self.symlabels.append(self.normalisesym(irrep))
 
         # SCF convergence output begins with:
         #

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -60,9 +60,6 @@ class ORCA(logfileparser.Logfile):
         # Keep track of whether this is a relaxed scan calculation
         self.is_relaxed_scan = False
 
-    def after_parsing(self):
-        super(ORCA, self).after_parsing()
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -61,7 +61,7 @@ class ORCA(logfileparser.Logfile):
         self.is_relaxed_scan = False
 
     def after_parsing(self):
-        super().after_parsing()
+        super(ORCA, self).after_parsing()
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -49,7 +49,7 @@ class Psi(logfileparser.Logfile):
 
 
     def after_parsing(self):
-        super().after_parsing()
+        super(Psi, self).after_parsing()
 
         # Newer versions of Psi4 don't explicitly print the number of atoms.
         if not hasattr(self, 'natom'):

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -94,6 +94,15 @@ class Psi(logfileparser.Logfile):
             if self.reference[0] == 'C':
                 self.reference = self.reference[1:]
 
+        if (self.version == 3) and (line.strip() == "-SYMMETRY INFORMATION:"):
+            line = next(inputfile)
+            assert "Computational point group is" in line
+            point_group_abelian = line.split()[4].lower()
+            # TODO
+            point_group_full = point_group_abelian
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
+
         # Psi3 prints the coordinates in several configurations, and we will parse the
         # the canonical coordinates system in Angstroms as the first coordinate set,
         # although it is actually somewhere later in the input, after basis set, etc.

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -49,6 +49,7 @@ class Psi(logfileparser.Logfile):
 
 
     def after_parsing(self):
+        super().after_parsing()
 
         # Newer versions of Psi4 don't explicitly print the number of atoms.
         if not hasattr(self, 'natom'):
@@ -138,6 +139,19 @@ class Psi(logfileparser.Logfile):
         #           C          1.415253322400    -0.230221785400     0.000000000000
         # ...
         #
+        if (self.section == "Geometry") and ("Molecular point group" in line):
+
+            point_group_abelian = line.split()[3].lower()
+            line = next(inputfile)
+            if "Full point group" in line:
+                point_group_full = line.split()[3].lower()
+            else:
+                # TODO this isn't right, need to "know" about symmetry.
+                point_group_full = point_group_abelian
+
+            self.metadata['symmetry_full'] = point_group_full
+            self.metadata['symmetry_abelian'] = point_group_abelian
+
         if (self.section == "Geometry") and ("Geometry (in Angstrom), charge" in line):
 
             assert line.split()[3] == "charge"

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -108,7 +108,7 @@ class QChem(logfileparser.Logfile):
         ]
 
     def after_parsing(self):
-        super().after_parsing()
+        super(QChem, self).after_parsing()
 
         # If parsing a fragment job, each of the geometries appended to
         # `atomcoords` may be of different lengths, which will prevent

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -108,6 +108,7 @@ class QChem(logfileparser.Logfile):
         ]
 
     def after_parsing(self):
+        super().after_parsing()
 
         # If parsing a fragment job, each of the geometries appended to
         # `atomcoords` may be of different lengths, which will prevent

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -344,6 +344,15 @@ class QChem(logfileparser.Logfile):
 
                     line = next(inputfile)
 
+            # Point group symmetry.
+            if 'Molecular Point Group' in line:
+                point_group_full = line.split()[3].lower()
+                line = next(inputfile)
+                assert 'Largest Abelian Subgroup' in line
+                point_group_abelian = line.split()[3].lower()
+                self.metadata['symmetry_full'] = point_group_full
+                self.metadata['symmetry_abelian'] = point_group_abelian
+
             # Parse the basis set name
             if 'Requested basis set' in line:
                 self.metadata["basis_set"] = line.split()[-1]

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -121,7 +121,6 @@ class GenericSPTest(unittest.TestCase):
         self.assertNotEquals(self.logfile.normalisesym("A"), "ERROR: This should be overwritten by this subclass")
 
     @skipForParser('Molpro', '?')
-    @skipForParser('ORCA', 'ORCA has no support for symmetry yet')
     def testsymlabels(self):
         """Are all the symmetry labels either Ag/u or Bg/u?"""
         sumwronglabels = sum([x not in ['Ag', 'Bu', 'Au', 'Bg'] for x in self.data.mosyms[0]])
@@ -248,7 +247,16 @@ class GenericSPTest(unittest.TestCase):
         self.assertIn("methods", self.data.metadata)
         self.assertIn("package", self.data.metadata)
         self.assertIn("package_version", self.data.metadata)
+        self.assertIn("symmetry_abelian", self.data.metadata)
         self.assertIn("symmetry_full", self.data.metadata)
+
+    @skipForParser('Molpro', 'these calculations were run with symmetry disabled')
+    def testsymmetry(self):
+        """DVB should have C2h symmetry, which is also an Abelian group.
+        """
+        self.assertEquals(self.data.metadata["symmetry_full"], "c2h")
+        self.assertEquals(self.data.metadata["symmetry_abelian"], "c2h")
+
 
 class ADFSPTest(GenericSPTest):
     """Customized restricted single point unittest"""

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -241,16 +241,6 @@ class GenericSPTest(unittest.TestCase):
             for m in moment32:
                 self.assertEquals(m, 0.0)
 
-    @skipForParser('ADF', 'Does not support metadata yet')
-    @skipForParser('GAMESS', 'Does not support metadata yet')
-    @skipForParser('GAMESSUK', 'Does not support metadata yet')
-    @skipForParser('Gaussian', 'Does not support metadata yet')
-    @skipForParser('Jaguar', 'Does not support metadata yet')
-    @skipForParser('Molpro', 'Does not support metadata yet')
-    @skipForParser('NWChem', 'Does not support metadata yet')
-    @skipForParser('ORCA', 'Does not support metadata yet')
-    @skipForParser('Psi', 'Does not support metadata yet')
-    @skipForParser('QChem', 'Does not support metadata yet')
     def testmetadata(self):
         """Does metadata have expected keys and values?"""
         self.assertTrue(hasattr(self.data, "metadata"))
@@ -258,6 +248,7 @@ class GenericSPTest(unittest.TestCase):
         self.assertIn("methods", self.data.metadata)
         self.assertIn("package", self.data.metadata)
         self.assertIn("package_version", self.data.metadata)
+        self.assertIn("symmetry_full", self.data.metadata)
 
 class ADFSPTest(GenericSPTest):
     """Customized restricted single point unittest"""

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -76,12 +76,13 @@ class FileWrapperTest(unittest.TestCase):
         for lf in logfiles:
             path = "%s/%s" % (__datadir__, lf)
             expected_attributes = get_attributes(cclib.io.ccopen(path).parse())
-            contents = open(path).read()
+            with open(path) as handle:
+                contents = handle.read()
             # This is fix strings not being unicode in Python2.
             try:
-              stdin = io.StringIO(contents)
+                stdin = io.StringIO(contents)
             except TypeError:
-              stdin = io.StringIO(unicode(contents))
+                stdin = io.StringIO(unicode(contents))
             stdin.seek = sys.stdin.seek
             data = cclib.io.ccopen(stdin).parse()
             self.assertEqual(get_attributes(data), expected_attributes)


### PR DESCRIPTION
This isn't currently full symmetry handling for all appropriate attributes, just the string representing the point group.

As mentioned in https://github.com/cclib/cclib/issues/258, these are currently in the metadata. `symmetry_full` is the real or molecular point group, and `symmetry_abelian` is the point group that the calculation is actually using. There are a few cases where only one is printed; right now, this PR is _not_ smart about fixing this.

If symmetry is not parsed, it assumes that both point groups are C1, so no symmetry is present.

Tests were added to `test/data/testSP.py`.

What things are called and so on is of course open for discussion, just figured this would be a good starting place.

The regression PR is https://github.com/cclib/cclib-data/pull/56, which needs to go in before this will pass.

---

Additionally,

- `metadata['package_version']` is added for ADF and GAMESS-UK. MOPAC is the only one missing this, as it is missing `metadata` entirely.
- `metadata['basis_set']` now defaults to the empty string.
- `mosyms` are now parsed from ORCA.
- All parsers now test to see if the `metadata` fields have been filled out (except for MOPAC).