### PR TITLE
Adding skipforMolcas on all test methods

### DIFF
--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -34,10 +34,12 @@ class GenericBasisTest(unittest.TestCase):
     gbasis_C_2s_func0 = [2.9412, -0.1000]
     gbasis_C_2p_func0 = [2.9412, 0.1559]
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testgbasis(self):
         """Is gbasis the right length?"""
         self.assertEquals(self.data.natom, len(self.data.gbasis))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnames(self):
         """Are the name of basis set functions acceptable?"""
         for atom in self.data.gbasis:
@@ -45,6 +47,7 @@ class GenericBasisTest(unittest.TestCase):
                 self.assert_(fns[0] in self.names,
                              "%s not one of S or P" % fns[0])
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsizeofbasis(self):
         """Is the basis set the correct size?"""
 
@@ -56,12 +59,14 @@ class GenericBasisTest(unittest.TestCase):
 
         self.assertEquals(self.data.nbasis, total)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcontractions(self):
         """Are the number of contractions on all atoms correct?"""
         for iatom, atom in enumerate(self.data.gbasis):
             atomno = self.data.atomnos[iatom]
             self.assertEquals(len(atom), self.contractions[atomno])
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testprimitives(self):
         """Are all primitives 2-tuples?"""
         for atom in self.data.gbasis:
@@ -69,6 +74,7 @@ class GenericBasisTest(unittest.TestCase):
                 for primitive in contraction:
                     self.assertEquals(len(primitive), 2)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcoeffs(self):
         """Are the atomic basis set exponents and coefficients correct?"""
 

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -10,6 +10,7 @@
 import os
 import unittest
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -19,6 +19,7 @@ __filedir__ = os.path.realpath(os.path.dirname(__file__))
 class GenericCCTest(unittest.TestCase):
     """Generic coupled cluster unittest"""
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsign(self):
         """Are the coupled cluster corrections negative?"""
         corrections = self.data.ccenergies - self.data.scfenergies

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -46,6 +46,7 @@ class GenericCISTest(unittest.TestCase):
 
     etsecs_precision = 0.0005
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testetenergiesvalues(self):
         """ Are etenergies within 50cm-1 of the correct values?"""
         indices0 = [i for i in range(self.nstates) if self.data.etsyms[i][0] == "S"]
@@ -60,12 +61,14 @@ class GenericCISTest(unittest.TestCase):
             tripletdiff = triplets[:4] - self.etenergies1
             self.failUnless(numpy.alltrue(tripletdiff < 50))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsecs(self):
         """Is the sum of etsecs close to 1?"""
         etsec = self.data.etsecs[2] # Pick one with several contributors
         sumofsec = sum([z*z for (x, y, z) in etsec])
         self.assertAlmostEquals(sumofsec, 1.0, delta=0.02)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testetsecsvalues(self):
         """ Are etsecs correct and coefficients close to the correct values?"""
         indices0 = [i for i in range(self.nstates) if self.data.etsyms[i][0] == "S"]

--- a/test/data/testCore.py
+++ b/test/data/testCore.py
@@ -24,6 +24,7 @@ class GenericCoreTest(unittest.TestCase):
     coredict = {'Mo': 28, 'O':0, 'Cl':10}
     charge = -2
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcorrect(self):
         """Is coreelectrons equal to what it should be?"""
         pt = PeriodicTable()
@@ -33,6 +34,7 @@ class GenericCoreTest(unittest.TestCase):
         ans = numpy.array(ans, "i")
         numpy.testing.assert_array_equal(self.data.coreelectrons, ans)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcharge(self):
         """Is the total charge correct?"""
         self.assertEqual(self.data.charge, self.charge)

--- a/test/data/testCore.py
+++ b/test/data/testCore.py
@@ -14,6 +14,7 @@ import numpy
 
 from cclib.parser.utils import PeriodicTable
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -35,10 +35,12 @@ class GenericGeoOptTest(unittest.TestCase):
     b3lyp_energy = -10365
     b3lyp_tolerance = 40
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
         self.assertEquals(self.data.natom, 20)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
         # This will work only for numpy
@@ -53,6 +55,7 @@ class GenericGeoOptTest(unittest.TestCase):
         count_H = sum(self.data.atomnos == 1)
         self.assertEquals(count_C + count_H, 20)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomcoords(self):
         """Are atomcoords consistent with natom and Angstroms?"""
         natom = len(self.data.atomcoords[0])
