### PR TITLE
Parses thermo from ORCA

### DIFF
--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -569,35 +569,35 @@ class ORCA(logfileparser.Logfile):
             while line[:17] != 'Electronic energy':
                 line = next(inputfile)
             self.zpe = next(inputfile).split()[4]
-            thermal_vibrational_correction = next(inputfile).split()[4]
-            thermal_rotional_correction = next(inputfile).split()[4]
-            thermal_translational_correction = next(inputfile).split()[4]
+            thermal_vibrational_correction = float(next(inputfile).split()[4])
+            thermal_rotional_correction = float(next(inputfile).split()[4])
+            thermal_translational_correction = float(next(inputfile).split()[4])
             next(inputfile)
-            total_thermal_energy = next(inputfile).split()[3]
+            total_thermal_energy = float(next(inputfile).split()[3])
 
             # Enthalpy
             line = next(inputfile)
             while line[:17] != 'Total free energy':
                 line = next(inputfile)
-            thermal_enthalpy_correction = next(inputfile).split()[4]
+            thermal_enthalpy_correction = float(next(inputfile).split()[4])
             next(inputfile)
-            self.enthalpy = next(inputfile).split()[3]
+            self.enthalpy = float(next(inputfile).split()[3])
 
             # Entropy
             line = next(inputfile)
             while line[:18] != 'Electronic entropy':
                 line = next(inputfile)
-            electronic_entropy = line.split()[3]
-            vibrational_entropy = next(inputfile).split()[3]
-            rotational_entropy = next(inputfile).split()[3]
-            translational_entropy = next(inputfile).split()[3]
+            electronic_entropy = float(line.split()[3])
+            vibrational_entropy = float(next(inputfile).split()[3])
+            rotational_entropy = float(next(inputfile).split()[3])
+            translational_entropy = float(next(inputfile).split()[3])
             next(inputfile)
-            self.entropy = next(inputfile).split()[4]
+            self.entropy = float(next(inputfile).split()[4])
 
             line = next(inputfile)
             while line[:25] != 'Final Gibbs free enthalpy':
                 line = next(inputfile)
-            self.freeenergy = line.split()[5]
+            self.freeenergy = float(line.split()[5])
 
         # Read TDDFT information
         if any(x in line for x in ("TD-DFT/TDA EXCITED", "TD-DFT EXCITED")):

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -551,6 +551,55 @@ class ORCA(logfileparser.Logfile):
                 self.gbasis.append(gbasis_tmp[bas_atname])
             del self.tmp_atnames
 
+        """
+        --------------------------
+        THERMOCHEMISTRY AT 298.15K
+        --------------------------
+        """
+        if 'THERMOCHEMISTRY AT' == line[:18]:
+            conv = lambda x: utils.convertor(float(x), "hartree", "eV")
+
+            next(inputfile)
+            next(inputfile)
+            self.temperature = float(next(inputfile).split()[2])
+            self.pressure    = float(next(inputfile).split()[2])
+            total_mass  = float(next(inputfile).split()[3])
+
+            # Vibrations, rotations, and translations
+            line = next(inputfile)
+            while line[:17] != 'Electronic energy':
+                line = next(inputfile)
+            self.zpe                         = conv(next(inputfile).split()[4])
+            thermal_vibrational_correction   = conv(next(inputfile).split()[4])
+            thermal_rotional_correction      = conv(next(inputfile).split()[4])
+            thermal_translational_correction = conv(next(inputfile).split()[4])
+            next(inputfile)
+            total_thermal_energy             = conv(next(inputfile).split()[3])
+
+            # Enthalpy
+            line = next(inputfile)
+            while line[:17] != 'Total free energy':
+                line = next(inputfile)
+            thermal_enthalpy_correction = conv(next(inputfile).split()[4])
+            next(inputfile)
+            self.enthalpy = conv(next(inputfile).split()[3])
+
+            # Entropy
+            line = next(inputfile)
+            while line[:18] != 'Electronic entropy':
+                line = next(inputfile)
+            electronic_entropy     = conv(line.split()[3])
+            vibrational_entropy    = conv(next(inputfile).split()[3])
+            rotational_entropy     = conv(next(inputfile).split()[3])
+            translational_entropy  = conv(next(inputfile).split()[3])
+            next(inputfile)
+            self.entropy           = conv(next(inputfile).split()[4])
+
+            line = next(inputfile)
+            while line[:25] != 'Final Gibbs free enthalpy':
+                line = next(inputfile)
+            self.freeenergy = conv(line.split()[5])
+
         # Read TDDFT information
         if any(x in line for x in ("TD-DFT/TDA EXCITED", "TD-DFT EXCITED")):
             # Could be singlets or triplets

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -551,54 +551,53 @@ class ORCA(logfileparser.Logfile):
                 self.gbasis.append(gbasis_tmp[bas_atname])
             del self.tmp_atnames
 
