### PR TITLE
Enable use of pytest and code coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build
 dist
 *.pyc
 .cache
+.coverage
 cclib.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ dist
 *.pyc
 .cache
 .coverage
+.pytest_cache
 cclib.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 before_install:
   - pip install numpy
   - pip install openbabel
+  - pip install pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then pip install biopython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then sh travis/install_pyquante.sh; fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 before_install:
   - pip install numpy
   - pip install openbabel
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install pytest==2.9.2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install -r travis/requirements_3.2.txt; fi
   - pip install pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then pip install biopython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then sh travis/install_pyquante.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 before_install:
   - pip install numpy
   - pip install openbabel
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install pytest==2.9.2; fi
   - pip install pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then pip install biopython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then sh travis/install_pyquante.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ before_install:
 install:
   - python setup.py install
 script:
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then alias pytest='py.test'; fi
   - sh travis/run_pytest.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,4 @@ before_install:
 install:
   - python setup.py install
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then alias pytest='py.test'; fi
   - sh travis/run_pytest.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_install:
 install:
   - python setup.py install
 script:
-  - sh travis/run_travis_tests.sh
+  - sh travis/run_pytest.sh

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+collect_ignore = [
+    # TODO doctest won't ignore specific files?
+    # https://stackoverflow.com/q/41358778/3249688
+    # 'src/cclib/progress/qt4progess.py',
+    'src/cclib/progress',
+]

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,28 @@
-collect_ignore = [
-    # TODO doctest won't ignore specific files?
-    # https://stackoverflow.com/q/41358778/3249688
-    # 'src/cclib/progress/qt4progess.py',
-    'src/cclib/progress',
+import sys
+
+
+version_major = sys.version_info.major
+version_minor = sys.version_info.minor
+
+
+paths_allver = [
+    'src/cclib/progress/qt4progress.py',
 ]
+
+paths_2_7_only = [
+    'src/cclib/bridge/cclib2pyquante.py',
+]
+
+
+def match_path(path, partial_paths):
+    return any(partial_path in str(path)
+               for partial_path in partial_paths)
+
+
+def pytest_ignore_collect(path, config):
+    if match_path(path, paths_allver):
+        return True
+    if version_major != 2:
+        if match_path(path, paths_2_7_only):
+            return True
+    return False

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import sys
 version_major = sys.version_info.major
 version_minor = sys.version_info.minor
 
-# Paths than should be ignored for all Python versions.
+# Paths that should be ignored for all Python versions.
 paths_allver = [
     'src/cclib/progress/qt4progress.py',
 ]

--- a/conftest.py
+++ b/conftest.py
@@ -4,25 +4,36 @@ import sys
 version_major = sys.version_info.major
 version_minor = sys.version_info.minor
 
-
+# Paths than should be ignored for all Python versions.
 paths_allver = [
     'src/cclib/progress/qt4progress.py',
 ]
 
-paths_2_7_only = [
+# Paths that should run only for Python 2.7.
+paths_only_2_7 = [
     'src/cclib/bridge/cclib2pyquante.py',
+]
+
+# Paths that should run everywhere except Python 3.2.
+paths_not_3_2 = [
+    'src/cclib/bridge/cclib2biopython.py',
 ]
 
 
 def match_path(path, partial_paths):
+    """Does the given path contain any of the stubs in partial_paths?"""
     return any(partial_path in str(path)
                for partial_path in partial_paths)
 
 
 def pytest_ignore_collect(path, config):
+    """If this returns True for a given path, pytest will ignore it."""
     if match_path(path, paths_allver):
         return True
     if version_major != 2:
-        if match_path(path, paths_2_7_only):
+        if match_path(path, paths_only_2_7_only):
+            return True
+    if version_major == 3 and version_minor == 2:
+        if match_path(path, paths_not_3_2):
             return True
     return False

--- a/conftest.py
+++ b/conftest.py
@@ -31,7 +31,7 @@ def pytest_ignore_collect(path, config):
     if match_path(path, paths_allver):
         return True
     if version_major != 2:
-        if match_path(path, paths_only_2_7_only):
+        if match_path(path, paths_only_2_7):
             return True
     if version_major == 3 and version_minor == 2:
         if match_path(path, paths_not_3_2):

--- a/old/downloadwiki.py
+++ b/old/downloadwiki.py
@@ -5,6 +5,8 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
+from __future__ import print_function
+
 import urllib
 
 from BeautifulSoup import BeautifulSoup
@@ -19,12 +21,11 @@ soup = BeautifulSoup(allpages)
 hrefs = []
 for anchor in soup('table')[2]('a'):
     hrefs.append(anchor['href'].split("/")[-1])
-print 'Pages to download:\n', ', '.join(hrefs)
+print('Pages to download:\n', ', '.join(hrefs))
 
 params = urllib.urlencode({"action":"submit",
                            "pages":"\n".join(hrefs)})
 
 query = urllib.urlopen(wiki + "/index.php/Special:Export", params)
-outputfile = open("backup.xml","w")
-print >> outputfile, query.read()
-outputfile.close()
+with open("backup.xml", "w") as outputfile:
+    outputfile.write(query.read())

--- a/src/cclib/__init__.py
+++ b/src/cclib/__init__.py
@@ -25,15 +25,15 @@ as well as example methods that take parsed data as input.
 
 __version__ = "1.5.2"
 
-from . import parser
-from . import progress
-from . import method
-from . import bridge
-from . import io
+from cclib import parser
+from cclib import progress
+from cclib import method
+from cclib import bridge
+from cclib import io
 
 # The test module can be imported if it was installed with cclib.
 try:
-    from . import test
+    from cclib import test
 except ImportError:
     pass
 

--- a/src/cclib/bridge/__init__.py
+++ b/src/cclib/bridge/__init__.py
@@ -12,18 +12,18 @@ try:
 except ImportError:
     pass
 else:
-    from .cclib2openbabel import makeopenbabel
+    from cclib.bridge.cclib2openbabel import makeopenbabel
 
 try:
     import PyQuante
 except ImportError:
     pass
 else:
-    from .cclib2pyquante import makepyquante
+    from cclib.bridge.cclib2pyquante import makepyquante
 
 try:
     import Bio
 except ImportError:
     pass
 else:
-    from .cclib2biopython import makebiopython
+    from cclib.bridge.cclib2biopython import makebiopython

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -12,7 +12,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from ..parser.utils import PeriodicTable
+from cclib.parser.utils import PeriodicTable
 
 
 def makebiopython(atomcoords, atomnos):

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -28,7 +28,7 @@ def makebiopython(atomcoords, atomnos):
     >>> b = numpy.array([[1.1,2,0],[1,1,0],[2,1,0]],"f")
     >>> si = Superimposer()
     >>> si.set_atoms(makebiopython(a,atomnos),makebiopython(b,atomnos))
-    >>> print si.rms
+    >>> print(si.rms)
     0.29337859596
     """
     pt = PeriodicTable()

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -12,7 +12,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from cclib.parser.utils import PeriodicTable
+from ..parser.utils import PeriodicTable
 
 
 def makebiopython(atomcoords, atomnos):

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -37,8 +37,3 @@ def makebiopython(atomcoords, atomnos):
         symbol = pt.element[atomno]
         bioatoms.append(Atom(symbol, coords, 0, 0, 0, symbol, 0, symbol.upper()))
     return bioatoms
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from cclib.parser.data import ccData
+from ..parser.data import ccData
 
 
 def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -21,12 +21,12 @@ def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):
 
     >>> import numpy, openbabel
     >>> atomnos = numpy.array([1, 8, 1], "i")
-    >>> coords = numpy.array([[-1., 1., 0.], [0., 0., 0.], [1., 1., 0.]])
-    >>> obmol = makeopenbabel(coords, atomnos)
+    >>> atomcoords = numpy.array([[[-1., 1., 0.], [0., 0., 0.], [1., 1., 0.]]])
+    >>> obmol = makeopenbabel(atomcoords, atomnos)
     >>> obconversion = openbabel.OBConversion()
     >>> formatok = obconversion.SetOutFormat("inchi")
     >>> print(obconversion.WriteString(obmol).strip())
-    InChI=1/H2O/h1H2
+    InChI=1S/H2O/h1H2
     """
     obmol = ob.OBMol()
     for i in range(len(atomnos)):

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -76,8 +76,3 @@ def readfile(fname, format):
     else:
         print("Unable to load the %s reader from OpenBabel." % format)
         return {}
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -25,7 +25,7 @@ def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):
     >>> obmol = makeopenbabel(coords, atomnos)
     >>> obconversion = openbabel.OBConversion()
     >>> formatok = obconversion.SetOutFormat("inchi")
-    >>> print obconversion.WriteString(obmol).strip()
+    >>> print(obconversion.WriteString(obmol).strip())
     InChI=1/H2O/h1H2
     """
     obmol = ob.OBMol()

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from ..parser.data import ccData
+from cclib.parser.data import ccData
 
 
 def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -27,8 +27,8 @@ def makepyquante(atomcoords, atomnos, charge=0, mult=1):
     >>> a = numpy.array([[-1,1,0],[0,0,0],[1,1,0]],"f")
     >>> pyqmol = makepyquante(a,atomnos)
     >>> en, orbe, orbs = hf(pyqmol)
-    >>> en
-    -75.8247540498
+    >>> ref = 75.824754
+    >>> assert abs(en - ref) < 1.0e-7
     """
     return Molecule("notitle", list(zip(atomnos, atomcoords)), units="Angstrom",
                     charge=charge, multiplicity=mult)

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -26,8 +26,8 @@ def makepyquante(atomcoords, atomnos, charge=0, mult=1):
     >>> atomnos = numpy.array([1,8,1],"i")
     >>> a = numpy.array([[-1,1,0],[0,0,0],[1,1,0]],"f")
     >>> pyqmol = makepyquante(a,atomnos)
-    >>> en,orbe,orbs = hf(pyqmol)
-    >>> print int(en * 10) / 10. # Should be around -73.8
+    >>> en, orbe, orbs = hf(pyqmol)
+    >>> print(en) # Should be around -73.8
     -73.8
     """
     return Molecule("notitle", list(zip(atomnos, atomcoords)), units="Angstrom",

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -27,8 +27,8 @@ def makepyquante(atomcoords, atomnos, charge=0, mult=1):
     >>> a = numpy.array([[-1,1,0],[0,0,0],[1,1,0]],"f")
     >>> pyqmol = makepyquante(a,atomnos)
     >>> en, orbe, orbs = hf(pyqmol)
-    >>> ref = 75.824754
-    >>> assert abs(en - ref) < 1.0e-7
+    >>> ref = -75.824754
+    >>> assert abs(en - ref) < 1.0e-6
     """
     return Molecule("notitle", list(zip(atomnos, atomcoords)), units="Angstrom",
                     charge=charge, multiplicity=mult)

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -27,8 +27,8 @@ def makepyquante(atomcoords, atomnos, charge=0, mult=1):
     >>> a = numpy.array([[-1,1,0],[0,0,0],[1,1,0]],"f")
     >>> pyqmol = makepyquante(a,atomnos)
     >>> en, orbe, orbs = hf(pyqmol)
-    >>> print(en) # Should be around -73.8
-    -73.8
+    >>> en
+    -75.8247540498
     """
     return Molecule("notitle", list(zip(atomnos, atomcoords)), units="Angstrom",
                     charge=charge, multiplicity=mult)

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -32,8 +32,3 @@ def makepyquante(atomcoords, atomnos, charge=0, mult=1):
     """
     return Molecule("notitle", list(zip(atomnos, atomcoords)), units="Angstrom",
                     charge=charge, multiplicity=mult)
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/src/cclib/io/__init__.py
+++ b/src/cclib/io/__init__.py
@@ -7,19 +7,19 @@
 
 """Contains all writers for standard chemical representations"""
 
-from .cjsonwriter import CJSON as CJSONWriter
-from .cmlwriter import CML
-from .xyzwriter import XYZ
-from .moldenwriter import MOLDEN
-from .wfxwriter import WFXWriter
-from .cjsonreader import CJSON as CJSONReader
+from cclib.io.cjsonwriter import CJSON as CJSONWriter
+from cclib.io.cmlwriter import CML
+from cclib.io.xyzwriter import XYZ
+from cclib.io.moldenwriter import MOLDEN
+from cclib.io.wfxwriter import WFXWriter
+from cclib.io.cjsonreader import CJSON as CJSONReader
 
 # This allows users to type:
 #   from cclib.io import ccopen
 #   from cclib.io import ccread
 #   from cclib.io import ccwrite
 #   from cclib.io import URL_PATTERN
-from .ccio import ccopen
-from .ccio import ccread
-from .ccio import ccwrite
-from .ccio import URL_PATTERN
+from cclib.io.ccio import ccopen
+from cclib.io.ccio import ccread
+from cclib.io.ccio import ccwrite
+from cclib.io.ccio import URL_PATTERN

--- a/src/cclib/io/ccio.py
+++ b/src/cclib/io/ccio.py
@@ -29,31 +29,31 @@ else:
     from urllib.request import urlopen
     from urllib.error import URLError
 
-from ..parser import logfileparser
-from ..parser import data
+from cclib.parser import logfileparser
+from cclib.parser import data
 
-from ..parser.adfparser import ADF
-from ..parser.daltonparser import DALTON
-from ..parser.gamessparser import GAMESS
-from ..parser.gamessukparser import GAMESSUK
-from ..parser.gaussianparser import Gaussian
-from ..parser.jaguarparser import Jaguar
-from ..parser.molproparser import Molpro
-from ..parser.mopacparser import MOPAC
-from ..parser.nwchemparser import NWChem
-from ..parser.orcaparser import ORCA
-from ..parser.psiparser import Psi
-from ..parser.qchemparser import QChem
+from cclib.parser.adfparser import ADF
+from cclib.parser.daltonparser import DALTON
+from cclib.parser.gamessparser import GAMESS
+from cclib.parser.gamessukparser import GAMESSUK
+from cclib.parser.gaussianparser import Gaussian
+from cclib.parser.jaguarparser import Jaguar
+from cclib.parser.molproparser import Molpro
+from cclib.parser.mopacparser import MOPAC
+from cclib.parser.nwchemparser import NWChem
+from cclib.parser.orcaparser import ORCA
+from cclib.parser.psiparser import Psi
+from cclib.parser.qchemparser import QChem
 
-from . import cjsonreader
-from . import cjsonwriter
-from . import cmlwriter
-from . import xyzwriter
-from . import moldenwriter
-from . import wfxwriter
+from cclib.io import cjsonreader
+from cclib.io import cjsonwriter
+from cclib.io import cmlwriter
+from cclib.io import xyzwriter
+from cclib.io import moldenwriter
+from cclib.io import wfxwriter
 
 try:
-    from ..bridge import cclib2openbabel
+    from cclib.bridge import cclib2openbabel
     _has_cclib2openbabel = True
 except ImportError:
     _has_cclib2openbabel = False

--- a/src/cclib/io/cjsonreader.py
+++ b/src/cclib/io/cjsonreader.py
@@ -7,7 +7,8 @@
 
 import json
 
-from ..parser.data import ccData
+from cclib.parser.data import ccData
+
 
 class CJSON:
     """ CJSON log file"""

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -214,7 +214,3 @@ class JSONIndentEncoder(json.JSONEncoder):
             return json.dumps(np.asscalar(o), cls=NumpyAwareJSONEncoder)
         else:
             return json.dumps(o, cls=NumpyAwareJSONEncoder)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -18,7 +18,7 @@ import json
 import numpy as np
 
 from . import filewriter
-from cclib.parser.data import ccData
+from ..parser.data import ccData
 
 class CJSON(filewriter.Writer):
     """A writer for chemical JSON (CJSON) files."""

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -17,8 +17,9 @@ import os.path
 import json
 import numpy as np
 
-from . import filewriter
-from ..parser.data import ccData
+from cclib.io import filewriter
+from cclib.parser.data import ccData
+
 
 class CJSON(filewriter.Writer):
     """A writer for chemical JSON (CJSON) files."""

--- a/src/cclib/io/cmlwriter.py
+++ b/src/cclib/io/cmlwriter.py
@@ -15,7 +15,7 @@ except ImportError:
 
 import xml.etree.cElementTree as ET
 
-from . import filewriter
+from cclib.io import filewriter
 
 
 class CML(filewriter.Writer):
@@ -43,7 +43,7 @@ class CML(filewriter.Writer):
         if self.jobfilename is not None:
             d['id'] = self.jobfilename
         _set_attrs(molecule, d)
-        
+
         # Form the listing of all the atoms present.
         atomArray = ET.SubElement(molecule, 'atomArray')
         if hasattr(self.ccdata, 'atomcoords') and hasattr(self.ccdata, 'atomnos'):
@@ -113,7 +113,3 @@ def _tostring(element, xml_declaration=True, encoding='utf-8', method='xml'):
                                   encoding=encoding,
                                   method=method)
     return b''.join(data).decode(encoding)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -8,7 +8,7 @@
 """Generic file writer and related tools"""
 
 try:
-    from ..bridge import makeopenbabel
+    from cclib.bridge import makeopenbabel
     import openbabel as ob
     import pybel as pb
     has_openbabel = True
@@ -18,7 +18,7 @@ except ImportError:
 from math import sqrt
 from collections import Iterable
 
-from ..parser.utils import PeriodicTable
+from cclib.parser.utils import PeriodicTable
 
 
 class MissingAttributeError(Exception):

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -8,7 +8,7 @@
 """Generic file writer and related tools"""
 
 try:
-    from cclib.bridge import makeopenbabel
+    from ..bridge import makeopenbabel
     import openbabel as ob
     import pybel as pb
     has_openbabel = True
@@ -18,7 +18,7 @@ except ImportError:
 from math import sqrt
 from collections import Iterable
 
-from cclib.parser.utils import PeriodicTable
+from ..parser.utils import PeriodicTable
 
 
 class MissingAttributeError(Exception):

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -127,7 +127,3 @@ class Writer(object):
                 indices.add(i)
             self.indices = indices
         return
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -11,7 +11,7 @@ import os.path
 import math
 import decimal
 
-from cclib.parser import utils
+from ..parser import utils
 from . import filewriter
 
 
@@ -241,7 +241,7 @@ class MoldenReformatter(object):
             line = line.replace('\n', '')
             # Replace multiple spaces with single spaces.
             line = ' '.join(line.split())