@@ -60,43 +63,51 @@ class GenericGeoOptTest(unittest.TestCase):
         msg = "natom is %d but len(atomcoords[0]) is %d" % (ref, natom)
         self.assertEquals(natom, ref, msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomcoords_units(self):
         """Are atomcoords consistent with Angstroms?"""
         min_carbon_dist = get_minimum_carbon_separation(self.data)
         dev = abs(min_carbon_dist - 1.34)
         self.assertTrue(dev < 0.15, "Minimum carbon dist is %.2f (not 1.34)" % min_carbon_dist)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
         self.assertEquals(self.data.charge, 0)
         self.assertEquals(self.data.mult, 1)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnbasis(self):
         """Is the number of basis set functions correct?"""
         count = sum([self.nbasisdict[n] for n in self.data.atomnos])
         self.assertEquals(self.data.nbasis, count)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcoreelectrons(self):
         """Are the coreelectrons all 0?"""
         ans = numpy.zeros(self.data.natom, 'i')
         numpy.testing.assert_array_equal(self.data.coreelectrons, ans)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnormalisesym(self):
         """Did this subclass overwrite normalisesym?"""
         # https://stackoverflow.com/a/8747890
         self.logfile.normalisesym("A")
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testhomos(self):
         """Is the index of the HOMO equal to 34?"""
         ref = numpy.array([34], "i")
         msg = "%s != array([34], 'i')" % numpy.array_repr(self.data.homos)
         numpy.testing.assert_array_equal(self.data.homos, ref, msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscfvaluetype(self):
         """Are scfvalues and its elements the right type?"""
         self.assertEquals(type(self.data.scfvalues),type([]))
         self.assertEquals(type(self.data.scfvalues[0]),type(numpy.array([])))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscfenergy(self):
         """Is the SCF energy close to target?"""
         scf = self.data.scfenergies[-1]
@@ -105,18 +116,21 @@ class GenericGeoOptTest(unittest.TestCase):
         msg = "Final scf energy: %f not %i +- %ieV" %(scf, ref, tol)
         self.assertAlmostEquals(scf, ref, delta=40, msg=msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscfenergydim(self):
         """Is the number of SCF energies consistent with atomcoords?"""
         count_scfenergies = self.data.scfenergies.shape[0] - self.extrascfs
         count_atomcoords = self.data.atomcoords.shape[0] - self.extracoords
         self.assertEquals(count_scfenergies, count_atomcoords)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscftargetdim(self):
         """Do the scf targets have the right dimensions?"""
         dim_scftargets = self.data.scftargets.shape
         dim_scfvalues = (len(self.data.scfvalues),len(self.data.scfvalues[0][0]))
         self.assertEquals(dim_scftargets, dim_scfvalues)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testgeovalues_atomcoords(self):
         """Are atomcoords consistent with geovalues?"""
         count_geovalues = len(self.data.geovalues)
@@ -124,18 +138,21 @@ class GenericGeoOptTest(unittest.TestCase):
         msg = "len(atomcoords) is %d but len(geovalues) is %d" % (count_coords, count_geovalues)
         self.assertEquals(count_geovalues, count_coords, msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testgeovalues_scfvalues(self):
         """Are scfvalues consistent with geovalues?"""
         count_scfvalues = len(self.data.scfvalues) - self.extrascfs
         count_geovalues = len(self.data.geovalues)
         self.assertEquals(count_scfvalues, count_geovalues)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testgeotargets(self):
         """Do the geo targets have the right dimensions?"""
         dim_geotargets = self.data.geotargets.shape
         dim_geovalues = (len(self.data.geovalues[0]), )
         self.assertEquals(dim_geotargets, dim_geovalues)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testoptdone(self):
         """Has the geometry converged and set optdone to True?"""
         self.assertTrue(self.data.optdone)
@@ -146,6 +163,7 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser("GAMESS", "Not implemented.")
     @skipForParser("GAMESSUK", "Not implemented.")
     @skipForParser("Jaguar", "Not implemented.")
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser("Molpro", "Not implemented.")
     @skipForParser("NWChem", "Not implemented.")
     @skipForParser("ORCA", "Not implemented.")
@@ -158,6 +176,7 @@ class GenericGeoOptTest(unittest.TestCase):
             self.assertEqual(self.data.optstatus[i], self.data.OPT_UNKNOWN)
         self.assertEqual(self.data.optstatus[-1], self.data.OPT_DONE)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are only the final MOs parsed?"""
         self.assertEquals(len(self.data.moenergies), 1)
@@ -169,6 +188,7 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser("GAMESS", "Not implemented.")
     @skipForParser("GAMESSUK", "Not implemented.")
     @skipForParser("Jaguar", "Not implemented.")
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser("NWChem", "Not implemented.")
     @skipForParser("ORCA", "Not implemented.")
     def testgradsdim(self):

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -21,11 +21,13 @@ class GenericMP2Test(unittest.TestCase):
 
     level = 2
     
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsizeandshape(self):
         """(MP2) Are the dimensions of mpenergies correct?"""
         self.assertEqual(self.data.mpenergies.shape,
                          (len(self.data.scfenergies), self.level-1))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testchange(self):
         """(MP2) Are Moller-Plesset corrections negative?"""
         if self.level == 2:

--- a/test/data/testPolar.py
+++ b/test/data/testPolar.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testPolar.py
+++ b/test/data/testPolar.py
@@ -19,6 +19,7 @@ __filedir__ = os.path.realpath(os.path.dirname(__file__))
 class GenericPolarTest(unittest.TestCase):
     """Generic static polarizability unittest"""
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testshape(self):
         """Is the dimension of the polarizability tensor 3 x 3?"""
         self.assertEqual(len(self.data.polarizabilities), 1)
@@ -34,6 +35,7 @@ class ReferencePolarTest(GenericPolarTest):
     isotropic_delta = 0.01
     principal_components_delta = 0.01
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testisotropic(self):
         """Is the isotropic polarizability (average of the diagonal elements)
         +/- 0.01 from a reference?
@@ -41,6 +43,7 @@ class ReferencePolarTest(GenericPolarTest):
         isotropic = numpy.average(numpy.diag(self.data.polarizabilities[0]))
         self.assertAlmostEqual(isotropic, self.isotropic, delta=self.isotropic_delta)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testprincomponents(self):
         """Are each of the principal components (eigenvalues) of the
         polarizability tensor +/- 0.01 from a reference?

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -37,10 +37,12 @@ class GenericSPTest(unittest.TestCase):
     # Overlap first two atomic orbitals.
     overlap01 = 0.24
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
         self.assertEquals(self.data.natom, 20)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
 
@@ -53,6 +55,7 @@ class GenericSPTest(unittest.TestCase):
 
     @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
     @skipForLogfile('Jaguar/basicJaguar7', 'We did not print the atomic partial charges in the unit tests for this version')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForLogfile('Molpro/basicMolpro2006', "These tests were run a long time ago and since we don't have access to Molpro 2006 anymore, we can skip this test (it is tested in 2012)")
     @skipForLogfile('Psi/basicPsi3', 'Psi3 did not print partial atomic charges')
     def testatomcharges(self):
@@ -62,22 +65,26 @@ class GenericSPTest(unittest.TestCase):
             self.assertEquals(len(charges), self.data.natom)
             self.assertAlmostEquals(sum(charges), 0.0, delta=0.001)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""
         expected_shape = (1, self.data.natom, 3)
         self.assertEquals(self.data.atomcoords.shape, expected_shape)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomcoords_units(self):
         """Are atomcoords consistent with Angstroms?"""
         min_carbon_dist = get_minimum_carbon_separation(self.data)
         dev = abs(min_carbon_dist - 1.34)
         self.assertTrue(dev < 0.03, "Minimum carbon dist is %.2f (not 1.34)" % min_carbon_dist)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
         self.assertEquals(self.data.charge, 0)
         self.assertEquals(self.data.mult, 1)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnbasis(self):
         """Is the number of basis set functions correct?"""
         count = sum([self.nbasisdict[n] for n in self.data.atomnos])
@@ -85,6 +92,7 @@ class GenericSPTest(unittest.TestCase):
 
     @skipForParser('ADF', 'ADF parser does not extract atombasis')
     @skipForLogfile('Jaguar/basicJaguar7', 'Data file does not contain enough information. Can we make a new one?')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatombasis(self):
         """Are the indices in atombasis the right amount and unique?"""
         all = []
@@ -99,6 +107,7 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('GAMESS', 'atommasses not implemented yet')
     @skipForParser('GAMESSUK', 'atommasses not implemented yet')
     @skipForParser('Jaguar', 'atommasses not implemented yet')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', 'atommasses not implemented yet')
     @skipForParser('NWChem', 'atommasses not implemented yet')
     @skipForLogfile('Psi/basicPsi3', 'atommasses not implemented yet')
@@ -110,16 +119,19 @@ class GenericSPTest(unittest.TestCase):
         msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
         self.assertAlmostEquals(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcoreelectrons(self):
         """Are the coreelectrons all 0?"""
         ans = numpy.zeros(self.data.natom, 'i')
         numpy.testing.assert_array_equal(self.data.coreelectrons, ans)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnormalisesym(self):
         """Did this subclass overwrite normalisesym?"""
         # https://stackoverflow.com/a/8747890
         self.logfile.normalisesym("A")
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', '?')
     @skipForParser('ORCA', 'ORCA has no support for symmetry yet')
     def testsymlabels(self):
@@ -127,27 +139,33 @@ class GenericSPTest(unittest.TestCase):
         sumwronglabels = sum([x not in ['Ag', 'Bu', 'Au', 'Bg'] for x in self.data.mosyms[0]])
         self.assertEquals(sumwronglabels, 0)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testhomos(self):
         """Is the index of the HOMO equal to 34?"""
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34],"i"), "%s != array([34],'i')" % numpy.array_repr(self.data.homos))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscfvaluetype(self):
         """Are scfvalues and its elements the right type??"""
         self.assertEquals(type(self.data.scfvalues),type([]))
         self.assertEquals(type(self.data.scfvalues[0]),type(numpy.array([])))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscfenergy(self):
         """Is the SCF energy within the target?"""
         self.assertAlmostEquals(self.data.scfenergies[-1], self.b3lyp_energy, delta=40, msg="Final scf energy: %f not %i +- 40eV" %(self.data.scfenergies[-1], self.b3lyp_energy))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testscftargetdim(self):
         """Do the scf targets have the right dimensions?"""
         self.assertEquals(self.data.scftargets.shape, (len(self.data.scfvalues), len(self.data.scfvalues[0][0])))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testlengthmoenergies(self):
         """Is the number of evalues equal to nmo?"""
         self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testtypemoenergies(self):
         """Is moenergies a list containing one numpy array?"""
         self.assertEquals(type(self.data.moenergies), type([]))
@@ -155,6 +173,7 @@ class GenericSPTest(unittest.TestCase):
 
     @skipForParser('DALTON', 'mocoeffs not implemented yet')
     @skipForLogfile('Jaguar/basicJaguar7', 'Data file does not contain enough information. Can we make a new one?')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForLogfile('Psi/basicPsi3', 'MO coefficients are printed separately for each SALC')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis?"""
@@ -164,6 +183,7 @@ class GenericSPTest(unittest.TestCase):
                           (self.data.nmo, self.data.nbasis))
 
     @skipForParser('DALTON', 'To print: **INTEGRALS\n.PROPRI')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Psi', 'Psi does not currently have the option to print the overlap matrix')
     @skipForParser('QChem', 'QChem cannot print the overlap matrix')
     def testaooverlaps(self):
@@ -186,12 +206,14 @@ class GenericSPTest(unittest.TestCase):
         self.assertEquals(self.data.aooverlaps[3,0], 0.0)
         self.assertEquals(self.data.aooverlaps[0,3], 0.0)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testoptdone(self):
         """There should be no optdone attribute set."""
         self.assertFalse(hasattr(self.data, 'optdone'))
 
     @skipForParser('Gaussian', 'Logfile needs to be updated')
     @skipForParser('Jaguar', 'No dipole moments in the logfile')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testmoments(self):
         """Does the dipole and possible higher molecular moments look reasonable?"""
 
@@ -246,6 +268,7 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('GAMESSUK', 'Does not support metadata yet')
     @skipForParser('Gaussian', 'Does not support metadata yet')
     @skipForParser('Jaguar', 'Does not support metadata yet')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', 'Does not support metadata yet')
     @skipForParser('NWChem', 'Does not support metadata yet')
     @skipForParser('ORCA', 'Does not support metadata yet')

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -22,21 +22,25 @@ __filedir__ = os.path.realpath(os.path.dirname(__file__))
 class GenericSPunTest(unittest.TestCase):
     """Generic unrestricted single point unittest"""
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
         self.assertEquals(self.data.natom, 20)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
         self.failUnless(numpy.alltrue([numpy.issubdtype(atomno,int) for atomno in self.data.atomnos]))
         self.assertEquals(self.data.atomnos.shape, (20,) )
         self.assertEquals(sum(self.data.atomnos==6) + sum(self.data.atomnos==1), 20)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""
         self.assertEquals(self.data.atomcoords.shape,(1,self.data.natom,3))
 
     @skipForParser('Jaguar', 'Data file does not contain enough information')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 2 x nmo x nbasis?"""
         self.assertEquals(type(self.data.mocoeffs), type([]))
@@ -46,22 +50,26 @@ class GenericSPunTest(unittest.TestCase):
         self.assertEquals(self.data.mocoeffs[1].shape,
                           (self.data.nmo, self.data.nbasis))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
         self.assertEquals(self.data.charge, 1)
         self.assertEquals(self.data.mult, 2)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testhomos(self):
         """Are the homos correct?"""
         msg = "%s != array([34,33],'i')" % numpy.array_repr(self.data.homos)
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34,33],"i"), msg)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 2 x nmo?"""
         self.assertEquals(len(self.data.moenergies), 2)
         self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
         self.assertEquals(len(self.data.moenergies[1]), self.data.nmo)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', '?')
     @skipForParser('ORCA', 'ORCA has no support for symmetry yet')
     def testmosyms(self):

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -82,6 +82,7 @@ class GenericROSPTest(GenericSPunTest):
     """Customized restricted open-shell single point unittest"""
 
     @skipForParser('DALTON', 'mocoeffs not implemented yet')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis?"""
         self.assertEquals(type(self.data.mocoeffs), type([]))
@@ -89,6 +90,7 @@ class GenericROSPTest(GenericSPunTest):
         self.assertEquals(self.data.mocoeffs[0].shape,
                           (self.data.nmo, self.data.nbasis))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testhomos(self):
         """Are the HOMO indices equal to 34 and 33 (one more alpha electron
         than beta electron)?
@@ -97,11 +99,13 @@ class GenericROSPTest(GenericSPunTest):
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34, 33], "i"), msg)
 
     @skipForParser('QChem', 'prints 2 sets of different MO energies?')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 1 x nmo?"""
         self.assertEquals(len(self.data.moenergies), 1)
         self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testmosyms(self):
         """Are the dims of the mosyms equals to 1 x nmo?"""
         shape = (len(self.data.mosyms), len(self.data.mosyms[0]))

--- a/test/data/testScan.py
+++ b/test/data/testScan.py
@@ -38,16 +38,19 @@ class GenericScanTest_optdone_bool(GenericScanTestBase):
 
     datatype = cclib.parser.data.ccData_optdone_bool
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testoptdone(self):
         """Is the optimization finished?"""
         self.assertIsInstance(self.data.optdone, bool)
         self.assertEquals(self.data.optdone, True)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testindices(self):
         """Do the indices match the results from geovalues."""
         assert self.data.optdone and numpy.all(self.data.geovalues[-1] <= self.data.geotargets)
 
     @skipForParser("Jaguar", "Not implemented")
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser("ORCA", "Not implemented")
     def testoptstatus(self):
         """Does optstatus contain expected values?"""
@@ -64,11 +67,13 @@ class GenericScanTest(GenericScanTestBase):
     # extra indices
     extra = 0
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnumindices(self):
         """Do the number of indices match number of scan points."""
         self.assertEquals(len(self.data.optdone), 12 + self.extra)
 
     @skipForParser("Jaguar", "Does not work as expected")
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser("ORCA", "Does not work as expected")
     def testindices(self):
         """Do the indices match the results from geovalues."""
@@ -79,6 +84,7 @@ class GenericScanTest(GenericScanTestBase):
         numpy.testing.assert_array_equal(geovalues, geovalues_from_index)
 
     @skipForParser("Jaguar", "Not implemented")
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser("ORCA", "Not implemented")
     def testoptstatus(self):
         """Does optstatus contain expected values?"""

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -25,6 +25,7 @@ class GenericTDTest(unittest.TestCase):
     expected_l_max = 41000
 
     @skipForParser('DALTON', 'etoscs are not parsed')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testenergies(self):
         """Is the l_max reasonable?"""
 
@@ -36,12 +37,14 @@ class GenericTDTest(unittest.TestCase):
         self.assertAlmostEqual(self.data.etenergies[idx_lambdamax], self.expected_l_max, delta=5000)
 
     @skipForParser('DALTON', 'Oscillator strengths will have to be calculated, not just parsed.')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""
         self.assertEqual(len(self.data.etoscs), self.number)
         self.assertAlmostEqual(max(self.data.etoscs), 0.67, delta=0.1)
 
     @skipForParser('DALTON', '???')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsecs(self):
         """Is the sum of etsecs close to 1?"""
         self.assertEqual(len(self.data.etsecs), self.number)
@@ -50,6 +53,7 @@ class GenericTDTest(unittest.TestCase):
         self.assertAlmostEqual(sumofsec, 1.0, delta=0.16)
 
     @skipForParser('DALTON', '???')
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsecs_transition(self):
         """Is the lowest E transition from the HOMO or to the LUMO?"""
         idx_minenergy = numpy.argmin(self.data.etoscs)
@@ -60,6 +64,7 @@ class GenericTDTest(unittest.TestCase):
         self.assert_(t[0][1][0] == self.data.homos[0] or
                      t[0][2][0] == self.data.homos[0]+1, t[0])
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')    
     def testsymsnumber(self):
         """Is the length of etsyms correct?"""
         self.assertEqual(len(self.data.etsyms), self.number)

--- a/test/data/testTDun.py
+++ b/test/data/testTDun.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy
 
+from skip import skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 

--- a/test/data/testTDun.py
+++ b/test/data/testTDun.py
@@ -21,26 +21,32 @@ class GenericTDunTest(unittest.TestCase):
 
     number = 24
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testenergiesnumber(self):
         """Is the length of etenergies correct?"""
         self.assertEqual(len(self.data.etenergies), self.number)
     
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testoscsnumber(self):
         """Is the length of eotscs correct?"""
         self.assertEqual(len(self.data.etoscs), self.number)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testrotatsnumber(self):
         """Is the length of etrotats correct?"""
         self.assertEqual(len(self.data.etrotats), self.number)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsecsnumber(self):
         """Is the length of etsecs correct?"""
         self.assertEqual(len(self.data.etsecs), self.number)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsymsnumber(self):
         """Is the length of etsyms correct?"""
         self.assertEqual(len(self.data.etsyms), self.number)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testsyms(self):
         """Is etsyms populated by singlets and triplets 50/50?"""
         singlets = [sym for sym in self.data.etsyms if "Singlet" in sym]

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -22,16 +22,19 @@ class GenericIRTest(unittest.TestCase):
     # Unit tests should normally give this value for the largest IR intensity.
     max_IR_intensity = 100
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def setUp(self):
         """Initialize the number of vibrational frequencies on a per molecule basis"""
         self.numvib = 3*len(self.data.atomnos) - 6
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testvibdisps(self):
         """Are the dimensions of vibdisps consistent with numvib x N x 3"""
         self.assertEqual(len(self.data.vibfreqs), self.numvib)
         self.assertEqual(self.data.vibdisps.shape,
                          (self.numvib, len(self.data.atomnos), 3))
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testlengths(self):
         """Are the lengths of vibfreqs and vibirs (and if present, vibsyms) correct?"""
         self.assertEqual(len(self.data.vibfreqs), self.numvib)
@@ -40,10 +43,12 @@ class GenericIRTest(unittest.TestCase):
         if hasattr(self.data, 'vibsyms'):
             self.assertEqual(len(self.data.vibsyms), self.numvib)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testfreqval(self):
         """Is the highest freq value 3630 +/- 200 cm-1?"""
         self.assertAlmostEqual(max(self.data.vibfreqs), 3630, delta=200)
 
+    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Psi', 'Psi cannot print IR intensities')
     def testirintens(self):
         """Is the maximum IR intensity 100 +/- 10 km mol-1?"""


### PR DESCRIPTION
Just adding the skipforParser decorator on the methods. These will be removed as we keep on adding more functionality to the parser.