-        """
+        """ Banner announcing Thermochemistry
         --------------------------
         THERMOCHEMISTRY AT 298.15K
         --------------------------
         """
         if 'THERMOCHEMISTRY AT' == line[:18]:
-            conv = lambda x: utils.convertor(float(x), "hartree", "eV")
 
             next(inputfile)
             next(inputfile)
             self.temperature = float(next(inputfile).split()[2])
-            self.pressure    = float(next(inputfile).split()[2])
-            total_mass  = float(next(inputfile).split()[3])
+            self.pressure = float(next(inputfile).split()[2])
+            total_mass = float(next(inputfile).split()[3])
 
             # Vibrations, rotations, and translations
             line = next(inputfile)
             while line[:17] != 'Electronic energy':
                 line = next(inputfile)
-            self.zpe                         = conv(next(inputfile).split()[4])
-            thermal_vibrational_correction   = conv(next(inputfile).split()[4])
-            thermal_rotional_correction      = conv(next(inputfile).split()[4])
-            thermal_translational_correction = conv(next(inputfile).split()[4])
+            self.zpe = next(inputfile).split()[4]
+            thermal_vibrational_correction = next(inputfile).split()[4]
+            thermal_rotional_correction = next(inputfile).split()[4]
+            thermal_translational_correction = next(inputfile).split()[4]
             next(inputfile)
-            total_thermal_energy             = conv(next(inputfile).split()[3])
+            total_thermal_energy = next(inputfile).split()[3]
 
             # Enthalpy
             line = next(inputfile)
             while line[:17] != 'Total free energy':
                 line = next(inputfile)
-            thermal_enthalpy_correction = conv(next(inputfile).split()[4])
+            thermal_enthalpy_correction = next(inputfile).split()[4]
             next(inputfile)
-            self.enthalpy = conv(next(inputfile).split()[3])
+            self.enthalpy = next(inputfile).split()[3]
 
             # Entropy
             line = next(inputfile)
             while line[:18] != 'Electronic entropy':
                 line = next(inputfile)
-            electronic_entropy     = conv(line.split()[3])
-            vibrational_entropy    = conv(next(inputfile).split()[3])
-            rotational_entropy     = conv(next(inputfile).split()[3])
-            translational_entropy  = conv(next(inputfile).split()[3])
+            electronic_entropy = line.split()[3]
+            vibrational_entropy = next(inputfile).split()[3]
+            rotational_entropy = next(inputfile).split()[3]
+            translational_entropy = next(inputfile).split()[3]
             next(inputfile)
-            self.entropy           = conv(next(inputfile).split()[4])
+            self.entropy = next(inputfile).split()[4]
 
             line = next(inputfile)
             while line[:25] != 'Final Gibbs free enthalpy':
                 line = next(inputfile)
-            self.freeenergy = conv(line.split()[5])
+            self.freeenergy = line.split()[5]
 
         # Read TDDFT information
         if any(x in line for x in ("TD-DFT/TDA EXCITED", "TD-DFT EXCITED")):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -83,7 +83,6 @@ class OrcaIRTest(GenericIRTest):
 
     def testtemperature(self):
         """Is the temperature 298.15 K?"""
-        print(self.data)
         self.assertAlmostEqual(298.15, self.data.temperature)
 
     def testpressure(self):
@@ -91,15 +90,15 @@ class OrcaIRTest(GenericIRTest):
         self.assertAlmostEqual(1, self.data.pressure)
 
     def testenthalpy(self):
-         """Is the enthalpy defined"""
+         """Is the enthalpy defined?"""
          self.assertTrue(hasattr(self.data, 'enthalpy'))
 
     def testentropy(self):
-         """Is the entropy defined"""
+         """Is the entropy defined?"""
          self.assertTrue(hasattr(self.data, 'entropy'))
 
     def testfreeenergy(self):
-         """Is the freeenergy defined"""
+         """Is the freeenergy defined?"""
          self.assertTrue(hasattr(self.data, 'freeenergy'))
 
 

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -74,11 +74,7 @@ class JaguarIRTest(GenericIRTest):
 class OrcaIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
-    # We have not been able to determine why ORCA gets such a different
-    # maximum IR intensity. The coordinates are exactly the same, and
-    # the basis set seems close enough to other programs. It would be nice
-    # to determine whether this difference is algorithmic in nature,
-    # but in the meanwhile we will expect to parse this value.
+    # ORCA has a bug in the intensities for version < 4.0
     max_IR_intensity = 215
 
     def testtemperature(self):
@@ -90,16 +86,16 @@ class OrcaIRTest(GenericIRTest):
         self.assertAlmostEqual(1, self.data.pressure)
 
     def testenthalpy(self):
-         """Is the enthalpy defined?"""
-         self.assertTrue(hasattr(self.data, 'enthalpy'))
+         """Is the enthalpy correct?"""
+         self.assertAlmostEqual(-381.85224835, self.data.enthalpy, 3)
 
     def testentropy(self):
-         """Is the entropy defined?"""
-         self.assertTrue(hasattr(self.data, 'entropy'))
+         """Is the entropy correct?"""
+         self.assertAlmostEqual(0.03601749, self.data.entropy, 3)
 
     def testfreeenergy(self):
-         """Is the freeenergy defined?"""
-         self.assertTrue(hasattr(self.data, 'freeenergy'))
+         """Is the freeenergy correct?"""
+         self.assertAlmostEqual(-381.88826585, self.data.freeenergy, 3)
 
 
 class QChemIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -86,16 +86,16 @@ class OrcaIRTest(GenericIRTest):
         self.assertAlmostEqual(1, self.data.pressure)
 
     def testenthalpy(self):
-         """Is the enthalpy correct?"""
-         self.assertAlmostEqual(-381.85224835, self.data.enthalpy, 3)
+         """Is the enthalpy reasonable"""
+         self.assertAlmostEqual(-381.85224835, self.data.enthalpy, -1)
 
     def testentropy(self):
-         """Is the entropy correct?"""
-         self.assertAlmostEqual(0.03601749, self.data.entropy, 3)
+         """Is the entropy reasonable"""
+         self.assertAlmostEqual(0.03601749, self.data.entropy, -1)
 
     def testfreeenergy(self):
-         """Is the freeenergy correct?"""
-         self.assertAlmostEqual(-381.88826585, self.data.freeenergy, 3)
+         """Is the freeenergy reasonable"""
+         self.assertAlmostEqual(-381.88826585, self.data.freeenergy, -1)
 
 
 class QChemIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -81,6 +81,27 @@ class OrcaIRTest(GenericIRTest):
     # but in the meanwhile we will expect to parse this value.
     max_IR_intensity = 215
 
+    def testtemperature(self):
+        """Is the temperature 298.15 K?"""
+        print(self.data)
+        self.assertAlmostEqual(298.15, self.data.temperature)
+
+    def testpressure(self):
+        """Is the pressure 1 atm?"""
+        self.assertAlmostEqual(1, self.data.pressure)
+
+    def testenthalpy(self):
+         """Is the enthalpy defined"""
+         self.assertTrue(hasattr(self.data, 'enthalpy'))
+
+    def testentropy(self):
+         """Is the entropy defined"""
+         self.assertTrue(hasattr(self.data, 'entropy'))
+
+    def testfreeenergy(self):
+         """Is the freeenergy defined"""
+         self.assertTrue(hasattr(self.data, 'freeenergy'))
+
 
 class QChemIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -163,6 +163,7 @@ class DataSuite(object):
             parser = self.parsers[td['parser']]
             test = getattr(module, td['class'])
 
+            description = ''
             if not self.silent:
                 print("", file=stream_test)
                 description = "%s/%s: %s" % (td['subdir'], ",".join(td['files']), test.__doc__)


### PR DESCRIPTION
Parses temperature, pressure, ZPE, enthalpy, entropy, and free energy.

I've added all my energies in eV. The specified the thermodynamic units of `hartree/particle` (which perhaps should be just `hartree`) is inconsistent with scf and mp energies, which are in `eV`. Is this intentional? It would perhaps be nicer if most energies used the same units (though vibfreqs should obviously be `cm^-1`).

I've added simple unit tests. Should I add more complex ones, and if so, what should they include?

Other recommendations for my code? I hope to add more ORCA related stuff in the future.

Note: ORCA 3 had a bug in the IR intensities for SCF and MP2. This has been fixed in ORCA 4, but it explains why the results were not good (as noted in testvib).