### PR TITLE
Fix argument inspection

### DIFF
--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -18,6 +18,11 @@ import random
 import sys
 import zipfile
 
+if sys.version_info.major == 2:
+    getargspec = inspect.getargspec
+else:
+    getargspec = inspect.getfullargspec
+
 import numpy
 
 from cclib.parser import utils
@@ -275,7 +280,7 @@ class Logfile(object):
             raise AttributeError("Class %s has no extract() method." % self.__class__.__name__)
         if not callable(self.extract):
             raise AttributeError("Method %s._extract not callable." % self.__class__.__name__)
-        if len(inspect.getargspec(self.extract)[0]) != 3:
+        if len(getargspec(self.extract)[0]) != 3:
             raise AttributeError("Method %s._extract takes wrong number of arguments." % self.__class__.__name__)
 
         # Save the current list of attributes to keep after parsing.


### PR DESCRIPTION
This eliminates warnings like:
```
/home/eric/development/cclib_berquist/cclib/parser/logfileparser.py:278: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
  if len(inspect.getargspec(self.extract)[0]) != 3:
```