### PR TITLE
Switch completely to using absolute imports

### DIFF
--- a/src/cclib/__init__.py
+++ b/src/cclib/__init__.py
@@ -25,15 +25,15 @@ as well as example methods that take parsed data as input.
 
 __version__ = "1.5.2"
 
-from . import parser
-from . import progress
-from . import method
-from . import bridge
-from . import io
+from cclib import parser
+from cclib import progress
+from cclib import method
+from cclib import bridge
+from cclib import io
 
 # The test module can be imported if it was installed with cclib.
 try:
-    from . import test
+    from cclib import test
 except ImportError:
     pass
 

--- a/src/cclib/bridge/__init__.py
+++ b/src/cclib/bridge/__init__.py
@@ -12,18 +12,18 @@ try:
 except ImportError:
     pass
 else:
-    from .cclib2openbabel import makeopenbabel
+    from cclib.bridge.cclib2openbabel import makeopenbabel
 
 try:
     import PyQuante
 except ImportError:
     pass
 else:
-    from .cclib2pyquante import makepyquante
+    from cclib.bridge.cclib2pyquante import makepyquante
 
 try:
     import Bio
 except ImportError:
     pass
 else:
-    from .cclib2biopython import makebiopython
+    from cclib.bridge.cclib2biopython import makebiopython

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -12,7 +12,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from ..parser.utils import PeriodicTable
+from cclib.parser.utils import PeriodicTable
 
 
 def makebiopython(atomcoords, atomnos):

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -12,7 +12,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from cclib.parser.utils import PeriodicTable
+from ..parser.utils import PeriodicTable
 
 
 def makebiopython(atomcoords, atomnos):

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from cclib.parser.data import ccData
+from ..parser.data import ccData
 
 
 def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -13,7 +13,7 @@ except ImportError:
     # Fail silently for now.
     pass
 
-from ..parser.data import ccData
+from cclib.parser.data import ccData
 
 
 def makeopenbabel(atomcoords, atomnos, charge=0, mult=1):

--- a/src/cclib/io/__init__.py
+++ b/src/cclib/io/__init__.py
@@ -7,19 +7,19 @@
 
 """Contains all writers for standard chemical representations"""
 
-from .cjsonwriter import CJSON as CJSONWriter
-from .cmlwriter import CML
-from .xyzwriter import XYZ
-from .moldenwriter import MOLDEN
-from .wfxwriter import WFXWriter
-from .cjsonreader import CJSON as CJSONReader
+from cclib.io.cjsonwriter import CJSON as CJSONWriter
+from cclib.io.cmlwriter import CML
+from cclib.io.xyzwriter import XYZ
+from cclib.io.moldenwriter import MOLDEN
+from cclib.io.wfxwriter import WFXWriter
+from cclib.io.cjsonreader import CJSON as CJSONReader
 
 # This allows users to type:
 #   from cclib.io import ccopen
 #   from cclib.io import ccread
 #   from cclib.io import ccwrite
 #   from cclib.io import URL_PATTERN
-from .ccio import ccopen
-from .ccio import ccread
-from .ccio import ccwrite
-from .ccio import URL_PATTERN
+from cclib.io.ccio import ccopen
+from cclib.io.ccio import ccread
+from cclib.io.ccio import ccwrite
+from cclib.io.ccio import URL_PATTERN

--- a/src/cclib/io/ccio.py
+++ b/src/cclib/io/ccio.py
@@ -29,31 +29,31 @@ else:
     from urllib.request import urlopen
     from urllib.error import URLError
 
-from ..parser import logfileparser
-from ..parser import data
+from cclib.parser import logfileparser
+from cclib.parser import data
 
-from ..parser.adfparser import ADF
-from ..parser.daltonparser import DALTON
-from ..parser.gamessparser import GAMESS
-from ..parser.gamessukparser import GAMESSUK
-from ..parser.gaussianparser import Gaussian
-from ..parser.jaguarparser import Jaguar
-from ..parser.molproparser import Molpro
-from ..parser.mopacparser import MOPAC
-from ..parser.nwchemparser import NWChem
-from ..parser.orcaparser import ORCA
-from ..parser.psiparser import Psi
-from ..parser.qchemparser import QChem
+from cclib.parser.adfparser import ADF
+from cclib.parser.daltonparser import DALTON
+from cclib.parser.gamessparser import GAMESS
+from cclib.parser.gamessukparser import GAMESSUK
+from cclib.parser.gaussianparser import Gaussian
+from cclib.parser.jaguarparser import Jaguar
+from cclib.parser.molproparser import Molpro
+from cclib.parser.mopacparser import MOPAC
+from cclib.parser.nwchemparser import NWChem
+from cclib.parser.orcaparser import ORCA
+from cclib.parser.psiparser import Psi
+from cclib.parser.qchemparser import QChem
 
-from . import cjsonreader
-from . import cjsonwriter
-from . import cmlwriter
-from . import xyzwriter
-from . import moldenwriter
-from . import wfxwriter
+from cclib.io import cjsonreader
+from cclib.io import cjsonwriter
+from cclib.io import cmlwriter
+from cclib.io import xyzwriter
+from cclib.io import moldenwriter
+from cclib.io import wfxwriter
 
 try:
-    from ..bridge import cclib2openbabel
+    from cclib.bridge import cclib2openbabel
     _has_cclib2openbabel = True
 except ImportError:
     _has_cclib2openbabel = False

--- a/src/cclib/io/cjsonreader.py
+++ b/src/cclib/io/cjsonreader.py
@@ -7,7 +7,8 @@
 
 import json
 
-from ..parser.data import ccData
+from cclib.parser.data import ccData
+
 
 class CJSON:
     """ CJSON log file"""

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -18,7 +18,7 @@ import json
 import numpy as np
 
 from . import filewriter
-from cclib.parser.data import ccData
+from ..parser.data import ccData
 
 class CJSON(filewriter.Writer):
     """A writer for chemical JSON (CJSON) files."""

--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -17,8 +17,9 @@ import os.path
 import json
 import numpy as np
 
-from . import filewriter
-from ..parser.data import ccData
+from cclib.io import filewriter
+from cclib.parser.data import ccData
+
 
 class CJSON(filewriter.Writer):
     """A writer for chemical JSON (CJSON) files."""

--- a/src/cclib/io/cmlwriter.py
+++ b/src/cclib/io/cmlwriter.py
@@ -15,7 +15,7 @@ except ImportError:
 
 import xml.etree.cElementTree as ET
 
-from . import filewriter
+from cclib.io import filewriter
 
 
 class CML(filewriter.Writer):
@@ -43,7 +43,7 @@ class CML(filewriter.Writer):
         if self.jobfilename is not None:
             d['id'] = self.jobfilename
         _set_attrs(molecule, d)
-        
+
         # Form the listing of all the atoms present.
         atomArray = ET.SubElement(molecule, 'atomArray')
         if hasattr(self.ccdata, 'atomcoords') and hasattr(self.ccdata, 'atomnos'):
@@ -113,7 +113,3 @@ def _tostring(element, xml_declaration=True, encoding='utf-8', method='xml'):
                                   encoding=encoding,
                                   method=method)
     return b''.join(data).decode(encoding)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -8,7 +8,7 @@
 """Generic file writer and related tools"""
 
 try:
-    from ..bridge import makeopenbabel
+    from cclib.bridge import makeopenbabel
     import openbabel as ob
     import pybel as pb
     has_openbabel = True
@@ -18,7 +18,7 @@ except ImportError:
 from math import sqrt
 from collections import Iterable
 
-from ..parser.utils import PeriodicTable
+from cclib.parser.utils import PeriodicTable
 
 
 class MissingAttributeError(Exception):

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -8,7 +8,7 @@
 """Generic file writer and related tools"""
 
 try:
-    from cclib.bridge import makeopenbabel
+    from ..bridge import makeopenbabel
     import openbabel as ob
     import pybel as pb
     has_openbabel = True
@@ -18,7 +18,7 @@ except ImportError:
 from math import sqrt
 from collections import Iterable
 
-from cclib.parser.utils import PeriodicTable
+from ..parser.utils import PeriodicTable
 
 
 class MissingAttributeError(Exception):

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -11,7 +11,7 @@ import os.path
 import math
 import decimal
 
-from cclib.parser import utils
+from ..parser import utils
 from . import filewriter
 
 
@@ -241,7 +241,7 @@ class MoldenReformatter(object):
             line = line.replace('\n', '')
             # Replace multiple spaces with single spaces.
             line = ' '.join(line.split())
-            
+
             # Check for [Title] section.
             if '[title]' in line.lower():
                 line = next(filelines)

--- a/src/cclib/io/moldenwriter.py
+++ b/src/cclib/io/moldenwriter.py
@@ -11,8 +11,8 @@ import os.path
 import math
 import decimal
 
-from ..parser import utils
-from . import filewriter
+from cclib.parser import utils
+from cclib.io import filewriter
 
 
 def round_molden(num, p=6):

--- a/src/cclib/io/wfxwriter.py
+++ b/src/cclib/io/wfxwriter.py
@@ -10,8 +10,8 @@
 import os.path
 import numpy
 
-from . import filewriter
-from ..parser import utils
+from cclib.io import filewriter
+from cclib.parser import utils
 
 
 # Number of orbitals of type key.

--- a/src/cclib/io/wfxwriter.py
+++ b/src/cclib/io/wfxwriter.py
@@ -9,9 +9,9 @@
 
 import os.path
 import numpy
-from cclib.parser import utils
 
 from . import filewriter
+from ..parser import utils
 
 
 # Number of orbitals of type key.

--- a/src/cclib/io/xyzwriter.py
+++ b/src/cclib/io/xyzwriter.py
@@ -7,7 +7,7 @@
 
 """A writer for XYZ (Cartesian coordinate) files."""
 
-from . import filewriter
+from cclib.io import filewriter
 
 
 class XYZ(filewriter.Writer):

--- a/src/cclib/method/__init__.py
+++ b/src/cclib/method/__init__.py
@@ -7,15 +7,15 @@
 
 """Example analyses and calculations based on data parsed by cclib."""
 
