### PR TITLE
Fix: natom can't be parsed if number of atoms is > 9999 in Gaussian

### DIFF
--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -225,7 +225,7 @@ class Gaussian(logfileparser.Logfile):
 
             self.updateprogress(inputfile, "Attributes", self.fupdate)
 
-            natom = int(line.split()[1])
+            natom = int(line.split('=')[1].split()[0])
             self.set_attribute('natom', natom)
 
         # Basis set name

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -225,7 +225,7 @@ class Gaussian(logfileparser.Logfile):
 
             self.updateprogress(inputfile, "Attributes", self.fupdate)
 
-            natom = int(line.split('=')[1].split()[0])
+            natom = int(re.search('NAtoms=\s*(\d+)', line).group(1))
             self.set_attribute('natom', natom)
 
         # Basis set name


### PR DESCRIPTION
Currently, the `natom` attribute is obtained (among other sources) from this type of line:

`NAtoms=  280 NActive=  280 NUniq=  280 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=T Big=T`

However, in huge Gaussian files (QM/MM and such), the number of atoms can be very large, resulting in this type of line:

`NAtoms=10500 NActive=10500 NUniq=10500 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=T Big=T`

The current code assumes the number of atoms would be always the 2nd field after `line.split()`, but this fails for big numbers. This PR solves that.
