### PR TITLE
Parsing geotargets, geovalues correctly and enabling optdone for Molcas

### DIFF
--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -144,7 +144,6 @@ class GenericGeoOptTest(unittest.TestCase):
         dim_geovalues = (len(self.data.geovalues[0]), )
         self.assertEquals(dim_geotargets, dim_geovalues)
 
-    @skipForParser("Molcas", "geovalues and geotargets need to discussed and parsed correctly.")
     def testoptdone(self):
         """Has the geometry converged and set optdone to True?"""
         self.assertTrue(self.data.optdone)


### PR DESCRIPTION
Currently we were parsing the `geotargets` and `geovalues` which included energy changes in `geovalues` and energy change threshold in `geotargets`. But since energy change threshold can be zero (Default for Gaussian method of &slapaf), which means that energy change is not considered a criteria for optimization. In such cases `testoptdone` in testGeoOpt fails as the geotarget is zero and geovalues cannot be less than zero.
In such cases we parse the `energy change threshold` target as `numpy.inf`