### PR TITLE
Fix warnings about unclosed files and replace ccopen with ccread

### DIFF
--- a/test/io/testcjsonreader.py
+++ b/test/io/testcjsonreader.py
@@ -29,7 +29,7 @@ class CJSONReaderTest(unittest.TestCase):
         """File->ccData->CJSON->attribute_dict, the attributes within ccData and attribute_dict
            should be the same."""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         self.assertIsNotNone(data, "The logfileparser failed to parse the output file")
 
         cjson_obj = cclib.io.cjsonwriter.CJSON(data, terse=True)

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Unit tests for writer cjsonwriter module."""
+"""Unit tests for CJSON writer."""
 
 import os
 import unittest
@@ -27,7 +27,7 @@ class CJSONTest(unittest.TestCase):
     def test_init(self):
         """Does the class initialize correctly?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         cjson = cclib.io.cjsonwriter.CJSON(data)
 
         # The object should keep the ccData instance passed to its constructor.
@@ -36,7 +36,7 @@ class CJSONTest(unittest.TestCase):
     def test_cjson_generation(self):
         """Does the CJSON format get generated properly?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
 
         cjson = cclib.io.cjsonwriter.CJSON(data).generate_repr()
 

--- a/test/io/testfilewriter.py
+++ b/test/io/testfilewriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Unit tests for writer filewriter module."""
+"""Unit tests for general file writer."""
 
 import os
 import unittest
@@ -23,7 +23,7 @@ class WriterTest(unittest.TestCase):
     def test_init(self):
         """Does the class initialize correctly?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         writer = cclib.io.filewriter.Writer(data)
 
         # The object should keep the ccData instance passed to its constructor.

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Unit tests for moldenwriter module."""
+"""Unit tests for Molden writer."""
 
 import os
 import unittest
@@ -28,7 +28,7 @@ class MOLDENTest(unittest.TestCase):
                              "data/GAMESS/basicGAMESS-US2014/dvb_un_sp.out")
         required_attrs = ['atomcoords', 'atomnos', 'natom']
         for attr in required_attrs:
-            data = cclib.io.ccopen(fpath).parse()
+            data = cclib.io.ccread(fpath)
             delattr(data, attr)
 
             # Molden files cannot be wriiten if required attrs are missing.
@@ -39,7 +39,7 @@ class MOLDENTest(unittest.TestCase):
         """Check if size of Atoms section is equal to expected."""
         fpath = os.path.join(__datadir__,
                              "data/GAMESS/basicGAMESS-US2014/dvb_un_sp.out")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         writer = cclib.io.moldenwriter.MOLDEN(data)
         # Check size of Atoms section.
         self.assertEqual(len(writer._coords_from_ccdata(-1)), data.natom)
@@ -48,7 +48,7 @@ class MOLDENTest(unittest.TestCase):
         """Check if size of GTO section is equal to expected."""
         fpath = os.path.join(__datadir__,
                              "data/GAMESS/basicGAMESS-US2014/dvb_un_sp.out")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         writer = cclib.io.moldenwriter.MOLDEN(data)
         # Check size of GTO section.
         size_gto_ccdata = 0
@@ -64,7 +64,7 @@ class MOLDENTest(unittest.TestCase):
         """Check if size of MO section is equal to expected."""
         fpath = os.path.join(__datadir__,
                              "data/GAMESS/basicGAMESS-US2014/dvb_un_sp.out")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         writer = cclib.io.moldenwriter.MOLDEN(data)
         # Check size of MO section.
         size_mo_ccdata = 0
@@ -97,12 +97,13 @@ class MOLDENTest(unittest.TestCase):
         for fn in filenames:
             fpath = os.path.join(__datadir__,
                                  "data/GAMESS/basicGAMESS-US2014/"+fn+".out")
-            data = cclib.io.ccopen(fpath).parse()
+            data = cclib.io.ccread(fpath)
             cclib_out = cclib.io.moldenwriter.MOLDEN(data).generate_repr()
             # Reformat cclib's output to remove extra spaces.
             cclib_out_formatted = MoldenReformatter(cclib_out).reformat()
             fpath = os.path.join(__testdir__, "data/molden5.7_"+fn+".molden")
-            molden_out = open(fpath).read()
+            with open(fpath) as handle:
+                molden_out = handle.read()
             # Reformat Molden's output to remove extra spaces,
             # and fix number formatting.
             molden_out_formatted = MoldenReformatter(molden_out).reformat()

