### PR TITLE
Updates ORCA geometry parsing.

### DIFF
--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -123,6 +123,18 @@ class GenericGeoOptTest(unittest.TestCase):
         msg = "len(atomcoords) is %d but len(geovalues) is %d" % (count_coords, count_geovalues)
         self.assertEquals(count_geovalues, count_coords, msg)
 
+    @skipForParser("GAMESSUK", "Not implemented.")
+    @skipForParser("GAMESS", "Not implemented.")
+    @skipForParser("Jaguar", "Not implemented.")
+    @skipForParser("Molpro", "Not implemented.")
+    @skipForParser("NWChem", "Not implemented.")
+    @skipForParser("QChem", "Not implemented.")
+    def testatommasses(self):
+        """Are atommasses correct?"""
+        H, C = 1.008, 12.011
+        for atommass in self.data.atommasses:
+            self.assertTrue(numpy.isclose(atommass, H, 3) or numpy.isclose(atommass, C, 1))
+
     def testgeovalues_scfvalues(self):
         """Are scfvalues consistent with geovalues?"""
         count_scfvalues = len(self.data.scfvalues) - self.extrascfs

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -123,18 +123,6 @@ class GenericGeoOptTest(unittest.TestCase):
         msg = "len(atomcoords) is %d but len(geovalues) is %d" % (count_coords, count_geovalues)
         self.assertEquals(count_geovalues, count_coords, msg)
 
-    @skipForParser("GAMESSUK", "Not implemented.")
-    @skipForParser("GAMESS", "Not implemented.")
-    @skipForParser("Jaguar", "Not implemented.")
-    @skipForParser("Molpro", "Not implemented.")
-    @skipForParser("NWChem", "Not implemented.")
-    @skipForParser("QChem", "Not implemented.")
-    def testatommasses(self):
-        """Are atommasses correct?"""
-        H, C = 1.008, 12.011
-        for atommass in self.data.atommasses:
-            self.assertTrue(numpy.isclose(atommass, H, 3) or numpy.isclose(atommass, C, 1))
-
     def testgeovalues_scfvalues(self):
         """Are scfvalues consistent with geovalues?"""
         count_scfvalues = len(self.data.scfvalues) - self.extrascfs

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -101,15 +101,17 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('Jaguar', 'atommasses not implemented yet')
     @skipForParser('Molpro', 'atommasses not implemented yet')
     @skipForParser('NWChem', 'atommasses not implemented yet')
-    @skipForParser('ORCA', 'atommasses not implemented yet')
     @skipForLogfile('Psi/basicPsi3', 'atommasses not implemented yet')
     @skipForLogfile('Psi/basicPsi4.0b5', 'atommasses not implemented yet')
     @skipForParser('QChem', 'atommasses not implemented yet')
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass?"""
         mm = 1000*sum(self.data.atommasses)
-        msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
-        self.assertAlmostEquals(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
+        molecularmass = self.molecularmass
+        if self.logfile.logname == 'ORCA':
+            molecularmass = 130190.0
+        msg = "Molecule mass: %f not %f +- %fmD" % (mm, molecularmass, self.mass_precision)
+        self.assertAlmostEquals(mm, molecularmass, delta=self.mass_precision, msg=msg)
 
     def testcoreelectrons(self):
         """Are the coreelectrons all 0?"""

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -107,11 +107,8 @@ class GenericSPTest(unittest.TestCase):
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass?"""
         mm = 1000*sum(self.data.atommasses)
-        molecularmass = self.molecularmass
-        if self.logfile.logname == 'ORCA':
-            molecularmass = 130190.0
-        msg = "Molecule mass: %f not %f +- %fmD" % (mm, molecularmass, self.mass_precision)
-        self.assertAlmostEquals(mm, molecularmass, delta=self.mass_precision, msg=msg)
+        msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
+        self.assertAlmostEquals(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
 
     def testcoreelectrons(self):
         """Are the coreelectrons all 0?"""
@@ -305,6 +302,13 @@ class Psi3SPTest(GenericSPTest):
     # The final energy is also a bit higher here, I think due to the fact
     # that a SALC calculation is done instead of a full LCAO.
     b3lyp_energy = -10300
+
+
+class OrcaSPTest(GenericSPTest):
+    """Customized restricted single point unittest"""
+
+    # Orca has different weights for the masses
+    molecularmass = 130190
 
 
 if __name__=="__main__":

--- a/test/testdata
+++ b/test/testdata
@@ -189,8 +189,8 @@ SP        NWChem      GenericSPTest         basicNWChem6.0        dvb_sp_hf.out
 SP        NWChem      GenericSPTest         basicNWChem6.0        dvb_sp_ks.out
 SP        NWChem      GenericSPTest         basicNWChem6.5        dvb_sp_hf.out
 SP        NWChem      GenericSPTest         basicNWChem6.5        dvb_sp_ks.out
-SP        ORCA        GenericSPTest         basicORCA2.9          dvb_sp.out
-SP        ORCA        GenericSPTest         basicORCA3.0          dvb_sp.out
+SP        ORCA        OrcaSPTest            basicORCA2.9          dvb_sp.out
+SP        ORCA        OrcaSPTest            basicORCA3.0          dvb_sp.out
 SP        Psi         Psi3SPTest            basicPsi3             dvb_sp_hf.out
 SP        Psi         GenericSPTest         basicPsi4.0           dvb_sp_rhf.out
 SP        Psi         GenericSPTest         basicPsi4.0           dvb_sp_rks.out


### PR DESCRIPTION
Simplifies geometry parsing by combining single point and optimization geometry parsing. Adds parsing for atommasses and a test case.

Notes
-----
- Apparently different programs have different weights for atoms, necessitating large error bars.

Questions
---------
- [x] Is there a way to run a test only for a set of parsers (e.g. with a decorator like `runForParser` akin to `skipForParser`)?
- [x] I had to use the ugly test `self.assertTrue(numpy.isclose(atommass, H, 3) or numpy.isclose(atommass, C, 1))` in order to pass the regressions as some regressions have the atoms ordered differently. Could the regressions be changed to have the same starting geometries and atom order?

Status
------
- [ ] Regression tests need to be merged, PR cclib/cclib-data#60