### PR TITLE
Setupscript + gradient parsing for Molpro + Pep8 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 dist
 *.pyc
 .cache
+cclib.egg-info

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ chemistry log files. It also provides a platform to implement
 algorithms in a package-independent manner.
 """
 
-import sys
+from __future__ import with_statement
+from __future__ import absolute_import
+from setuptools import setup, find_packages
+from io import open  # pylint:disable=redefined-builtin
 
 
 # Chosen from http://www.python.org/pypi?:action=list_classifiers
@@ -28,46 +31,34 @@ Topic :: Scientific/Engineering :: Chemistry
 Topic :: Software Development :: Libraries :: Python Modules"""
 
 
+def readme():
+    '''Return the contents of the README.md file.'''
+    with open('README.md') as freadme:
+        return freadme.read()
+
+
 def setup_cclib():
-
-    # Import from setuptools only if requested.
-    if 'egg' in sys.argv:
-        sys.argv.pop(sys.argv.index('egg'))
-        from setuptools import setup
-
-    from distutils.core import setup
-
-    # The list of packages to be installed.
-    cclib_packages = [
-        'cclib',
-        'cclib.bridge',
-        'cclib.io',
-        'cclib.method',
-        'cclib.parser',
-        'cclib.progress',
-    ]
 
     doclines = __doc__.split("\n")
 
     setup(
-        name = "cclib",
-        version = "1.5.2",
-        url = "http://cclib.github.io/",
-        author = "cclib development team",
-        author_email = "cclib-users@lists.sourceforge.net",
-        maintainer = "cclib development team",
-        maintainer_email = "cclib-users@lists.sourceforge.net",
-        license = "BSD 3-Clause License",
-        description = doclines[0],
-        long_description = "\n".join(doclines[2:]),
-        classifiers = classifiers.split("\n"),
-        platforms = ["Any."],
-        packages = cclib_packages,
-        package_dir = { 'cclib':'src/cclib' },
-        scripts = ["src/scripts/ccget", "src/scripts/ccwrite", "src/scripts/cda"],
+        name="cclib",
+        version="1.5.2",
+        url="http://cclib.github.io/",
+        author="cclib development team",
+        author_email="cclib-users@lists.sourceforge.net",
+        maintainer="cclib development team",
+        maintainer_email="cclib-users@lists.sourceforge.net",
+        license="BSD 3-Clause License",
+        description=doclines[0],
+        long_description="\n".join(doclines[2:]),
+        classifiers=classifiers.split("\n"),
+        platforms=["Any."],
+        packages=find_packages('src'),
+        package_dir={'': 'src'},
+        scripts=["src/scripts/ccget", "src/scripts/ccwrite", "src/scripts/cda"]
     )
 
 
 if __name__ == '__main__':
-
     setup_cclib()

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -462,7 +462,7 @@ class Molpro(logfileparser.Logfile):
             if not hasattr(self, "scftargets"):
                 self.scftargets = []
 
-            scftargets = list(map(float, line.split()[2::2]))
+            scftargets = [float(x) for x in line.split()[2::2]]
             self.scftargets.append(scftargets)
             # Usually two criteria, but save the names this just in case.
             self.scftargetnames = line.split()[3::2]
@@ -776,19 +776,19 @@ class Molpro(logfileparser.Logfile):
 
                 if line[1:25].isspace():
                     if not islow:  # vibsyms not printed for low freq modes
-                        numbers = list(map(int, line.split()[::2]))
+                        numbers = [int(x) for x in line.split()[::2]]
                         vibsyms = line.split()[1::2]
                     else:
                         # give low freq modes an empty str as vibsym
                         # note there could be other possibilities..
-                        numbers = list(map(int, line.split()))
-                        vibsyms = ['']*len(numbers)
+                        numbers = [int(x) for x in line.split()]
+                        vibsyms = [''] * len(numbers)
 
                 if line[1:12] == "Wavenumbers":
-                    vibfreqs = list(map(float, line.strip().split()[2:]))
+                    vibfreqs = [float(x) for x in line.strip().split()[2:]]
 
                 if line[1:21] == "Intensities [km/mol]":
-                    vibirs = list(map(float, line.strip().split()[2:]))
+                    vibirs = [float(x) for x in line.strip().split()[2:]]
 
                 # There should always by 3xnatom displacement rows.
                 if line[1:11].isspace() and line[13:25].strip().isdigit():
@@ -855,11 +855,11 @@ class Molpro(logfileparser.Logfile):
 
             while line.strip():
                 try:
-                    list(map(float, line.strip().split()[2:]))
+                    [float(x) for x in line.strip().split()[2:]]
                 except:
                     line = next(inputfile)
                 line.strip().split()[1:]
-                hess.extend([list(map(float, line.strip().split()[1:]))])
+                hess.append([float(x) for x in line.strip().split()[1:]])
                 line = next(inputfile)
             lig = 0
 
@@ -881,11 +881,11 @@ class Molpro(logfileparser.Logfile):
         if line[1:14] == "Atomic Masses" and hasattr(self, "hessian"):
 
             line = next(inputfile)
-            self.amass = list(map(float, line.strip().split()[2:]))
+            self.amass = [float(x) for x in line.strip().split()[2:]]
 
             while line.strip():
                 line = next(inputfile)
-                self.amass += list(map(float, line.strip().split()[2:]))
+                self.amass += [float(x) for x in line.strip().split()[2:]]
 
         #1PROGRAM * POP (Mulliken population analysis)
         #

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -918,7 +918,6 @@ class Molpro(logfileparser.Logfile):
         if 'GRADIENT FOR STATE' in line:
             for _ in range(3):
                 next(inputfile)
-
             grad = []
             lines_read = 0
             while lines_read < self.natom:


### PR DESCRIPTION
1. Changes in setupscript:

Previously it was not possible to install the module in development mode or use pip for installing. Now you can do ``pip install -e .``
I hope there were no special reasons for sticking to distutils.

2. Gradient parsing for Molpro implemented.

Unit is eV / Angstrom.

3. PEP 8

I made some changes to make the molproparser a bit more PEP8 compatible.
For readability reasons I changed:

```
list(map(f, A))
to
[f(x) for x in A]
```