### PR TITLE
Fix NumPy deprecation warning about casting during subtype call

### DIFF
--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -50,7 +50,8 @@ class GenericGeoOptTest(unittest.TestCase):
         # This will work only for numpy
         #self.assertEquals(self.data.atomnos.dtype.char, 'i')
 
-        atomnos_types = [numpy.issubdtype(atomno,int) for atomno in self.data.atomnos]
+        atomnos_types = [numpy.issubdtype(atomno, numpy.signedinteger)
+                         for atomno in self.data.atomnos]
         self.failUnless(numpy.alltrue(atomnos_types))
 
         self.assertEquals(self.data.atomnos.shape, (20,) )

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -45,7 +45,8 @@ class GenericSPTest(unittest.TestCase):
         """Are the atomnos correct?"""
 
         # The nuclear charges should be integer values in a NumPy array.
-        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno, int) for atomno in self.data.atomnos]))
+        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
+                                       for atomno in self.data.atomnos]))
         self.assertEquals(self.data.atomnos.dtype.char, 'i')
 
         self.assertEquals(self.data.atomnos.shape, (20,) )

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -30,7 +30,8 @@ class GenericSPunTest(unittest.TestCase):
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
-        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno,int) for atomno in self.data.atomnos]))
+        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
+                                       for atomno in self.data.atomnos]))
         self.assertEquals(self.data.atomnos.shape, (20,) )
         self.assertEquals(sum(self.data.atomnos==6) + sum(self.data.atomnos==1), 20)
 


### PR DESCRIPTION
This eliminates warnings like
```
/home/eric/development/cclib_berquist/test/data/testGeoOpt.py:53: FutureWarning: Conversion of the second argument of issubdtype from `int` to `np.signedinteger` is deprecated. In future, it will be treated as `np.int64 == np.dtype(int).type`.
  atomnos_types = [numpy.issubdtype(atomno,int) for atomno in self.data.atomnos]
```