--- a/test/io/testwfxwriter.py
+++ b/test/io/testwfxwriter.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Unit tests for writer WFXwriter module."""
+"""Unit tests for wfx writer."""
 
 import os
 import unittest
@@ -31,7 +31,7 @@ class WFXTest(unittest.TestCase):
         required_attrs = ('atomcoords', 'atomnos', 'gbasis', 'charge',
                           'homos', 'mult', 'mocoeffs')
         for attr in required_attrs:
-            data = cclib.io.ccopen(fpath).parse()
+            data = cclib.io.ccread(fpath)
             delattr(data, attr)
 
             # WFX files cannot be written if required attrs are missing.
@@ -47,7 +47,7 @@ class WFXTest(unittest.TestCase):
         filepaths = [os.path.join(gamessdir, fn) for fn in filenames]
 
         for fpath in filepaths:
-            data = cclib.io.ccopen(fpath).parse()
+            data = cclib.io.ccread(fpath)
             wfx = cclib.io.wfxwriter.WFXWriter(data)
 
             no_prims_writer = wfx._no_of_prims()
@@ -63,7 +63,7 @@ class WFXTest(unittest.TestCase):
         """Check if MO section is printed correctly."""
         fpath = os.path.join(__datadir__,
                              "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         wfx = cclib.io.wfxwriter.WFXWriter(data)
 
         normalized_mocoeffs = wfx._normalized_mocoeffs()
@@ -77,7 +77,7 @@ class WFXTest(unittest.TestCase):
         """Check if MOs are normalized as expected."""
         fpath = os.path.join(__datadir__,
                              "data/GAMESS/basicGAMESS-US2017/dvb_sp.out")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         wfx = cclib.io.wfxwriter.WFXWriter(data)
 
         normalized_mocoeffs_wfx = wfx._normalized_mocoeffs()
@@ -122,14 +122,14 @@ class WFXTest(unittest.TestCase):
             'Firefly': "data/GAMESS/basicFirefly8.0/dvb_sp.out",
         }
         fpath_ref = os.path.join(__datadir__, ref_file)
-        data_ref = cclib.io.ccopen(fpath_ref).parse()
+        data_ref = cclib.io.ccread(fpath_ref)
         wfx_ref = cclib.io.wfxwriter.WFXWriter(data_ref)
         norm_mat_ref = wfx_ref._norm_mat()[0]
         mos_ref = wfx_ref._no_of_mos()
 
         for name in programs:
             fpath_prog = os.path.join(__datadir__, programs[name])
-            data_prog = cclib.io.ccopen(fpath_prog).parse()
+            data_prog = cclib.io.ccread(fpath_prog)
             wfx_prog = cclib.io.wfxwriter.WFXWriter(data_prog)
 
             norm_mat_prog = wfx_prog._norm_mat()[0]

--- a/test/io/testxyzwriter.py
+++ b/test/io/testxyzwriter.py
@@ -26,7 +26,7 @@ class XYZTest(unittest.TestCase):
     def test_init(self):
         """Does the class initialize correctly?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        data = cclib.io.ccopen(fpath).parse()
+        data = cclib.io.ccread(fpath)
         xyz = cclib.io.xyzwriter.XYZ(data)
 
         # The object should keep the ccData instance passed to its constructor.

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -75,15 +75,16 @@ class FileWrapperTest(unittest.TestCase):
         get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
         for lf in logfiles:
             path = "%s/%s" % (__datadir__, lf)
-            expected_attributes = get_attributes(cclib.io.ccopen(path).parse())
-            contents = open(path).read()
+            expected_attributes = get_attributes(cclib.io.ccread(path))
+            with open(path) as handle:
+                contents = handle.read()
             # This is fix strings not being unicode in Python2.
             try:
                 stdin = io.StringIO(contents)
             except TypeError:
                 stdin = io.StringIO(unicode(contents))
             stdin.seek = sys.stdin.seek
-            data = cclib.io.ccopen(stdin).parse()
+            data = cclib.io.ccread(stdin)
             self.assertEqual(get_attributes(data), expected_attributes)
 
 


### PR DESCRIPTION
One unclosed handle remains in the actual CJSON reader, but my solution involves other changes to the reader, so it can be fixed later.