### PR TITLE
Bring ORCA IR unit test precisions back to sane values

### DIFF
--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -77,9 +77,9 @@ class OrcaIRTest(GenericIRTest):
     # ORCA has a bug in the intensities for version < 4.0
     max_IR_intensity = 215
 
-    enthalpy_places = -1
-    entropy_places = -1
-    freeenergy_places = -1
+    enthalpy_places = 3
+    entropy_places = 3
+    freeenergy_places = 3
 
     def testtemperature(self):
         """Is the temperature 298.15 K?"""


### PR DESCRIPTION
This is a follow up to cclib/cclib#393 and cclib/cclib#397 and needs to be merged AFTER cclib/cclib-data#59.