### PR TITLE
Adds success flag to metadata

### DIFF
--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -1151,3 +1151,6 @@ class ADF(logfileparser.Logfile):
                     self.polarizabilities.append(polarizability)
 
                 line = next(inputfile)
+
+        if line[:24] == ' Buffered I/O statistics':
+            self.metadata['success'] = True

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1173,7 +1173,7 @@ class DALTON(logfileparser.Logfile):
             # self.set_attribute('etoscs', etoscs)
             self.set_attribute('etsecs', etsecs)
 
-        if line[:36] == '>>>> Total wall time used in DALTON:':
+        if line[:37] == ' >>>> Total wall time used in DALTON:':
             self.metadata['success'] = True
 
         # TODO:

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1173,6 +1173,9 @@ class DALTON(logfileparser.Logfile):
             # self.set_attribute('etoscs', etoscs)
             self.set_attribute('etsecs', etsecs)
 
+        if line[:36] == '>>>> Total wall time used in DALTON:':
+            self.metadata['success'] = True
+
         # TODO:
         # aonames
         # aooverlaps

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1431,3 +1431,7 @@ class GAMESS(logfileparser.Logfile):
                     i, j = coord_to_idx[tokens[1][0]], coord_to_idx[tokens[1][1]]
                     polarizability[i, j] = tokens[3]
             self.polarizabilities.append(polarizability)
+
+        if line[:30] == ' ddikick.x: exited gracefully.' or\
+                line[:41] == ' EXECUTION OF FIREFLY TERMINATED NORMALLY':
+            self.metadata['success'] = True

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1432,6 +1432,7 @@ class GAMESS(logfileparser.Logfile):
                     polarizability[i, j] = tokens[3]
             self.polarizabilities.append(polarizability)
 
-        if line[:30] == ' ddikick.x: exited gracefully.' or\
-                line[:41] == ' EXECUTION OF FIREFLY TERMINATED NORMALLY':
+        if line[:30] == ' ddikick.x: exited gracefully.'\
+                or line[:41] == ' EXECUTION OF FIREFLY TERMINATED NORMALLY'\
+                or line[:40] == ' EXECUTION OF GAMESS TERMINATED NORMALLY':
             self.metadata['success'] = True

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -653,3 +653,6 @@ class GAMESSUK(logfileparser.Logfile):
                 line = inputfile.next()
 
             self.set_attribute('nooccnos', occupations)
+
+        if line[:33] == ' end of  G A M E S S   program at':
+            self.metadata['success'] = True

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1800,3 +1800,6 @@ class Gaussian(logfileparser.Logfile):
                 if not hasattr(self, 'optdone'):
                     self.optdone = []
                 self.optdone.append(len(self.optstatus) - 1)
+
+        if line[:31] == ' Normal termination of Gaussian':
+            self.metadata['success'] = True

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -701,3 +701,6 @@ class Jaguar(logfileparser.Logfile):
                 line = next(inputfile)
             strength = float(line.split()[-1])
             self.etoscs.append(strength)
+
+        if line[:20] == ' Total elapsed time:':
+            self.metadata['success'] = True

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -702,5 +702,6 @@ class Jaguar(logfileparser.Logfile):
             strength = float(line.split()[-1])
             self.etoscs.append(strength)
 
-        if line[:20] == ' Total elapsed time:':
+        if line[:20] == ' Total elapsed time:' \
+                or line[:18] == ' Total cpu seconds':
             self.metadata['success'] = True

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -233,6 +233,8 @@ class Logfile(object):
             self.metadata = {}
             self.metadata["package"] = self.logname
             self.metadata["methods"] = []
+            # Indicate if the computation has completed successfully
+            self.metadata['success'] = False
 
 
         # Periodic table of elements.

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -896,3 +896,6 @@ class Molpro(logfileparser.Logfile):
             if not hasattr(self, 'grads'):
                 self.grads = []
             self.grads.append(grad)
+
+        if line[:25] == ' Variable memory released':
+            self.metadata['success'] = True

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -232,3 +232,6 @@ class MOPAC(logfileparser.Logfile):
         # Partial charges and dipole moments
         # Example:
         # NET ATOMIC CHARGES
+
+        if line[:16] == '== MOPAC DONE ==':
+            self.metadata['success'] = True

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1038,6 +1038,9 @@ class NWChem(logfileparser.Logfile):
                 polarizability.append(line.split()[1:])
             self.polarizabilities.append(numpy.array(polarizability))
 
+        if line[:18] == ' Total times  cpu:':
+            self.metadata['success'] = True
+
     def after_parsing(self):
         """NWChem-specific routines for after parsing file.
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -936,6 +936,9 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 polarizability.append(line.split())
             self.polarizabilities.append(numpy.array(polarizability))
 
+        if line[:15] == 'TOTAL RUN TIME:':
+            self.metadata['success'] = True
+
     def parse_charge_section(self, line, inputfile, chargestype):
         """Parse a charge section, modifies class in place
 

--- a/cclib/parser/psiparser.py
+++ b/cclib/parser/psiparser.py
@@ -1151,7 +1151,8 @@ class Psi(logfileparser.Logfile):
                 self.vibdisps.append(normal_mode_disps)
                 line = next(inputfile)
 
-        if line[:54] == '*** Psi4 exiting successfully. Buy a developer a beer!':
+        if line[:54] == '*** Psi4 exiting successfully. Buy a developer a beer!'\
+                or line[:54] == '*** PSI4 exiting successfully. Buy a developer a beer!':
             self.metadata['success'] = True
 
     def _parse_mosyms_moenergies(self, inputfile, spinidx):

--- a/cclib/parser/psiparser.py
+++ b/cclib/parser/psiparser.py
@@ -1151,6 +1151,9 @@ class Psi(logfileparser.Logfile):
                 self.vibdisps.append(normal_mode_disps)
                 line = next(inputfile)
 
+        if line[:54] == '*** Psi4 exiting successfully. Buy a developer a beer!':
+            self.metadata['success'] = True
+
     def _parse_mosyms_moenergies(self, inputfile, spinidx):
         """Parse molecular orbital symmetries and energies from the
         'Post-Iterations' section.

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1591,6 +1591,9 @@ cannot be determined. Rerun without `$molecule read`."""
                 if not hasattr(self, 'freeenergy'):
                     self.freeenergy = self.enthalpy - self.entropy
 
+        if line[:16] == ' Total job time:':
+            self.metadata['success'] = True
+
         # TODO:
         # 'enthalpy' (incorrect)
         # 'entropy' (incorrect)

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -35,6 +35,10 @@ class GenericGeoOptTest(unittest.TestCase):
     b3lyp_energy = -10365
     b3lyp_tolerance = 40
 
+    @skipForParser("ADF", "Not implemented.")
+    def test_success(self):
+        self.assertTrue(self.data.metadata['success'])
+
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -35,7 +35,6 @@ class GenericGeoOptTest(unittest.TestCase):
     b3lyp_energy = -10365
     b3lyp_tolerance = 40
 
-    @skipForParser("ADF", "Not implemented.")
     def test_success(self):
         self.assertTrue(self.data.metadata['success'])
 


### PR DESCRIPTION
If a computation is completed successfully, sets `metadata['success'] = True` otherwise it is `False`. As discussed in #435.

Implemented  for all parsers and tested in `testGeoOpt.py`.

Question?
------
- [x] Should I test this in other places?
    Looks like we'll only test in `testGeoOpt.py`