-from .cda import CDA
-from .cspa import CSPA
-from .density import Density
-from .electrons import Electrons
-from .fragments import FragmentAnalysis
-from .lpa import LPA
-from .mbo import MBO
-from .mpa import MPA
-from .nuclear import Nuclear
-from .opa import OPA
-from .orbitals import Orbitals
-from .volume import Volume
+from cclib.method.cda import CDA
+from cclib.method.cspa import CSPA
+from cclib.method.density import Density
+from cclib.method.electrons import Electrons
+from cclib.method.fragments import FragmentAnalysis
+from cclib.method.lpa import LPA
+from cclib.method.mbo import MBO
+from cclib.method.mpa import MPA
+from cclib.method.nuclear import Nuclear
+from cclib.method.opa import OPA
+from cclib.method.orbitals import Orbitals
+from cclib.method.volume import Volume

--- a/src/cclib/method/cda.py
+++ b/src/cclib/method/cda.py
@@ -13,7 +13,7 @@ import random
 
 import numpy
 
-from .fragments import FragmentAnalysis
+from cclib.method.fragments import FragmentAnalysis
 
 
 class CDA(FragmentAnalysis):

--- a/src/cclib/method/cspa.py
+++ b/src/cclib/method/cspa.py
@@ -119,5 +119,6 @@ class CSPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, cspa
+    import doctest
+    from . import cspa
     doctest.testmod(cspa, verbose=False)

--- a/src/cclib/method/cspa.py
+++ b/src/cclib/method/cspa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class CSPA(Population):
@@ -120,5 +120,5 @@ class CSPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import cspa
+    from cclib.method import cspa
     doctest.testmod(cspa, verbose=False)

--- a/src/cclib/method/density.py
+++ b/src/cclib/method/density.py
@@ -12,7 +12,7 @@ import random
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Density(Method):

--- a/src/cclib/method/electrons.py
+++ b/src/cclib/method/electrons.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Electrons(Method):

--- a/src/cclib/method/fragments.py
+++ b/src/cclib/method/fragments.py
@@ -12,7 +12,7 @@ import random
 import numpy
 numpy.inv = numpy.linalg.inv
 
-from .calculationmethod import *
+from cclib.method.calculationmethod import Method
 
 
 class FragmentAnalysis(Method):

--- a/src/cclib/method/fragments.py
+++ b/src/cclib/method/fragments.py
@@ -7,6 +7,7 @@
 
 """Fragment analysis based on parsed ADF data."""
 
+import logging
 import random
 
 import numpy

--- a/src/cclib/method/lpa.py
+++ b/src/cclib/method/lpa.py
@@ -140,5 +140,6 @@ class LPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, lpa
+    import doctest
+    from . import lpa
     doctest.testmod(lpa, verbose=False)

--- a/src/cclib/method/lpa.py
+++ b/src/cclib/method/lpa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class LPA(Population):
@@ -141,5 +141,5 @@ class LPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import lpa
+    from cclib.method import lpa
     doctest.testmod(lpa, verbose=False)

--- a/src/cclib/method/mbo.py
+++ b/src/cclib/method/mbo.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .density import Density
+from cclib.method.density import Density
 
 
 class MBO(Density):

--- a/src/cclib/method/mpa.py
+++ b/src/cclib/method/mpa.py
@@ -132,5 +132,6 @@ class MPA(Population):
 
 
 if __name__ == "__main__":
-    import doctest, mpa
+    import doctest
+    from . import mpa
     doctest.testmod(mpa, verbose=False)

--- a/src/cclib/method/mpa.py
+++ b/src/cclib/method/mpa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .population import Population
+from cclib.method.population import Population
 
 
 class MPA(Population):
@@ -133,5 +133,5 @@ class MPA(Population):
 
 if __name__ == "__main__":
     import doctest
-    from . import mpa
+    from cclib.method import mpa
     doctest.testmod(mpa, verbose=False)

--- a/src/cclib/method/nuclear.py
+++ b/src/cclib/method/nuclear.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Nuclear(Method):

