### PR TITLE
Added required_attrs for electrons.py and nuclear.py

### DIFF
--- a/src/cclib/method/electrons.py
+++ b/src/cclib/method/electrons.py
@@ -19,6 +19,8 @@ class Electrons(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
+        self.required_attrs = ('atomnos','charge','coreelectrons')
+
         super(Electrons, self).__init__(data, progress, loglevel, logname)
 
     def __str__(self):

--- a/src/cclib/method/nuclear.py
+++ b/src/cclib/method/nuclear.py
@@ -19,6 +19,8 @@ class Nuclear(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
+        self.required_attrs = ('natom','atomcoords','atomnos')
+
         super(Nuclear, self).__init__(data, progress, loglevel, logname)
 
     def __str__(self):


### PR DESCRIPTION
This PR adds required attributes for Electrons and Nuclear method subclasses. These were similar to Orbitals subclass.