### PR TITLE
Exit with status 1 when there are any failures as well

### DIFF
--- a/test/test_data.py
+++ b/test/test_data.py
@@ -230,7 +230,7 @@ class DataSuite(object):
         print("TOTAL: %d\tPASSED: %d\tFAILED: %d\tERRORS: %d\tSKIPPED: %d" \
                 %(total[0], total[0]-(total[1]+total[2]+total[3]), total[2], total[1], total[3]), file=self.stream)
 
-        if self.status and len(self.errors) > 0:
+        if self.status and (self.errors or self.failures):
             sys.exit(1)
 
     def visualtests(self, stream=sys.stdout):


### PR DESCRIPTION
Note that this causes Travis to fail, intentionally. This should be followed by a fix for the failing Molcas unit test.