--- a/src/cclib/method/opa.py
+++ b/src/cclib/method/opa.py
@@ -11,7 +11,7 @@ import random
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 def func(x):
@@ -140,5 +140,5 @@ class OPA(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import opa
+    from cclib.method import opa
     doctest.testmod(opa, verbose=False)

--- a/src/cclib/method/opa.py
+++ b/src/cclib/method/opa.py
@@ -139,5 +139,6 @@ class OPA(Method):
 
 
 if __name__ == "__main__":
-    import doctest, opa
+    import doctest
+    from . import opa
     doctest.testmod(opa, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -16,7 +16,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Orbitals(Method):
@@ -56,5 +56,5 @@ class Orbitals(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import orbitals
+    from cclib.method import orbitals
     doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -55,5 +55,6 @@ class Orbitals(Method):
 
 
 if __name__ == "__main__":
-    import doctest, orbitals
+    import doctest
+    from . import orbitals
     doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -92,5 +92,6 @@ class Population(Method):
 
 
 if __name__ == "__main__":
-    import doctest, population
+    import doctest
+    from . import population
     doctest.testmod(population, verbose=False)

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy
 
-from .calculationmethod import Method
+from cclib.method.calculationmethod import Method
 
 
 class Population(Method):
@@ -93,5 +93,5 @@ class Population(Method):
 
 if __name__ == "__main__":
     import doctest
-    from . import population
+    from cclib.method import population
     doctest.testmod(population, verbose=False)

--- a/src/cclib/method/volume.py
+++ b/src/cclib/method/volume.py
@@ -14,7 +14,7 @@ import numpy
 
 try:
     from PyQuante.CGBF import CGBF
-    from cclib.bridge import cclib2pyquante
+    from ..bridge import cclib2pyquante
     module_pyq = True
 except:
     module_pyq = False
@@ -26,7 +26,7 @@ try:
 except:
     module_pyvtk = False
 
-from cclib.parser.utils import convertor
+from ..parser.utils import convertor
 
 
 class Volume(object):
@@ -235,7 +235,7 @@ def electrondensity(coords, mocoeffslist, gbasis, volume):
     return density
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
 
     try:
         import psyco
@@ -243,7 +243,7 @@ if __name__=="__main__":
     except ImportError:
         pass
 
-    from cclib.io import ccopen
+    from ..io import ccopen
     import logging
     a = ccopen("../../../data/Gaussian/basicGaussian03/dvb_sp_basis.log")
     a.logger.setLevel(logging.ERROR)

--- a/src/cclib/method/volume.py
+++ b/src/cclib/method/volume.py
@@ -14,7 +14,7 @@ import numpy
 
 try:
     from PyQuante.CGBF import CGBF
-    from ..bridge import cclib2pyquante
+    from cclib.bridge import cclib2pyquante
     module_pyq = True
 except:
     module_pyq = False
@@ -26,7 +26,7 @@ try:
 except:
     module_pyvtk = False
 
-from ..parser.utils import convertor
+from cclib.parser.utils import convertor
 
 
 class Volume(object):
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     except ImportError:
         pass
 
-    from ..io import ccopen
+    from cclib.io import ccopen
     import logging
     a = ccopen("../../../data/Gaussian/basicGaussian03/dvb_sp_basis.log")
     a.logger.setLevel(logging.ERROR)

--- a/src/cclib/parser/__init__.py
+++ b/src/cclib/parser/__init__.py
@@ -14,21 +14,21 @@
 # they can use:
 #         from cclib.parser import Gaussian
 
-from .adfparser import ADF
-from .daltonparser import DALTON
-from .gamessparser import GAMESS
-from .gamessukparser import GAMESSUK
-from .gaussianparser import Gaussian
-from .jaguarparser import Jaguar
-from .molproparser import Molpro
-from .mopacparser import MOPAC
-from .nwchemparser import NWChem
-from .orcaparser import ORCA
-from .psiparser import Psi
-from .qchemparser import QChem
+from cclib.parser.adfparser import ADF
+from cclib.parser.daltonparser import DALTON
+from cclib.parser.gamessparser import GAMESS
+from cclib.parser.gamessukparser import GAMESSUK
+from cclib.parser.gaussianparser import Gaussian
+from cclib.parser.jaguarparser import Jaguar
+from cclib.parser.molproparser import Molpro
+from cclib.parser.mopacparser import MOPAC
+from cclib.parser.nwchemparser import NWChem
+from cclib.parser.orcaparser import ORCA
+from cclib.parser.psiparser import Psi
+from cclib.parser.qchemparser import QChem
 
-from .data import ccData
+from cclib.parser.data import ccData
 
 # This allows users to type:
 #         from cclib.parser import ccopen
-from ..io.ccio import ccopen
+from cclib.io.ccio import ccopen

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -14,8 +14,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class ADF(logfileparser.Logfile):
@@ -1160,5 +1160,5 @@ class ADF(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import adfparser
+    from cclib.parser import adfparser
     doctest.testmod(adfparser, verbose=False)

--- a/src/cclib/parser/adfparser.py
+++ b/src/cclib/parser/adfparser.py
@@ -1159,5 +1159,6 @@ class ADF(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, adfparser
+    import doctest
+    from . import adfparser
     doctest.testmod(adfparser, verbose=False)

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -1207,7 +1207,10 @@ class DALTON(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, daltonparser, sys
+    import doctest
+    import sys
+    from . import daltonparser
+
     if len(sys.argv) == 1:
         doctest.testmod(daltonparser, verbose=False)
 

--- a/src/cclib/parser/daltonparser.py
+++ b/src/cclib/parser/daltonparser.py
@@ -12,8 +12,8 @@ from __future__ import print_function
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class DALTON(logfileparser.Logfile):
@@ -1209,7 +1209,7 @@ class DALTON(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import daltonparser
+    from cclib.parser import daltonparser
 
     if len(sys.argv) == 1:
         doctest.testmod(daltonparser, verbose=False)

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -11,8 +11,8 @@
 import numpy
 from collections import namedtuple
 
-from cclib.method import Electrons
-from cclib.method import orbitals
+from ..method import Electrons
+from ..method import orbitals
 
 
 Attribute = namedtuple('Attribute', ['type', 'jsonKey', 'attributePath'])

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -11,8 +11,8 @@
 import numpy
 from collections import namedtuple
 
-from ..method import Electrons
-from ..method import orbitals
+from cclib.method import Electrons
+from cclib.method import orbitals
 
 
 Attribute = namedtuple('Attribute', ['type', 'jsonKey', 'attributePath'])
@@ -295,7 +295,7 @@ class ccData(object):
           .xyz - output a Cartesian XYZ file of the last coordinates available
         """
 
-        from ..io import ccwrite
+        from cclib.io import ccwrite
         outputstr = ccwrite(self, outputdest=filename, indices=indices,
                             *args, **kwargs)
         return outputstr

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -14,8 +14,8 @@ import re
 import numpy
 
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class GAMESS(logfileparser.Logfile):
@@ -1442,7 +1442,7 @@ class GAMESS(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import gamessparser
+    from cclib.parser import gamessparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gamessparser, verbose=False)

--- a/src/cclib/parser/gamessparser.py
+++ b/src/cclib/parser/gamessparser.py
@@ -1440,7 +1440,10 @@ class GAMESS(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, gamessparser, sys
+    import doctest
+    import sys
+    from . import gamessparser
+
     if len(sys.argv) == 1:
         doctest.testmod(gamessparser, verbose=False)
 

--- a/src/cclib/parser/gamessukparser.py
+++ b/src/cclib/parser/gamessukparser.py
@@ -12,8 +12,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class GAMESSUK(logfileparser.Logfile):

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -13,9 +13,9 @@ import re
 
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Gaussian(logfileparser.Logfile):
@@ -1800,7 +1800,7 @@ class Gaussian(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import gaussianparser
+    from cclib.parser import gaussianparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gaussianparser, verbose=False)

--- a/src/cclib/parser/gaussianparser.py
+++ b/src/cclib/parser/gaussianparser.py
@@ -1798,7 +1798,9 @@ class Gaussian(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, gaussianparser, sys
+    import doctest
+    import sys
+    from . import gaussianparser
 
     if len(sys.argv) == 1:
         doctest.testmod(gaussianparser, verbose=False)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -710,5 +710,6 @@ class Jaguar(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, jaguarparser
+    import doctest
+    from . import jaguarparser
     doctest.testmod(jaguarparser, verbose=False)

--- a/src/cclib/parser/jaguarparser.py
+++ b/src/cclib/parser/jaguarparser.py
@@ -12,8 +12,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Jaguar(logfileparser.Logfile):
@@ -711,5 +711,5 @@ class Jaguar(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import jaguarparser
+    from cclib.parser import jaguarparser
     doctest.testmod(jaguarparser, verbose=False)

--- a/src/cclib/parser/logfileparser.py
+++ b/src/cclib/parser/logfileparser.py
@@ -20,9 +20,9 @@ import zipfile
 
 import numpy
 
-from . import utils
-from .data import ccData
-from .data import ccData_optdone_bool
+from cclib.parser import utils
+from cclib.parser.data import ccData
+from cclib.parser.data import ccData_optdone_bool
 
 
 # This seems to avoid a problem with Avogadro.

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -12,8 +12,8 @@ import itertools
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 def create_atomic_orbital_names(orbitals):
@@ -900,5 +900,5 @@ class Molpro(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import molproparser
+    from cclib.parser import molproparser
     doctest.testmod(molproparser, verbose=False)

--- a/src/cclib/parser/molproparser.py
+++ b/src/cclib/parser/molproparser.py
@@ -899,5 +899,6 @@ class Molpro(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, molproparser
+    import doctest
+    from . import molproparser
     doctest.testmod(molproparser, verbose=False)

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -233,7 +233,9 @@ class MOPAC(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, mopacparser, sys
+    import doctest
+    import sys
+    from . import mopacparser
 
     if len(sys.argv) == 1:
         doctest.testmod(mopacparser, verbose=False)

--- a/src/cclib/parser/mopacparser.py
+++ b/src/cclib/parser/mopacparser.py
@@ -14,14 +14,15 @@
 # Merged and modernized by Geoff Hutchison
 
 from __future__ import print_function
-import re
 
+import re
 import math
+
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 def symbol2int(symbol):
@@ -235,7 +236,7 @@ class MOPAC(logfileparser.Logfile):
 if __name__ == "__main__":
     import doctest
     import sys
-    from . import mopacparser
+    from cclib.parser import mopacparser
 
     if len(sys.argv) == 1:
         doctest.testmod(mopacparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -13,8 +13,8 @@ import re
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class NWChem(logfileparser.Logfile):
@@ -1117,5 +1117,5 @@ class NWChem(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import nwchemparser
+    from cclib.parser import nwchemparser
     doctest.testmod(nwchemparser, verbose=False)

--- a/src/cclib/parser/nwchemparser.py
+++ b/src/cclib/parser/nwchemparser.py
@@ -1116,5 +1116,6 @@ class NWChem(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, nwchemparser
+    import doctest
+    from . import nwchemparser
     doctest.testmod(nwchemparser, verbose=False)

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -12,8 +12,8 @@ from __future__ import print_function
 
 import numpy
 
-from . import logfileparser
-from . import utils
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class ORCA(logfileparser.Logfile):
@@ -1164,7 +1164,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 if __name__ == "__main__":
     import sys
     import doctest
-    from . import orcaparser
+    from cclib.parser import orcaparser
 
     if len(sys.argv) == 1:
         doctest.testmod(orcaparser, verbose=False)

--- a/src/cclib/parser/orcaparser.py
+++ b/src/cclib/parser/orcaparser.py
@@ -1163,7 +1163,8 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 
 if __name__ == "__main__":
     import sys
-    import doctest, orcaparser
+    import doctest
+    from . import orcaparser
 
     if len(sys.argv) == 1:
         doctest.testmod(orcaparser, verbose=False)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -1126,5 +1126,6 @@ class Psi(logfileparser.Logfile):
 
 
 if __name__ == "__main__":
-    import doctest, psiparser
+    import doctest
+    from . import psiparser
     doctest.testmod(psiparser, verbose=False)

--- a/src/cclib/parser/psiparser.py
+++ b/src/cclib/parser/psiparser.py
@@ -12,9 +12,9 @@ import re
 
 import numpy
 
-from . import data
-from . import logfileparser
-from . import utils
+from cclib.parser import data
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class Psi(logfileparser.Logfile):
@@ -1127,5 +1127,5 @@ class Psi(logfileparser.Logfile):
 
 if __name__ == "__main__":
     import doctest
-    from . import psiparser
+    from cclib.parser import psiparser
     doctest.testmod(psiparser, verbose=False)

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -1394,7 +1394,8 @@ class QChem(logfileparser.Logfile):
 
 if __name__ == '__main__':
     import sys
-    import doctest, qchemparser
+    import doctest
+    from . import qchemparser
 
     if len(sys.argv) == 1:
         doctest.testmod(qchemparser, verbose=False)

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -11,11 +11,12 @@ from __future__ import division
 from __future__ import print_function
 
 import re
-import numpy
 import itertools
 
-from . import logfileparser
-from . import utils
+import numpy
+
+from cclib.parser import logfileparser
+from cclib.parser import utils
 
 
 class QChem(logfileparser.Logfile):
@@ -1395,7 +1396,7 @@ class QChem(logfileparser.Logfile):
 if __name__ == '__main__':
     import sys
     import doctest
-    from . import qchemparser
+    from cclib.parser import qchemparser
 
     if len(sys.argv) == 1:
         doctest.testmod(qchemparser, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -196,5 +196,5 @@ class WidthSplitter:
 
 if __name__ == "__main__":
     import doctest
-    from . import utils
+    from cclib.parser import utils
     doctest.testmod(utils, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -195,5 +195,6 @@ class WidthSplitter:
 
 
 if __name__ == "__main__":
-    import doctest, utils
+    import doctest
+    from . import utils
     doctest.testmod(utils, verbose=False)

--- a/src/cclib/progress/__init__.py
+++ b/src/cclib/progress/__init__.py
@@ -8,7 +8,7 @@
 import sys
 
 if 'PyQt4' in list(sys.modules.keys()):
-    from .qt4progress import Qt4Progress
+    from cclib.progress.qt4progress import Qt4Progress
 
-from .textprogress import TextProgress
+from cclib.progress.textprogress import TextProgress
 

--- a/src/cclib/progress/textprogress.py
+++ b/src/cclib/progress/textprogress.py
@@ -6,6 +6,7 @@
 # the terms of the BSD 3-Clause License.
 
 from __future__ import print_function
+
 import sys
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -7,4 +7,4 @@
 
 """Unit tests and parser data tests for cclib."""
 
-from data import *
+from .data import *

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -149,7 +149,7 @@ class QChemBigBasisTest(GenericBigBasisTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['Basis'])

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -28,7 +28,7 @@ class GenericCCTest(unittest.TestCase):
 if __name__ == "__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['CC'])

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -143,7 +143,7 @@ class QChemCISTest(GenericCISTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['CI'])

--- a/test/data/testCore.py
+++ b/test/data/testCore.py
@@ -51,7 +51,7 @@ class JaguarCoreTest(GenericCoreTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['Suite'])

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -310,7 +310,7 @@ class PsiGeoOptTest(GenericGeoOptTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['GeoOpt'])

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -87,7 +87,7 @@ class QChemMP4SDTQTest(GenericMP2Test):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['MP'])

--- a/test/data/testPolar.py
+++ b/test/data/testPolar.py
@@ -55,7 +55,7 @@ class ReferencePolarTest(GenericPolarTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['Polar'])

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -314,7 +314,7 @@ class OrcaSPTest(GenericSPTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['SP'])

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -158,7 +158,7 @@ class JaguarSPunTest(GenericSPunTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['SPun'])

--- a/test/data/testScan.py
+++ b/test/data/testScan.py
@@ -112,7 +112,7 @@ class OrcaScanTest(GenericScanTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['Scan'])

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -179,7 +179,7 @@ class GenericTDDFTtrpTest(GenericTDTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['TD'])

--- a/test/data/testTDun.py
+++ b/test/data/testTDun.py
@@ -52,7 +52,7 @@ class GenericTDunTest(unittest.TestCase):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['TDun'])

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -225,7 +225,7 @@ class QChemRamanTest(GenericRamanTest):
 if __name__=="__main__":
 
     import sys
-    sys.path.append(os.path.join(__filedir__, ".."))
+    sys.path.insert(1, os.path.join(__filedir__, ".."))
 
     from test_data import DataSuite
     suite = DataSuite(['vib'])

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 from cclib.method import CDA

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -17,7 +17,8 @@ import unittest
 import numpy
 
 sys.path.append("..")
-from test_data import getdatafile
+
+from ..test_data import getdatafile
 from cclib.method import CDA
 from cclib.parser import Gaussian
 

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -21,7 +21,7 @@ from cclib.method import Electrons
 from cclib.parser import Gaussian
 from cclib.parser import QChem
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -17,12 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
-
 from cclib.method import Electrons
 from cclib.parser import Gaussian
 from cclib.parser import QChem
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class ElectronsTest(unittest.TestCase):

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -16,10 +16,12 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import MBO
 from cclib.parser import Gaussian
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class MBOTest(unittest.TestCase):

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -19,7 +19,7 @@ import numpy
 from cclib.method import MBO
 from cclib.parser import Gaussian
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -17,11 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import Nuclear
 from cclib.parser import QChem
 from cclib.parser import utils
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class NuclearTest(unittest.TestCase):

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -21,7 +21,7 @@ from cclib.method import Nuclear
 from cclib.parser import QChem
 from cclib.parser import utils
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -17,11 +17,13 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import Orbitals
 from cclib.parser import Gaussian
 from cclib.parser import Psi
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class RestrictedCalculationTest(unittest.TestCase):

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -21,7 +21,7 @@ from cclib.method import Orbitals
 from cclib.parser import Gaussian
 from cclib.parser import Psi
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -16,10 +16,12 @@ import unittest
 
 import numpy
 
-sys.path.append("..")
-from test_data import getdatafile
 from cclib.method import MPA, LPA, CSPA
 from cclib.parser import Gaussian
+
+sys.path.append("..")
+
+from ..test_data import getdatafile
 
 
 class GaussianMPATest(unittest.TestCase):

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -19,7 +19,7 @@ import numpy
 from cclib.method import MPA, LPA, CSPA
 from cclib.parser import Gaussian
 
-sys.path.append("..")
+sys.path.insert(1, "..")
 
 from ..test_data import getdatafile
 

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -79,9 +79,9 @@ class FileWrapperTest(unittest.TestCase):
             contents = open(path).read()
             # This is fix strings not being unicode in Python2.
             try:
-              stdin = io.StringIO(contents)
+                stdin = io.StringIO(contents)
             except TypeError:
-              stdin = io.StringIO(unicode(contents))
+                stdin = io.StringIO(unicode(contents))
             stdin.seek = sys.stdin.seek
             data = cclib.io.ccopen(stdin).parse()
             self.assertEqual(get_attributes(data), expected_attributes)

--- a/test/regression.py
+++ b/test/regression.py
@@ -65,7 +65,7 @@ from cclib.io import ccopen
 # within the cclib repository. It would be better to figure out a more natural
 # way to import the relevant tests from cclib here.
 test_dir = os.path.realpath(os.path.dirname(__file__)) + "/../../test"
-sys.path.append(os.path.abspath(test_dir))
+sys.path.insert(1, os.path.abspath(test_dir))
 from .test_data import all_modules
 from .test_data import all_parsers
 from .test_data import module_names

--- a/test/regression.py
+++ b/test/regression.py
@@ -66,11 +66,11 @@ from cclib.io import ccopen
 # way to import the relevant tests from cclib here.
 test_dir = os.path.realpath(os.path.dirname(__file__)) + "/../../test"
 sys.path.append(os.path.abspath(test_dir))
-from test_data import all_modules
-from test_data import all_parsers
-from test_data import module_names
-from test_data import parser_names
-from test_data import get_program_dir
+from .test_data import all_modules
+from .test_data import all_parsers
+from .test_data import module_names
+from .test_data import parser_names
+from .test_data import get_program_dir
 
 
 # We need this to point to files relative to this script.
@@ -1348,7 +1348,7 @@ def flatten(seq):
 def normalisefilename(filename):
     """Replace all non-alphanumeric symbols by underscores.
 
-    >>> import regression
+    >>> from . import regression
     >>> for x in [ "Gaussian/Gaussian03/Mo4OSibdt2-opt.log" ]:
     ...     print(regression.normalisefilename(x))
     ...

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -10,7 +10,7 @@
 import sys
 import unittest
 
-sys.path.append("bridge")
+sys.path.insert(1, "bridge")
 
 from .bridge.testopenbabel import *
 

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -11,7 +11,8 @@ import sys
 import unittest
 
 sys.path.append("bridge")
-from testopenbabel import *
+
+from .bridge.testopenbabel import *
 
 
 if __name__ == "__main__":

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -274,7 +274,7 @@ def test_all(parsers=None, modules=None, status=False, terse=False, silent=True,
 
 
 if __name__ == "__main__":
-    
+
     # These allow the parsers and modules tested to be filtered on the command line
     # with any number of arguments. No matching parsers/modules implies all of them.
     parsers = {p: all_parsers[p] for p in parser_names if p in sys.argv} or None

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -22,7 +22,7 @@ __filedir__ = os.path.realpath(os.path.dirname(__file__))
 
 # We need this in Python3 for importing things from the same directory
 # within the unit test files.
-sys.path.append(os.path.join(__filedir__, 'data'))
+sys.path.insert(1, os.path.join(__filedir__, 'data'))
 
 
 parser_names = [

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -37,7 +37,8 @@ module_names = [
     "MP", "CC", "CI", "TD", "TDun",             # Post-SCF calculations.
     "vib", "Polar", "Scan",                     # Other property calculations.
 ]
-all_modules = {tn: importlib.import_module('data.test' + tn) for tn in module_names}
+all_modules = {tn: importlib.import_module('.data.test' + tn, package='test')
+               for tn in module_names}
 
 
 def gettestdata():

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -11,14 +11,17 @@ import sys
 import unittest
 
 sys.path.append('io')
-from testccio import *
-from testfilewriter import *
-from testxyzwriter import *
-from testcjsonreader import *
-from testcjsonwriter import *
-from testmoldenwriter import *
 
-from testwfxwriter import *
+from .io.testccio import *
+
+from .io.testfilewriter import *
+from .io.testcjsonwriter import *
+from .io.testmoldenwriter import *
+from .io.testwfxwriter import *
+from .io.testxyzwriter import *
+
+from .io.testcjsonreader import *
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -10,7 +10,7 @@
 import sys
 import unittest
 
-sys.path.append('io')
+sys.path.insert(1, 'io')
 
 from .io.testccio import *
 

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -11,11 +11,12 @@ import sys
 import unittest
 
 sys.path.append("method")
-from testcda import *
-from testmbo import *
-from testnuclear import *
-from testorbitals import *
-from testpopulation import *
+
+from .method.testcda import *
+from .method.testmbo import *
+from .method.testnuclear import *
+from .method.testorbitals import *
+from .method.testpopulation import *
 
 
 if __name__ == "__main__":

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -10,7 +10,7 @@
 import sys
 import unittest
 
-sys.path.append("method")
+sys.path.insert(1, "method")
 
 from .method.testcda import *
 from .method.testmbo import *

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -10,7 +10,7 @@
 import sys
 import unittest
 
-sys.path.append('parser')
+sys.path.insert(1, 'parser')
 
 from .parser.testdata import *
 from .parser.testlogfileparser import *

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -11,9 +11,10 @@ import sys
 import unittest
 
 sys.path.append('parser')
-from testdata import *
-from testlogfileparser import *
-from testutils import *
+
+from .parser.testdata import *
+from .parser.testlogfileparser import *
+from .parser.testutils import *
 
 
 if __name__ == "__main__":

--- a/test/testall.py
+++ b/test/testall.py
@@ -21,7 +21,7 @@ from .test_utils import *
 
 
 if __name__ == "__main__":
-	print("Running unit tests for data...")
-	test_data.test_all(silent=True, summary=False, visual_tests=False)
-	print("Running all other unit tests...")
-	unittest.main()
+    print("Running unit tests for data...")
+    test_data.test_all(silent=True, summary=False, visual_tests=False)
+    print("Running all other unit tests...")
+    unittest.main()

--- a/test/testall.py
+++ b/test/testall.py
@@ -11,13 +11,13 @@ from __future__ import print_function
 
 import unittest
 
-import test_data
+from . import test_data
 
-from test_bridge import *
-from test_io import *
-from test_method import *
-from test_parser import *
-from test_utils import *
+from .test_bridge import *
+from .test_io import *
+from .test_method import *
+from .test_parser import *
+from .test_utils import *
 
 
 if __name__ == "__main__":

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -9,4 +9,4 @@ python -m test.test_parser &&
 python -m test.test_io &&
 python -m test.test_data --status --terse &&
 cd data && bash regression_download.sh &&
-cd ../test && python -m test.regression --status --traceback
+cd .. && python -m test.regression --status --traceback

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -2,12 +2,11 @@
 
 # run_travis_tests.sh: Run the tests for Travis CI.
 
-cd test
-python test_bridge.py &&
-python test_utils.py &&
-python test_method.py &&
-python test_parser.py &&
-python test_io.py &&
-python test_data.py --status --terse &&
-cd ../data && bash regression_download.sh &&
+python -m test.test_bridge &&
+python -m test.test_utils &&
+python -m test.test_method &&
+python -m test.test_parser &&
+python -m test.test_io &&
+python -m test.test_data --status --terse &&
+cd data && bash regression_download.sh &&
 cd ../test && python regression.py --status --traceback

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -9,4 +9,4 @@ python -m test.test_parser &&
 python -m test.test_io &&
 python -m test.test_data --status --terse &&
 cd data && bash regression_download.sh &&
-cd ../test && python regression.py --status --traceback
+cd ../test && python -m test.regression --status --traceback


### PR DESCRIPTION
These are all the commits from https://github.com/cclib/cclib/pull/456 that make imports consistently absolute rather than relative. This makes it possible to run properly as a module.

It also switches path manipulation to use `sys.path.insert(1, 'path')` rather than `sys.path.append('path')` per https://stackoverflow.com/q/10095037.