### PR TITLE
Add basic EditorConfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# The full list of properties is located at
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties.
+
+root = true
+
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
See https://editorconfig.org/ for more information. Assuming your editor supports it either by default or using a plugin, these settings are automatically obeyed.

I didn't include `end_of_line = lf` because although we ultimately want that, I suspect it will automatically convert an entire Windows-terminated file once you open and save it, and if we want to fix line endings it should be done all at once as a separate change.