### PR TITLE
fixed some typos in ccwrite

### DIFF
--- a/src/cclib/io/ccio.py
+++ b/src/cclib/io/ccio.py
@@ -297,7 +297,7 @@ def fallback(source):
 
 
 def ccwrite(ccobj, outputtype=None, outputdest=None,
-            indices=None, terse=False , returnstr=False,
+            indices=None, terse=False, returnstr=False,
             *args, **kwargs):
     """Write the parsed data from an outputfile to a standard chemical
     representation.

--- a/src/scripts/ccwrite
+++ b/src/scripts/ccwrite
@@ -41,7 +41,7 @@ def main():
                         action='store_true',
                         help='use experimental features (currently optdone_as_list)')
 
-    parser.add_argument('-i', '--index'
+    parser.add_argument('-i', '--index',
                         type=int,
                         default=None,
                         help='optional zero-based index for which structure to extract')
@@ -93,7 +93,7 @@ def main():
 
         # The argument terse presently is only applicable to
         # CJSON/JSON formats
-        ccwrite(data, outputtype, outputdest, terse, indices=index,
+        ccwrite(data, outputtype, outputdest, terse=terse, indices=index,
                 **ccwrite_kwargs)
 
 


### PR DESCRIPTION
There are two unfortunate typos causing the following errors:

	$ python ../src/scripts/ccwrite cjson ./DALTON/basicDALTON-2013/C_bigbasis.out
    
      File "../src/scripts/ccwrite", line 45
        type=int,
           ^
    SyntaxError: invalid syntax

and then

    Traceback (most recent call last):
      File "/opt/pycharm-community-2017.3.4/helpers/pydev/pydevd.py", line 1668, in <module>
        main()
      File "/opt/pycharm-community-2017.3.4/helpers/pydev/pydevd.py", line 1662, in main
        globals = debugger.run(setup['file'], None, None, is_module)
      File "/opt/pycharm-community-2017.3.4/helpers/pydev/pydevd.py", line 1072, in run
        pydev_imports.execfile(file, globals, locals)  # execute the script
      File "/opt/pycharm-community-2017.3.4/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
        exec(compile(contents+"\n", file, 'exec'), glob, loc)
      File "/home/gosha/code/cclib/src/scripts/ccwrite", line 101, in <module>
        main()
      File "/home/gosha/code/cclib/src/scripts/ccwrite", line 97, in main
        **ccwrite_kwargs)
    TypeError: ccwrite() got multiple values for argument 'indices'

which is due to the order of unnamed arguments in the `ccwrite` invocation