-            
+
             # Check for [Title] section.
             if '[title]' in line.lower():
                 line = next(filelines)

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -280,7 +280,3 @@ class MoldenReformatter(object):
                 lines.append(line)
 
         return '\n'.join(lines)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -11,8 +11,8 @@ import os.path
 import math
 import decimal
 
-from ..parser import utils
-from . import filewriter
+from cclib.parser import utils
+from cclib.io import filewriter
 
 
 def round_molden(num, p=6):

--- a/src/cclib/io/wfxwriter.py
+++ b/src/cclib/io/wfxwriter.py
@@ -511,7 +511,3 @@ class WFXWriter(filewriter.Writer):
 
         wfx_lines.append('')
         return '\n'.join(wfx_lines)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/wfxwriter.py
+++ b/src/cclib/io/wfxwriter.py
@@ -10,8 +10,8 @@
 import os.path
 import numpy
 
-from . import filewriter
-from ..parser import utils
+from cclib.io import filewriter
+from cclib.parser import utils
 
 
 # Number of orbitals of type key.

--- a/src/cclib/io/wfxwriter.py
+++ b/src/cclib/io/wfxwriter.py
@@ -9,9 +9,9 @@
 
 import os.path
 import numpy
-from cclib.parser import utils
 
 from . import filewriter
+from ..parser import utils
 
 
 # Number of orbitals of type key.

--- a/src/cclib/io/xyzwriter.py
+++ b/src/cclib/io/xyzwriter.py
@@ -7,7 +7,7 @@
 
 """A writer for XYZ (Cartesian coordinate) files."""
 
-from . import filewriter
+from cclib.io import filewriter
 
 
 class XYZ(filewriter.Writer):

--- a/src/cclib/io/xyzwriter.py
+++ b/src/cclib/io/xyzwriter.py
@@ -96,7 +96,3 @@ class XYZ(filewriter.Writer):
         for element, (x, y, z) in zip(self.element_list, atomcoords):
             block.append(atom_template.format(element, x, y, z))
         return '\n'.join(block)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/method/__init__.py
+++ b/src/cclib/method/__init__.py
@@ -7,15 +7,15 @@
 
 """Example analyses and calculations based on data parsed by cclib."""
 
-from .cda import CDA
-from .cspa import CSPA
-from .density import Density
-from .electrons import Electrons
-from .fragments import FragmentAnalysis
-from .lpa import LPA
-from .mbo import MBO
-from .mpa import MPA
-from .nuclear import Nuclear
-from .opa import OPA
-from .orbitals import Orbitals
-from .volume import Volume
+from cclib.method.cda import CDA
+from cclib.method.cspa import CSPA
+from cclib.method.density import Density
+from cclib.method.electrons import Electrons
+from cclib.method.fragments import FragmentAnalysis
+from cclib.method.lpa import LPA
+from cclib.method.mbo import MBO
+from cclib.method.mpa import MPA
+from cclib.method.nuclear import Nuclear
+from cclib.method.opa import OPA
+from cclib.method.orbitals import Orbitals
+from cclib.method.volume import Volume

--- a/src/cclib/method/calculationmethod.py
+++ b/src/cclib/method/calculationmethod.py
@@ -28,7 +28,7 @@ class Method(object):
         Volume - volume/grid calculations
 
     All the modules containing methods should be importable:
-    >>> import cda, cspa, density, fragments, lpa, mbo, mpa, nuclear, opa, population, volume
+    >>> from cclib.method import cda, cspa, density, fragments, lpa, mbo, mpa, nuclear, opa, population, volume
     """
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):

--- a/src/cclib/method/calculationmethod.py
+++ b/src/cclib/method/calculationmethod.py
@@ -48,8 +48,3 @@ class Method(object):
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter(self.logformat))
         self.logger.addHandler(handler)
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod(verbose=False)

--- a/src/cclib/method/cda.py
+++ b/src/cclib/method/cda.py
@@ -13,7 +13,7 @@ import random
 
 import numpy
 
-from .fragments import FragmentAnalysis
+from cclib.method.fragments import FragmentAnalysis
 
 
 class CDA(FragmentAnalysis):

--- a/src/cclib/method/cspa.py
+++ b/src/cclib/method/cspa.py
@@ -119,5 +119,6 @@ class CSPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, cspa
+    import doctest
+    from . import cspa
     doctest.testmod(cspa, verbose=False)

--- a/src/cclib/method/cspa.py
+++ b/src/cclib/method/cspa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class CSPA(Population):
@@ -120,5 +120,5 @@ class CSPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import cspa
+    from cclib.method import cspa
     doctest.testmod(cspa, verbose=False)

--- a/src/cclib/method/cspa.py
+++ b/src/cclib/method/cspa.py
@@ -116,9 +116,3 @@ class CSPA(Population):
             self.fragspins = numpy.subtract(alpha, beta)
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import cspa
-    doctest.testmod(cspa, verbose=False)

--- a/src/cclib/method/density.py
+++ b/src/cclib/method/density.py
@@ -12,7 +12,7 @@ import random
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Density(Method):

--- a/src/cclib/method/electrons.py
+++ b/src/cclib/method/electrons.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Electrons(Method):

--- a/src/cclib/method/electrons.py
+++ b/src/cclib/method/electrons.py
@@ -39,8 +39,3 @@ class Electrons(Method):
         if core:
             nelectrons += sum(self.data.coreelectrons)
         return nelectrons
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod(verbose=True)

--- a/src/cclib/method/fragments.py
+++ b/src/cclib/method/fragments.py
@@ -12,7 +12,7 @@ import random
 import numpy
 numpy.inv = numpy.linalg.inv
 
-from .calculationmethod import *
+from cclib.method.calculationmethod import Method
 
 
 class FragmentAnalysis(Method):

--- a/src/cclib/method/fragments.py
+++ b/src/cclib/method/fragments.py
@@ -7,6 +7,7 @@
 
 """Fragment analysis based on parsed ADF data."""
 
+import logging
 import random
 
 import numpy

--- a/src/cclib/method/lpa.py
+++ b/src/cclib/method/lpa.py
@@ -140,5 +140,6 @@ class LPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, lpa
+    import doctest
+    from . import lpa
     doctest.testmod(lpa, verbose=False)

--- a/src/cclib/method/lpa.py
+++ b/src/cclib/method/lpa.py
@@ -137,9 +137,3 @@ class LPA(Population):
             self.fragspins = numpy.subtract(alpha, beta)
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import lpa
-    doctest.testmod(lpa, verbose=False)

--- a/src/cclib/method/lpa.py
+++ b/src/cclib/method/lpa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class LPA(Population):
@@ -141,5 +141,5 @@ class LPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import lpa
+    from cclib.method import lpa
     doctest.testmod(lpa, verbose=False)

--- a/src/cclib/method/mbo.py
+++ b/src/cclib/method/mbo.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .density import Density
+from cclib.method.density import Density
 
 
 class MBO(Density):

--- a/src/cclib/method/mpa.py
+++ b/src/cclib/method/mpa.py
@@ -129,9 +129,3 @@ class MPA(Population):
             self.fragspins = numpy.subtract(alpha, beta)
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import mpa
-    doctest.testmod(mpa, verbose=False)

--- a/src/cclib/method/mpa.py
+++ b/src/cclib/method/mpa.py
@@ -132,5 +132,6 @@ class MPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, mpa
+    import doctest
+    from . import mpa
     doctest.testmod(mpa, verbose=False)

--- a/src/cclib/method/mpa.py
+++ b/src/cclib/method/mpa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class MPA(Population):
@@ -133,5 +133,5 @@ class MPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import mpa
+    from cclib.method import mpa
     doctest.testmod(mpa, verbose=False)

--- a/src/cclib/method/nuclear.py
+++ b/src/cclib/method/nuclear.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Nuclear(Method):

--- a/src/cclib/method/nuclear.py
+++ b/src/cclib/method/nuclear.py
@@ -42,8 +42,3 @@ class Nuclear(Method):
                 d = numpy.linalg.norm(ri-rj)
                 nre += zi*zj/d
         return nre
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod(verbose=True)

--- a/src/cclib/method/opa.py
+++ b/src/cclib/method/opa.py
@@ -136,9 +136,3 @@ class OPA(Method):
             self.progress.update(nstep, "Done")
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import opa
-    doctest.testmod(opa, verbose=False)

--- a/src/cclib/method/opa.py
+++ b/src/cclib/method/opa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 def func(x):
@@ -140,5 +140,5 @@ class OPA(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import opa
+    from cclib.method import opa
     doctest.testmod(opa, verbose=False)

--- a/src/cclib/method/opa.py
+++ b/src/cclib/method/opa.py
@@ -139,5 +139,6 @@ class OPA(Method):
 
 
 if __name__ == "__main__":
-    import doctest, opa
+    import doctest
+    from . import opa
     doctest.testmod(opa, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -52,9 +52,3 @@ class Orbitals(Method):
             return False
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import orbitals
-    doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -16,7 +16,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Orbitals(Method):
@@ -56,5 +56,5 @@ class Orbitals(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import orbitals
+    from cclib.method import orbitals
     doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -55,5 +55,6 @@ class Orbitals(Method):
 
 
 if __name__ == "__main__":
-    import doctest, orbitals
+    import doctest
+    from . import orbitals
     doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -92,5 +92,6 @@ class Population(Method):
 
 
 if __name__ == "__main__":
-    import doctest, population
+    import doctest
+    from . import population
     doctest.testmod(population, verbose=False)

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -89,9 +89,3 @@ class Population(Method):
         self.fragresults = results
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.method import population
-    doctest.testmod(population, verbose=False)

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Population(Method):
@@ -93,5 +93,5 @@ class Population(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import population
+    from cclib.method import population
     doctest.testmod(population, verbose=False)

--- a/src/cclib/method/volume.py
+++ b/src/cclib/method/volume.py
@@ -14,7 +14,7 @@ import numpy
 
 try:
     from PyQuante.CGBF import CGBF
-    from cclib.bridge import cclib2pyquante
+    from ..bridge import cclib2pyquante
     module_pyq = True
 except:
     module_pyq = False
@@ -26,7 +26,7 @@ try:
 except:
     module_pyvtk = False
 
-from cclib.parser.utils import convertor
+from ..parser.utils import convertor
 
 
 class Volume(object):
@@ -235,7 +235,7 @@ def electrondensity(coords, mocoeffslist, gbasis, volume):
     return density
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
 
     try:
         import psyco
@@ -243,7 +243,7 @@ if __name__=="__main__":
     except ImportError:
         pass
 
-    from cclib.io import ccopen
+    from ..io import ccopen
     import logging
     a = ccopen("../../../data/Gaussian/basicGaussian03/dvb_sp_basis.log")
     a.logger.setLevel(logging.ERROR)

--- a/src/cclib/method/volume.py
+++ b/src/cclib/method/volume.py
@@ -14,7 +14,7 @@ import numpy
 
 try:
     from PyQuante.CGBF import CGBF
-    from ..bridge import cclib2pyquante
+    from cclib.bridge import cclib2pyquante
     module_pyq = True
 except:
     module_pyq = False
@@ -26,7 +26,7 @@ try:
 except:
     module_pyvtk = False
 
-from ..parser.utils import convertor
+from cclib.parser.utils import convertor
 
 
 class Volume(object):
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     except ImportError:
         pass
 
-    from ..io import ccopen
+    from cclib.io import ccopen
     import logging
     a = ccopen("../../../data/Gaussian/basicGaussian03/dvb_sp_basis.log")
     a.logger.setLevel(logging.ERROR)

--- a/src/cclib/parser/__init__.py
+++ b/src/cclib/parser/__init__.py
@@ -14,21 +14,21 @@
 # they can use:
 #         from cclib.parser import Gaussian
 
-from .adfparser import ADF
-from .daltonparser import DALTON
-from .gamessparser import GAMESS
-from .gamessukparser import GAMESSUK
-from .gaussianparser import Gaussian
-from .jaguarparser import Jaguar
-from .molproparser import Molpro
-from .mopacparser import MOPAC
-from .nwchemparser import NWChem
-from .orcaparser import ORCA
-from .psiparser import Psi
-from .qchemparser import QChem
+from cclib.parser.adfparser import ADF
+from cclib.parser.daltonparser import DALTON
+from cclib.parser.gamessparser import GAMESS
+from cclib.parser.gamessukparser import GAMESSUK
+from cclib.parser.gaussianparser import Gaussian
+from cclib.parser.jaguarparser import Jaguar
+from cclib.parser.molproparser import Molpro
+from cclib.parser.mopacparser import MOPAC
+from cclib.parser.nwchemparser import NWChem
+from cclib.parser.orcaparser import ORCA
+from cclib.parser.psiparser import Psi
+from cclib.parser.qchemparser import QChem
 
-from .data import ccData
+from cclib.parser.data import ccData
 
 # This allows users to type:
 #         from cclib.parser import ccopen
-from ..io.ccio import ccopen
+from cclib.io.ccio import ccopen

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -14,8 +14,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class ADF(logfileparser.Logfile):
@@ -1160,5 +1160,5 @@ class ADF(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import adfparser
+    from cclib.parser import adfparser
     doctest.testmod(adfparser, verbose=False)

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -1159,5 +1159,6 @@ class ADF(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, adfparser
+    import doctest
+    from . import adfparser
     doctest.testmod(adfparser, verbose=False)

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -1156,9 +1156,3 @@ class ADF(logfileparser.Logfile):
                     self.polarizabilities.append(polarizability)
 
                 line = next(inputfile)
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import adfparser
-    doctest.testmod(adfparser, verbose=False)

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -45,8 +45,8 @@ class ADF(logfileparser.Logfile):
             their lowercase equivalent.
 
         >>> sym = ADF("dummyfile").normalisesym
-        >>> labels = ['A','s','A1','A1.g','Sigma','Pi','Delta','Phi','Sigma.g','A.g','AA','AAA','EE1','EEE1']
-        >>> map(sym,labels)
+        >>> labels = ['A', 's', 'A1', 'A1.g', 'Sigma', 'Pi', 'Delta', 'Phi', 'Sigma.g', 'A.g', 'AA', 'AAA', 'EE1', 'EEE1']
+        >>> list(map(sym, labels))
         ['A', 's', 'A1', 'A1g', 'sigma', 'pi', 'delta', 'phi', 'sigma.g', 'Ag', "A'", 'A"', "E1'", 'E1"']
         """
         greeks = ['Sigma', 'Pi', 'Delta', 'Phi']

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -1207,7 +1207,10 @@ class DALTON(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, daltonparser, sys
+    import doctest
+    import sys
+    from . import daltonparser
+
     if len(sys.argv) == 1:
         doctest.testmod(daltonparser, verbose=False)
 

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -1203,22 +1203,3 @@ class DALTON(logfileparser.Logfile):
         # fooverlaps
         # fragnames
         # frags
-
-
-
-if __name__ == "__main__":
-    import doctest
-    import sys
-    from cclib.parser import daltonparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(daltonparser, verbose=False)
-
-    if len(sys.argv) >= 2:
-        parser = daltonparser.DALTON(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -12,8 +12,8 @@ from __future__ import print_function
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class DALTON(logfileparser.Logfile):
@@ -1209,7 +1209,7 @@ class DALTON(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import daltonparser
+    from cclib.parser import daltonparser
 
     if len(sys.argv) == 1:
         doctest.testmod(daltonparser, verbose=False)

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -33,9 +33,7 @@ class DALTON(logfileparser.Logfile):
         return 'DALTON("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """Normalise the symmetries used by DALTON."""
-
-        # It appears that DALTON is using the correct labels.
+        """DALTON does not require normalizing symmetry labels."""
         return label
 
     def before_parsing(self):
@@ -54,7 +52,6 @@ class DALTON(logfileparser.Logfile):
         # Is the basis set from a single library file? This is true
         # when the first line is BASIS, false for INTGRL/ATOMBASIS.
         self.basislibrary = True
-
 
     def parse_geometry(self, lines):
         """Parse DALTON geometry lines into an atomcoords array."""

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -11,8 +11,8 @@
 import numpy
 from collections import namedtuple
 
-from cclib.method import Electrons
-from cclib.method import orbitals
+from ..method import Electrons
+from ..method import orbitals
 
 
 Attribute = namedtuple('Attribute', ['type', 'jsonKey', 'attributePath'])

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -11,8 +11,8 @@
 import numpy
 from collections import namedtuple
 
-from ..method import Electrons
-from ..method import orbitals
+from cclib.method import Electrons
+from cclib.method import orbitals
 
 
 Attribute = namedtuple('Attribute', ['type', 'jsonKey', 'attributePath'])
@@ -295,7 +295,7 @@ class ccData(object):
           .xyz - output a Cartesian XYZ file of the last coordinates available
         """
 
-        from ..io import ccwrite
+        from cclib.io import ccwrite
         outputstr = ccwrite(self, outputdest=filename, indices=indices,
                             *args, **kwargs)
         return outputstr

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -14,8 +14,8 @@ import re
 import numpy
 
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class GAMESS(logfileparser.Logfile):
@@ -1442,7 +1442,7 @@ class GAMESS(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import gamessparser
+    from cclib.parser import gamessparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gamessparser, verbose=False)

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -67,10 +67,9 @@ class GAMESS(logfileparser.Logfile):
             must be lower-cased
         (2) Two single quotation marks must be replaced by a double
 
-        >>> t = GAMESS("dummyfile").normalisesym
+        >>> sym = GAMESS("dummyfile").normalisesym
         >>> labels = ['A', 'A1', 'A1G', "A'", "A''", "AG"]
-        >>> answers = map(t, labels)
-        >>> print answers
+        >>> list(map(sym, labels))
         ['A', 'A1', 'A1g', "A'", 'A"', 'Ag']
         """
 
@@ -88,7 +87,7 @@ class GAMESS(logfileparser.Logfile):
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
-        
+
         # extract the version number first
         if line.find("GAMESS VERSION") >= 0:
             self.metadata["package_version"] = line.split()[4] + line.split()[5] + line.split()[6]

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -1437,21 +1437,3 @@ class GAMESS(logfileparser.Logfile):
                     i, j = coord_to_idx[tokens[1][0]], coord_to_idx[tokens[1][1]]
                     polarizability[i, j] = tokens[3]
             self.polarizabilities.append(polarizability)
-
-
-if __name__ == "__main__":
-    import doctest
-    import sys
-    from cclib.parser import gamessparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(gamessparser, verbose=False)
-
-    if len(sys.argv) >= 2:
-        parser = gamessparser.GAMESS(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -1440,7 +1440,10 @@ class GAMESS(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, gamessparser, sys
+    import doctest
+    import sys
+    from . import gamessparser
+
     if len(sys.argv) == 1:
         doctest.testmod(gamessparser, verbose=False)
 

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -12,8 +12,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class GAMESSUK(logfileparser.Logfile):

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -662,8 +662,3 @@ class GAMESSUK(logfileparser.Logfile):
                 line = inputfile.next()
 
             self.set_attribute('nooccnos', occupations)
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -36,11 +36,10 @@ class GAMESSUK(logfileparser.Logfile):
     def normalisesym(self, label):
         """Use standard symmetry labels instead of GAMESS UK labels.
 
-        >>> t = GAMESSUK("dummyfile.txt")
+        >>> sym = GAMESSUK("dummyfile.txt").normalisesym
         >>> labels = ['a', 'a1', 'ag', "a'", 'a"', "a''", "a1''", 'a1"']
         >>> labels.extend(["e1+", "e1-"])
-        >>> answer = [t.normalisesym(x) for x in labels]
-        >>> answer
+        >>> list(map(sym, labels))
         ['A', 'A1', 'Ag', "A'", 'A"', 'A"', 'A1"', 'A1"', 'E1', 'E1']
         """
         label = label.replace("''", '"').replace("+", "").replace("-", "")

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -1794,22 +1794,3 @@ class Gaussian(logfileparser.Logfile):
                 if not hasattr(self, 'optdone'):
                     self.optdone = []
                 self.optdone.append(len(self.optstatus) - 1)
-
-
-
-if __name__ == "__main__":
-    import doctest
-    import sys
-    from cclib.parser import gaussianparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(gaussianparser, verbose=False)
-
-    if len(sys.argv) >= 2:
-        parser = gaussianparser.Gaussian(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -43,7 +43,7 @@ class Gaussian(logfileparser.Logfile):
 
         >>> sym = Gaussian("dummyfile").normalisesym
         >>> labels = ['A1', 'AG', 'A1G', "SG", "PI", "PHI", "DLTA", 'DLTU', 'SGG']
-        >>> map(sym, labels)
+        >>> list(map(sym, labels))
         ['A1', 'Ag', 'A1g', 'sigma', 'pi', 'phi', 'delta', 'delta.u', 'sigma.g']
         """
         # note: DLT must come after DLTA

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -13,9 +13,9 @@ import re
 
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Gaussian(logfileparser.Logfile):
@@ -1800,7 +1800,7 @@ class Gaussian(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import gaussianparser
+    from cclib.parser import gaussianparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gaussianparser, verbose=False)

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -1798,7 +1798,9 @@ class Gaussian(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, gaussianparser, sys
+    import doctest
+    import sys
+    from . import gaussianparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gaussianparser, verbose=False)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -710,5 +710,6 @@ class Jaguar(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, jaguarparser
+    import doctest
+    from . import jaguarparser
     doctest.testmod(jaguarparser, verbose=False)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -12,8 +12,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Jaguar(logfileparser.Logfile):
@@ -711,5 +711,5 @@ class Jaguar(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import jaguarparser
+    from cclib.parser import jaguarparser
     doctest.testmod(jaguarparser, verbose=False)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -40,10 +40,9 @@ class Jaguar(logfileparser.Logfile):
         (2) Replace two p's by "
         (2) Replace any remaining single p's by '
 
-        >>> t = Jaguar("dummyfile").normalisesym
+        >>> sym = Jaguar("dummyfile").normalisesym
         >>> labels = ['A', 'A1', 'Ag', 'Ap', 'App', "A1p", "A1pp", "E1pp/Ap"]
-        >>> answers = map(t, labels)
-        >>> print answers
+        >>> list(map(sym, labels))
         ['A', 'A1', 'Ag', "A'", 'A"', "A1'", 'A1"', 'E1"']
         """
         ans = label.split("/")[0].replace("pp", '"').replace("p", "'")

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -707,9 +707,3 @@ class Jaguar(logfileparser.Logfile):
                 line = next(inputfile)
             strength = float(line.split()[-1])
             self.etoscs.append(strength)
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import jaguarparser
-    doctest.testmod(jaguarparser, verbose=False)

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -20,9 +20,9 @@ import zipfile
 
 import numpy
 
-from . import utils
-from .data import ccData
-from .data import ccData_optdone_bool
+from cclib.parser import utils
+from cclib.parser.data import ccData
+from cclib.parser.data import ccData_optdone_bool
 
 
 # This seems to avoid a problem with Avogadro.

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -378,7 +378,7 @@ class Logfile(object):
         contain appropriate doctests. If is not overwritten, this is detected
         as an error by unit tests.
         """
-        return "ERROR: This should be overwritten by this subclass"
+        raise NotImplementedError("normalisesym(self, symlabel) must be overriden by the parser.")
 
     def float(self, number):
         """Convert a string to a float.

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -469,8 +469,3 @@ class Logfile(object):
         return lines
 
     skip_line = lambda self, inputfile, expected: self.skip_lines(inputfile, [expected])
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -12,8 +12,8 @@ import itertools
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 def create_atomic_orbital_names(orbitals):
@@ -885,5 +885,5 @@ class Molpro(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import molproparser
+    from cclib.parser import molproparser
     doctest.testmod(molproparser, verbose=False)

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -884,5 +884,6 @@ class Molpro(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, molproparser
+    import doctest
+    from . import molproparser
     doctest.testmod(molproparser, verbose=False)

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -65,7 +65,10 @@ class Molpro(logfileparser.Logfile):
         return 'Molpro("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """Normalise the symmetries used by Molpro."""
+        """Normalise the symmetries used by Molpro.
+
+        TODO write doctest
+        """
         ans = label.replace("`", "'").replace("``", "''")
         return ans
 

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -881,9 +881,3 @@ class Molpro(logfileparser.Logfile):
             if not hasattr(self, "atomcharges"):
                 self.atomcharges = {}
             self.atomcharges['mulliken'] = charges
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import molproparser
-    doctest.testmod(molproparser, verbose=False)

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -233,7 +233,9 @@ class MOPAC(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, mopacparser, sys
+    import doctest
+    import sys
+    from . import mopacparser
 
     if len(sys.argv) == 1:
         doctest.testmod(mopacparser, verbose=False)

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -47,6 +47,7 @@ class MOPAC(logfileparser.Logfile):
 
     def normalisesym(self, label):
         """MOPAC does not require normalizing symmetry labels."""
+        return label
 
     def before_parsing(self):
         #TODO

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -231,21 +231,3 @@ class MOPAC(logfileparser.Logfile):
         # Partial charges and dipole moments
         # Example:
         # NET ATOMIC CHARGES
-
-
-if __name__ == "__main__":
-    import doctest
-    import sys
-    from cclib.parser import mopacparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(mopacparser, verbose=False)
-
-    if len(sys.argv) >= 2:
-        parser = mopacparser.MOPAC(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -14,14 +14,15 @@
 # Merged and modernized by Geoff Hutchison
 
 from __future__ import print_function
-import re
 
+import re
 import math
+
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 def symbol2int(symbol):
@@ -235,7 +236,7 @@ class MOPAC(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import mopacparser
+    from cclib.parser import mopacparser
 
     if len(sys.argv) == 1:
         doctest.testmod(mopacparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -1113,9 +1113,3 @@ class NWChem(logfileparser.Logfile):
                 for k in range(count):
                     temp = [x % (j + k + 1) for x in labels[label]]
                     self.aonames.extend([prefix + x for x in temp])
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import nwchemparser
-    doctest.testmod(nwchemparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -13,8 +13,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class NWChem(logfileparser.Logfile):
@@ -1117,5 +1117,5 @@ class NWChem(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import nwchemparser
+    from cclib.parser import nwchemparser
     doctest.testmod(nwchemparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -1116,5 +1116,6 @@ class NWChem(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, nwchemparser
+    import doctest
+    from . import nwchemparser
     doctest.testmod(nwchemparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -34,18 +34,7 @@ class NWChem(logfileparser.Logfile):
         return 'NWChem("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """Use standard symmetry labels instead of NWChem labels.
-
-        To normalise:
-        (1) If label is one of [SG, PI, PHI, DLTA], replace by [sigma, pi, phi, delta]
-        (2) replace any G or U by their lowercase equivalent
-
-        >>> sym = NWChem("dummyfile").normalisesym
-        >>> labels = ['A1', 'AG', 'A1G', "SG", "PI", "PHI", "DLTA", 'DLTU', 'SGG']
-        >>> map(sym, labels)
-        ['A1', 'Ag', 'A1g', 'sigma', 'pi', 'phi', 'delta', 'delta.u', 'sigma.g']
-        """
-        # FIXME if necessary
+        """NWChem does not require normalizing symmetry labels."""
         return label
 
     name2element = lambda self, lbl: "".join(itertools.takewhile(str.isalpha, str(lbl)))

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -12,8 +12,8 @@ from __future__ import print_function
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class ORCA(logfileparser.Logfile):
@@ -1164,7 +1164,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 if __name__ == "__main__":
     import sys
     import doctest
-    from . import orcaparser
+    from cclib.parser import orcaparser
 
     if len(sys.argv) == 1:
         doctest.testmod(orcaparser, verbose=False)

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -34,17 +34,8 @@ class ORCA(logfileparser.Logfile):
         return 'ORCA("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """Use standard symmetry labels instead of Gaussian labels.
-
-        To normalise:
-        (1) If label is one of [SG, PI, PHI, DLTA], replace by [sigma, pi, phi, delta]
-        (2) replace any G or U by their lowercase equivalent
-
-        >>> sym = Gaussian("dummyfile").normalisesym
-        >>> labels = ['A1', 'AG', 'A1G', "SG", "PI", "PHI", "DLTA", 'DLTU', 'SGG']
-        >>> map(sym, labels)
-        ['A1', 'Ag', 'A1g', 'sigma', 'pi', 'phi', 'delta', 'delta.u', 'sigma.g']
-        """
+        """ORCA does not require normalizing symmetry labels."""
+        return label
 
     def before_parsing(self):
 

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -1159,21 +1159,3 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 assert maxDP_target == self.scftargets[-1][1]
             self.scfvalues[-1].append([deltaE_value, maxDP_value, rmsDP_value])
             self.scftargets.append([deltaE_target, maxDP_target, rmsDP_target])
-
-
-if __name__ == "__main__":
-    import sys
-    import doctest
-    from cclib.parser import orcaparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(orcaparser, verbose=False)
-
-    if len(sys.argv) == 2:
-        parser = orcaparser.ORCA(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -1163,7 +1163,8 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 
 if __name__ == "__main__":
     import sys
-    import doctest, orcaparser
+    import doctest
+    from . import orcaparser
 
     if len(sys.argv) == 1:
         doctest.testmod(orcaparser, verbose=False)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -56,8 +56,7 @@ class Psi(logfileparser.Logfile):
                 self.set_attribute('natom', len(self.atomnos))
 
     def normalisesym(self, label):
-        """Use standard symmetry labels instead of Psi labels."""
-        # Psi uses the correct labels.
+        """Psi does not require normalizing symmetry labels."""
         return label
 
     def extract(self, inputfile, line):

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -1126,5 +1126,6 @@ class Psi(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, psiparser
+    import doctest
+    from . import psiparser
     doctest.testmod(psiparser, verbose=False)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -12,9 +12,9 @@ import re
 
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Psi(logfileparser.Logfile):
@@ -1127,5 +1127,5 @@ class Psi(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import psiparser
+    from cclib.parser import psiparser
     doctest.testmod(psiparser, verbose=False)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -1123,9 +1123,3 @@ class Psi(logfileparser.Logfile):
             return -float(vibfreq[:-1])
         else:
             return float(vibfreq)
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import psiparser
-    doctest.testmod(psiparser, verbose=False)

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -1394,7 +1394,8 @@ class QChem(logfileparser.Logfile):
 
 if __name__ == '__main__':
     import sys
-    import doctest, qchemparser
+    import doctest
+    from . import qchemparser
 
     if len(sys.argv) == 1:
         doctest.testmod(qchemparser, verbose=False)

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -37,6 +37,7 @@ class QChem(logfileparser.Logfile):
 
     def normalisesym(self, label):
         """Q-Chem does not require normalizing symmetry labels."""
+        return label
 
     def before_parsing(self):
 

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -1391,21 +1391,3 @@ class QChem(logfileparser.Logfile):
         # 'nocoeffs'
         # 'nooccnos'
         # 'vibanharms'
-
-
-if __name__ == '__main__':
-    import sys
-    import doctest
-    from cclib.parser import qchemparser
-
-    if len(sys.argv) == 1:
-        doctest.testmod(qchemparser, verbose=False)
-
-    if len(sys.argv) == 2:
-        parser = qchemparser.QChem(sys.argv[1])
-        data = parser.parse()
-
-    if len(sys.argv) > 2:
-        for i in range(len(sys.argv[2:])):
-            if hasattr(data, sys.argv[2 + i]):
-                print(getattr(data, sys.argv[2 + i]))

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -11,11 +11,12 @@ from __future__ import division
 from __future__ import print_function
 
 import re
-import numpy
 import itertools
 
-from . import logfileparser
-from . import utils
+import numpy
+
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class QChem(logfileparser.Logfile):
@@ -1395,7 +1396,7 @@ class QChem(logfileparser.Logfile):
 if __name__ == '__main__':
     import sys
     import doctest
-    from . import qchemparser
+    from cclib.parser import qchemparser
 
     if len(sys.argv) == 1:
         doctest.testmod(qchemparser, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -196,5 +196,5 @@ class WidthSplitter:
 
 if __name__ == "__main__":
     import doctest
-    from . import utils
+    from cclib.parser import utils
     doctest.testmod(utils, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -192,9 +192,3 @@ class WidthSplitter:
             while len(elements) and elements[-1] == '':
                 elements.pop()
         return elements
-
-
-if __name__ == "__main__":
-    import doctest
-    from cclib.parser import utils
-    doctest.testmod(utils, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -195,5 +195,6 @@ class WidthSplitter:
 
 
 if __name__ == "__main__":
-    import doctest, utils
+    import doctest
+    from . import utils
     doctest.testmod(utils, verbose=False)

--- a/src/cclib/progress/__init__.py
+++ b/src/cclib/progress/__init__.py
@@ -8,7 +8,7 @@
 import sys
 
 if 'PyQt4' in list(sys.modules.keys()):
-    from .qt4progress import Qt4Progress
+    from cclib.progress.qt4progress import Qt4Progress
 
-from .textprogress import TextProgress
+from cclib.progress.textprogress import TextProgress
 

--- a/src/cclib/progress/qt4progress.py
+++ b/src/cclib/progress/qt4progress.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-from PyQt4 import QtGui,QtCore
+from PyQt4 import QtGui, QtCore
 
 
 class Qt4Progress(QtGui.QProgressDialog):

--- a/src/cclib/progress/textprogress.py
+++ b/src/cclib/progress/textprogress.py
@@ -6,6 +6,7 @@
 # the terms of the BSD 3-Clause License.
 
 from __future__ import print_function
+
 import sys
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -7,4 +7,4 @@
 
 """Unit tests and parser data tests for cclib."""
 
-from data import *
+from .data import *

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -83,7 +83,7 @@ class GenericGeoOptTest(unittest.TestCase):
 
     def testnormalisesym(self):
         """Did this subclass overwrite normalisesym?"""
-        self.assertNotEquals(self.logfile.normalisesym("A"),"ERROR: This should be overwritten by this subclass")
+        self.logfile.normalisesym("A")
 
     def testhomos(self):
         """Is the index of the HOMO equal to 34?"""

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -117,7 +117,7 @@ class GenericSPTest(unittest.TestCase):
 
     def testnormalisesym(self):
         """Did this subclass overwrite normalisesym?"""
-        self.assertNotEquals(self.logfile.normalisesym("A"), "ERROR: This should be overwritten by this subclass")
+        self.logfile.normalisesym("A")
 
     @skipForParser('Molpro', '?')
     @skipForParser('ORCA', 'ORCA has no support for symmetry yet')

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -17,7 +17,8 @@ import unittest
 import numpy
 
 sys.path.append("..")
-from test_data import getdatafile
+
+from ..test_data import getdatafile
 from cclib.method import CDA
 from cclib.parser import Gaussian
 

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -17,12 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
-
 from cclib.method import Electrons
 from cclib.parser import Gaussian
 from cclib.parser import QChem
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class ElectronsTest(unittest.TestCase):

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -16,10 +16,12 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import MBO
 from cclib.parser import Gaussian
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class MBOTest(unittest.TestCase):

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -17,11 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import Nuclear
 from cclib.parser import QChem
 from cclib.parser import utils
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class NuclearTest(unittest.TestCase):

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -17,11 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import Orbitals
 from cclib.parser import Gaussian
 from cclib.parser import Psi
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class RestrictedCalculationTest(unittest.TestCase):

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -16,10 +16,12 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import MPA, LPA, CSPA
 from cclib.parser import Gaussian
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class GaussianMPATest(unittest.TestCase):

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -79,9 +79,9 @@ class FileWrapperTest(unittest.TestCase):
             contents = open(path).read()
             # This is fix strings not being unicode in Python2.
             try:
-              stdin = io.StringIO(contents)
+                stdin = io.StringIO(contents)
             except TypeError:
-              stdin = io.StringIO(unicode(contents))
+                stdin = io.StringIO(unicode(contents))
             stdin.seek = sys.stdin.seek
             data = cclib.io.ccopen(stdin).parse()
             self.assertEqual(get_attributes(data), expected_attributes)

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -110,9 +110,9 @@ class LogfileTest(unittest.TestCase):
         self.assertTrue(numpy.isnan(float("*****")))
 
     def test_normalisesym_base_class_error(self):
-        """Does this method return ERROR in base class?"""
+        """Does this method raise an error in the base class?"""
         normalisesym = cclib.parser.logfileparser.Logfile('').normalisesym
-        self.assertTrue("ERROR" in normalisesym(""))
+        self.assertRaises(NotImplementedError, normalisesym, 'Ag')
 
 
 if __name__ == "__main__":

--- a/test/regression.py
+++ b/test/regression.py
@@ -1670,7 +1670,7 @@ def make_regression_from_old_unittest(test_class):
     return old_unit_test
 
 
-def main(which=[], opt_traceback=False, opt_status=False, regdir=__regression_dir__):
+def test_regressions(which=[], opt_traceback=False, opt_status=False, regdir=__regression_dir__):
 
     # Build a list of regression files that can be found.
     try:
@@ -1852,4 +1852,4 @@ if __name__ == "__main__":
         opt_traceback = "--traceback" in sys.argv
         opt_status = "--status" in sys.argv
         which = [arg for arg in sys.argv[1:] if not arg in ["--status", "--traceback"]]
-        main(which, opt_traceback, opt_status)
+        test_regressions(which, opt_traceback, opt_status)

--- a/test/regression.py
+++ b/test/regression.py
@@ -66,11 +66,11 @@ from cclib.io import ccopen
 # way to import the relevant tests from cclib here.
 test_dir = os.path.realpath(os.path.dirname(__file__)) + "/../../test"
 sys.path.append(os.path.abspath(test_dir))
-from test_data import all_modules
-from test_data import all_parsers
-from test_data import module_names
-from test_data import parser_names
-from test_data import get_program_dir
+from .test_data import all_modules
+from .test_data import all_parsers
+from .test_data import module_names
+from .test_data import parser_names
+from .test_data import get_program_dir
 
 
 # We need this to point to files relative to this script.
@@ -1348,7 +1348,7 @@ def flatten(seq):
 def normalisefilename(filename):
     """Replace all non-alphanumeric symbols by underscores.
 
-    >>> import regression
+    >>> from . import regression
     >>> for x in [ "Gaussian/Gaussian03/Mo4OSibdt2-opt.log" ]:
     ...     print(regression.normalisefilename(x))
     ...

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -11,7 +11,8 @@ import sys
 import unittest
 
 sys.path.append("bridge")
-from testopenbabel import *
+
+from .bridge.testopenbabel import *
 
 
 if __name__ == "__main__":

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -274,7 +274,7 @@ def test_all(parsers=None, modules=None, status=False, terse=False, silent=True,
 
 
 if __name__ == "__main__":
-    
+
     # These allow the parsers and modules tested to be filtered on the command line
     # with any number of arguments. No matching parsers/modules implies all of them.
     parsers = {p: all_parsers[p] for p in parser_names if p in sys.argv} or None

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -37,7 +37,8 @@ module_names = [
     "MP", "CC", "CI", "TD", "TDun",             # Post-SCF calculations.
     "vib", "Polar", "Scan",                     # Other property calculations.
 ]
-all_modules = {tn: importlib.import_module('data.test' + tn) for tn in module_names}
+all_modules = {tn: importlib.import_module('.data.test' + tn, package='test')
+               for tn in module_names}
 
 
 def gettestdata():

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -11,14 +11,17 @@ import sys
 import unittest
 
 sys.path.append('io')
-from testccio import *
-from testfilewriter import *
-from testxyzwriter import *
-from testcjsonreader import *
-from testcjsonwriter import *
-from testmoldenwriter import *
 
-from testwfxwriter import *
+from .io.testccio import *
+
+from .io.testfilewriter import *
+from .io.testcjsonwriter import *
+from .io.testmoldenwriter import *
+from .io.testwfxwriter import *
+from .io.testxyzwriter import *
+
+from .io.testcjsonreader import *
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -11,11 +11,12 @@ import sys
 import unittest
 
 sys.path.append("method")
-from testcda import *
-from testmbo import *
-from testnuclear import *
-from testorbitals import *
-from testpopulation import *
+
+from .method.testcda import *
+from .method.testmbo import *
+from .method.testnuclear import *
+from .method.testorbitals import *
+from .method.testpopulation import *
 
 
 if __name__ == "__main__":

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -11,9 +11,10 @@ import sys
 import unittest
 
 sys.path.append('parser')
-from testdata import *
-from testlogfileparser import *
-from testutils import *
+
+from .parser.testdata import *
+from .parser.testlogfileparser import *
+from .parser.testutils import *
 
 
 if __name__ == "__main__":

--- a/test/testall.py
+++ b/test/testall.py
@@ -21,7 +21,7 @@ from .test_utils import *
 
 
 if __name__ == "__main__":
-	print("Running unit tests for data...")
-	test_data.test_all(silent=True, summary=False, visual_tests=False)
-	print("Running all other unit tests...")
-	unittest.main()
+    print("Running unit tests for data...")
+    test_data.test_all(silent=True, summary=False, visual_tests=False)
+    print("Running all other unit tests...")
+    unittest.main()

--- a/test/testall.py
+++ b/test/testall.py
@@ -11,13 +11,13 @@ from __future__ import print_function
 
 import unittest
 
-import test_data
+from . import test_data
 
-from test_bridge import *
-from test_io import *
-from test_method import *
-from test_parser import *
-from test_utils import *
+from .test_bridge import *
+from .test_io import *
+from .test_method import *
+from .test_parser import *
+from .test_utils import *
 
 
 if __name__ == "__main__":

--- a/travis/requirements_3.2.txt
+++ b/travis/requirements_3.2.txt
@@ -1,0 +1,3 @@
+pytest==2.9.2
+# coverage==3.7.1
+coverage<4

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -4,3 +4,4 @@
 # and `pytest-cov`.
 
 pytest -v --doctest-modules --capture=no --cov=cclib test
+pytest -v --capture=no --cov=cclib --cov-append -k test_regression test/regression.py

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -3,7 +3,7 @@
 # run_pytest.sh: Run pytest on cclib with coverage checking. Requires `pytest`
 # and `pytest-cov`.
 
-pytest -v --doctest-modules --capture=no --cov=cclib test
+pytest -v --doctest-modules --capture=no --cov=cclib src test
 cd data
 bash ./regression_download.sh
 cd ..

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -3,8 +3,6 @@
 # run_pytest.sh: Run pytest on cclib with coverage checking. Requires `pytest`
 # and `pytest-cov`.
 
-pytest -v --doctest-modules --capture=no --cov=cclib src test
-cd data
-bash ./regression_download.sh
-cd ..
+pytest -v --doctest-modules --capture=no --cov=cclib src test &&
+cd data && bash ./regression_download.sh && cd .. &&
 pytest -v --capture=no --cov=cclib --cov-append -k test_regression test/regression.py

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -3,4 +3,4 @@
 # run_pytest.sh: Run pytest on cclib with coverage checking. Requires `pytest`
 # and `pytest-cov`.
 
-pytest -v --doctest-modules --cov=cclib test
+pytest -v --doctest-modules --capture=no --cov=cclib test

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -3,6 +3,6 @@
 # run_pytest.sh: Run pytest on cclib with coverage checking. Requires `pytest`
 # and `pytest-cov`.
 
-pytest -v --doctest-modules --capture=no --cov=cclib src test &&
+python -m pytest -v --doctest-modules --capture=no --cov=cclib src test &&
 cd data && bash ./regression_download.sh && cd .. &&
-pytest -v --capture=no --cov=cclib --cov-append -k test_regression test/regression.py
+python -m pytest -v --capture=no --cov=cclib --cov-append -k test_regression test/regression.py

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -4,4 +4,7 @@
 # and `pytest-cov`.
 
 pytest -v --doctest-modules --capture=no --cov=cclib test
+cd data
+bash ./regression_download.sh
+cd ..
 pytest -v --capture=no --cov=cclib --cov-append -k test_regression test/regression.py

--- a/travis/run_pytest.sh
+++ b/travis/run_pytest.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# run_pytest.sh: Run pytest on cclib with coverage checking. Requires `pytest`
+# and `pytest-cov`.
+
+pytest -v --doctest-modules --cov=cclib test

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -9,4 +9,4 @@ python -m test.test_parser &&
 python -m test.test_io &&
 python -m test.test_data --status --terse &&
 cd data && bash regression_download.sh &&
-cd ../test && python -m test.regression --status --traceback
+cd .. && python -m test.regression --status --traceback

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -2,12 +2,11 @@
 
 # run_travis_tests.sh: Run the tests for Travis CI.
 
-cd test
-python test_bridge.py &&
-python test_utils.py &&
-python test_method.py &&
-python test_parser.py &&
-python test_io.py &&
-python test_data.py --status --terse &&
-cd ../data && bash regression_download.sh &&
+python -m test.test_bridge &&
+python -m test.test_utils &&
+python -m test.test_method &&
+python -m test.test_parser &&
+python -m test.test_io &&
+python -m test.test_data --status --terse &&
+cd data && bash regression_download.sh &&
 cd ../test && python regression.py --status --traceback

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -9,4 +9,4 @@ python -m test.test_parser &&
 python -m test.test_io &&
 python -m test.test_data --status --terse &&
 cd data && bash regression_download.sh &&
-cd ../test && python regression.py --status --traceback
+cd ../test && python -m test.regression --status --traceback


### PR DESCRIPTION
Issue: https://github.com/cclib/cclib/issues/455

For this to work, it also solves https://github.com/cclib/cclib/issues/367. Everything should be a module now.

Currently Travis is not running this, because the output style isn't great. pytest as a drop-in replacement works, but our tests (in particular regressions) are not in the "right" format. Maybe pytest is only useful for us to run while developing?

- [x] Can I remove all the `if __name__ == '__main__'` calls in the source? Maintaining that is difficult and I don't think they're ever run.