### PR TITLE
Handle absent dipole moments in cjson writer

### DIFF
--- a/src/cclib/io/cjsonwriter.py
+++ b/src/cclib/io/cjsonwriter.py
@@ -75,12 +75,14 @@ class CJSON(filewriter.Writer):
             l1_data_object = cjson_dict[attributePath[0]]
 
             # 'moments' and 'atomcoords' key will contain processed data obtained from the output file.
-            if attributeName == 'moments' or attributeName == 'atomcoords' :
-                if attributeName == 'moments':
-                    cjson_dict['properties'][ccData._attributes['moments'].jsonKey] = self._calculate_total_dipole_moment()
-                else:
-                    cjson_dict['atoms']['coords'] = dict()
-                    cjson_dict['atoms']['coords']['3d'] = self.ccdata.atomcoords[-1].flatten().tolist()
+            if attributeName == 'moments':
+                dipole_moment = self._calculate_total_dipole_moment()
+                if dipole_moment is not None:
+                    cjson_dict['properties'][ccData._attributes['moments'].jsonKey] = dipole_moment
+                continue
+            elif attributeName == 'atomcoords':
+                cjson_dict['atoms']['coords'] = dict()
+                cjson_dict['atoms']['coords']['3d'] = self.ccdata.atomcoords[-1].flatten().tolist()
                 continue
 
             if levels == 1:

--- a/src/cclib/io/filewriter.py
+++ b/src/cclib/io/filewriter.py
@@ -72,7 +72,12 @@ class Writer(object):
 
     def _calculate_total_dipole_moment(self):
         """Calculate the total dipole moment."""
-        return sqrt(sum(self.ccdata.moments[1] ** 2))
+
+        # ccdata.moments may exist, but only contain center-of-mass coordinates
+        if len(getattr(self.ccdata, 'moments', [])) > 1:
+            return sqrt(sum(self.ccdata.moments[1] ** 2))
+        else:
+            return None
 
     def _check_required_attributes(self):
         """Check if required attributes are present in ccdata."""

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -7,12 +7,12 @@
 
 """Unit tests for writer cjsonwriter module."""
 
+import json
 import os
 import unittest
-import json
+from math import sqrt
 
 import cclib
-
 
 __filedir__ = os.path.dirname(__file__)
 __filepath__ = os.path.realpath(__filedir__)
@@ -35,7 +35,7 @@ class CJSONTest(unittest.TestCase):
 
     def test_cjson_generation(self):
         """Does the CJSON format get generated properly?"""
-        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
+        fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/NH3.adfout")
         data = cclib.io.ccopen(fpath).parse()
 
         cjson = cclib.io.cjsonwriter.CJSON(data).generate_repr()
@@ -44,6 +44,23 @@ class CJSONTest(unittest.TestCase):
         json_data = json.loads(cjson)
         number_of_atoms = json_data['properties']['number of atoms']
         self.assertEqual(number_of_atoms, data.natom)
+
+        dipole_moment = json_data['properties']['total dipole moment']
+        self.assertAlmostEqual(
+            dipole_moment,
+            sqrt(sum(data.moments[1] ** 2))
+        )
+
+    def test_incomplete_data(self):
+        """Does the CJSON writer handles missing properties correctly?"""
+        fpath = os.path.join(__datadir__, "data/DALTON/basicDALTON-2013/C_bigbasis.out")
+        data = cclib.io.ccopen(fpath).parse()
+
+        cjson = cclib.io.cjsonwriter.CJSON(data).generate_repr()
+
+        json_data = json.loads(cjson)
+        self.assertFalse("total dipole moment" in json_data["properties"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
partial fix for #377 
cjson writer fails if the input file contains no dipole moment:

        $ ccwrite cjson ./data/DALTON/basicDALTON-2013/C_bigbasis.out
        ...
        Traceback (most recent call last):
        ...
          File "/home/gosha/venvs/cclib/lib/python3.6/site-packages/cclib-1.5.2-py3.6.egg/cclib/io/filewriter.py", line 75, in _calculate_total_dipole_moment
            return sqrt(sum(self.ccdata.moments[1] ** 2))
        IndexError: list index out of range

Added a check so that if no dipole  moment is provided it will be omitted from CJSON.

On a side note, the method for calculating dipole moments seems out of place in `filewriter`, should it not be moved to `methods`, as simple as it is? And what's the current status of the idea to calculate dipole moments from atomic charges (#311)?