### PR TITLE
NameError: Replace kcal to kcal_mol-1

### DIFF
--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -61,6 +61,7 @@ def symmetrize(m, use_triangle='lower'):
 
 def convertor(value, fromunits, tounits):
     """Convert from one set of units to another.
+    
     Sources:
         NIST 2010 CODATA (http://physics.nist.gov/cuu/Constants/index.html)
         Documentation of GAMESS-US or other programs as noted
@@ -193,4 +194,4 @@ class WidthSplitter:
 if __name__ == "__main__":
     import doctest
     from cclib.parser import utils
-doctest.testmod(utils, verbose=False)
+    doctest.testmod(utils, verbose=False)

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -65,6 +65,7 @@ def convertor(value, fromunits, tounits):
     Sources:
         NIST 2010 CODATA (http://physics.nist.gov/cuu/Constants/index.html)
         Documentation of GAMESS-US or other programs as noted
+        
     >>> print("%.3f" % convertor(8.0, "eV", "cm-1"))
     64524.354
     """

--- a/src/cclib/parser/utils.py
+++ b/src/cclib/parser/utils.py
@@ -61,11 +61,9 @@ def symmetrize(m, use_triangle='lower'):
 
 def convertor(value, fromunits, tounits):
     """Convert from one set of units to another.
-
     Sources:
         NIST 2010 CODATA (http://physics.nist.gov/cuu/Constants/index.html)
         Documentation of GAMESS-US or other programs as noted
-
     >>> print("%.3f" % convertor(8.0, "eV", "cm-1"))
     64524.354
     """
@@ -77,30 +75,30 @@ def convertor(value, fromunits, tounits):
 
         "cm-1_to_eV":       lambda x: x / 8065.54429,
         "cm-1_to_hartree":  lambda x: x / 219474.6313708,
-        "cm-1_to_kcal":     lambda x: x / 349.7550112,
+        "cm-1_to_kcal_mol-1":     lambda x: x / 349.7550112,
         "cm-1_to_kJmol-1":  lambda x: x / 83.5934722814,
         "cm-1_to_nm":       lambda x: 1e7 / x,
         "cm-1_to_Hz":       lambda x: x * 29.9792458,
 
         "eV_to_cm-1":       lambda x: x * 8065.54429,
         "eV_to_hartree":    lambda x: x / 27.21138505,
-        "eV_to_kcal":       lambda x: x * 23.060548867,
+        "eV_to_kcal_mol-1":       lambda x: x * 23.060548867,
         "eV_to_kJmol-1":    lambda x: x * 96.4853364596,
 
         "hartree_to_cm-1":      lambda x: x * 219474.6313708,
         "hartree_to_eV":        lambda x: x * 27.21138505,
-        "hartree_to_kcal":      lambda x: x * 627.50947414,
+        "hartree_to_kcal_mol-1":      lambda x: x * 627.50947414,
         "hartree_to_kJmol-1":   lambda x: x * 2625.4996398,
 
-        "kcal_to_cm-1":     lambda x: x * 349.7550112,
-        "kcal_to_eV":       lambda x: x / 23.060548867,
-        "kcal_to_hartree":  lambda x: x / 627.50947414,
-        "kcal_to_kJmol-1":  lambda x: x * 4.184,
+        "kcal_mol-1_to_cm-1":     lambda x: x * 349.7550112,
+        "kcal_mol-1_to_eV":       lambda x: x / 23.060548867,
+        "kcal_mol-1_to_hartree":  lambda x: x / 627.50947414,
+        "kcal_mol-1_to_kJmol-1":  lambda x: x * 4.184,
 
         "kJmol-1_to_cm-1":  lambda x: x * 83.5934722814,
         "kJmol-1_to_eV":    lambda x: x / 96.4853364596,
         "kJmol-1_to_hartree": lambda x: x / 2625.49963978,
-        "kJmol-1_to_kcal":  lambda x: x / 4.184,
+        "kJmol-1_to_kcal_mol-1":  lambda x: x / 4.184,
         "nm_to_cm-1":       lambda x: 1e7 / x,
 
         # Taken from GAMESS docs, "Further information",
@@ -126,7 +124,6 @@ def convertor(value, fromunits, tounits):
 
 class PeriodicTable(object):
     """Allows conversion between element name and atomic no.
-
     >>> t = PeriodicTable()
     >>> t.element[6]
     'C'
@@ -168,7 +165,6 @@ class PeriodicTable(object):
 class WidthSplitter:
     """Split a line based not on a character, but a given number of field
     widths.
-
     >>> split_fixed = WidthSplitter((4, 3, 5, 6, 10, 10, 10, 10, 10, 10))
     >>> split_fixed.split("  60  H 10  s        0.14639   0.00000   0.00000  -0.00000  -0.00000   0.00000")
     ['60', 'H', '10', 's', '0.14639', '0.00000', '0.00000', '-0.00000', '-0.00000', '0.00000']
@@ -197,4 +193,4 @@ class WidthSplitter:
 if __name__ == "__main__":
     import doctest
     from cclib.parser import utils
-    doctest.testmod(utils, verbose=False)
+doctest.testmod(utils, verbose=False)


### PR DESCRIPTION
Fix issue #461
NameError in the convertor function - utils.py
All the hard coded value are perfectly fine. Here only kcal is changed to kcal_mol-1. 
For more info refer to http://web.utk.edu/%7Ercompton/constants