### PR TITLE
Append DF-MP2 to metadata methods

### DIFF
--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -746,6 +746,7 @@ class Psi(logfileparser.Logfile):
             self.mpenergies.append([mpenergy])
         # This is for the newer DF-MP2 code in 4.0.
         if 'DF-MP2 Energies' in line:
+            self.metadata["methods"].append("DF-MP2")
             while 'Total Energy' not in line:
                 line = next(inputfile)
             mpenergy = utils.convertor(float(line.split()[3]), 'hartree', 'eV')


### PR DESCRIPTION
When parsing a psi4 output file with the newer `DF-MP2` method, `data.metadata` has an empty list for `methods`. I added [this line](https://github.com/ChayaSt/cclib/blob/f959579c87e02f26e869f1b34e1c02b27f5149b8/src/cclib/parser/psiparser.py#L749) to fix this. 