### PR TITLE
Psi4: consolidate gradient parsing

### DIFF
--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -55,12 +55,8 @@ class Psi4(logfileparser.Logfile):
     # of gradient present (determined from the header), as
     # otherwise the parsing is identical.
     GRADIENT_HEADERS = {
-        '-Total Gradient:': 'analytic',
-        '## F-D gradient (Symmetry 0) ##': 'numerical',
-    }
-    GRADIENT_SKIP_LINES = {
-        'analytic': ['header', 'dash header'],
-        'numerical': ['Irrep num and total size', 'b', '123', 'b'],
+        '-Total Gradient:': ['header', 'dash header'],
+        '## F-D gradient (Symmetry 0) ##': ['Irrep num and total size', 'b', '123', 'b'],
     }
 
     def extract(self, inputfile, line):
@@ -823,8 +819,7 @@ class Psi4(logfileparser.Logfile):
 
             # Handle the different header lines between analytic and
             # numerical gradients.
-            gradient_type = Psi4.GRADIENT_HEADERS[line.strip()]
-            gradient_skip_lines = Psi4.GRADIENT_SKIP_LINES[gradient_type]
+            gradient_skip_lines = Psi4.GRADIENT_HEADERS[line.strip()]
             gradient = self.parse_gradient(inputfile, gradient_skip_lines)
 
             if not hasattr(self, 'grads'):

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -821,11 +821,15 @@ class Psi4(logfileparser.Logfile):
         #     3     0.00000000000000     0.00979709321487     0.01460651641258
         if line.strip() in Psi4.GRADIENT_HEADERS:
 
-            grads = self.parse_gradient(inputfile, line)
+            # Handle the different header lines between analytic and
+            # numerical gradients.
+            gradient_type = Psi4.GRADIENT_HEADERS[line.strip()]
+            gradient_skip_lines = Psi4.GRADIENT_SKIP_LINES[gradient_type]
+            gradient = self.parse_gradient(inputfile, gradient_skip_lines)
 
             if not hasattr(self, 'grads'):
                 self.grads = []
-            self.grads.append(grads)
+            self.grads.append(gradient)
 
         ## Harmonic frequencies.
 
@@ -935,13 +939,11 @@ class Psi4(logfileparser.Logfile):
             line = next(inputfile)
         return
 
-    def parse_gradient(self, inputfile, line):
+    def parse_gradient(self, inputfile, skip_lines):
         """Parse the nuclear gradient section into a list of lists with shape
-        [natom, 3]. It handles the different header lines between
-        analytic and numerical gradients.
+        [natom, 3].
         """
-        gradient_type = Psi4.GRADIENT_HEADERS[line.strip()]
-        self.skip_lines(inputfile, self.GRADIENT_SKIP_LINES[gradient_type])
+        self.skip_lines(inputfile, skip_lines)
         line = next(inputfile)
         gradient = []
 

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -22,18 +22,6 @@ class Psi4(logfileparser.Logfile):
         # Call the __init__ method of the superclass
         super(Psi4, self).__init__(logname="Psi4", *args, **kwargs)
 
-    # Match the number of skipped lines required based on the type
-    # of gradient present (determined from the header), as
-    # otherwise the parsing is identical.
-    GRADIENT_HEADERS = {
-        '-Total Gradient:': 'analytic',
-        '## F-D gradient (Symmetry 0) ##': 'numerical',
-    }
-    GRADIENT_SKIP_LINES = {
-        'analytic': ['header', 'dash header'],
-        'numerical': ['Irrep num and total size', 'b', '123', 'b'],
-    }
-
     def __str__(self):
         """Return a string representation of the object."""
         return "Psi4 log file %s" % (self.filename)
@@ -62,6 +50,18 @@ class Psi4(logfileparser.Logfile):
     def normalisesym(self, label):
         """Psi4 does not require normalizing symmetry labels."""
         return label
+
+    # Match the number of skipped lines required based on the type
+    # of gradient present (determined from the header), as
+    # otherwise the parsing is identical.
+    GRADIENT_HEADERS = {
+        '-Total Gradient:': 'analytic',
+        '## F-D gradient (Symmetry 0) ##': 'numerical',
+    }
+    GRADIENT_SKIP_LINES = {
+        'analytic': ['header', 'dash header'],
+        'numerical': ['Irrep num and total size', 'b', '123', 'b'],
+    }
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -819,17 +819,9 @@ class Psi4(logfileparser.Logfile):
         #     1     0.00000000000000     0.00000000000000    -0.02921303282515
         #     2     0.00000000000000    -0.00979709321487     0.01460651641258
         #     3     0.00000000000000     0.00979709321487     0.01460651641258
-
         if line.strip() in Psi4.GRADIENT_HEADERS:
-            gradient_type = Psi4.GRADIENT_HEADERS[line.strip()]
-            self.skip_lines(inputfile, self.GRADIENT_SKIP_LINES[gradient_type])
-            line = next(inputfile)
-            grads = []
 
-            while line.strip():
-                idx, x, y, z = line.split()
-                grads.append((float(x), float(y), float(z)))
-                line = next(inputfile)
+            grads = self.parse_gradient(inputfile, line)
 
             if not hasattr(self, 'grads'):
                 self.grads = []
@@ -942,6 +934,22 @@ class Psi4(logfileparser.Logfile):
                 self.moenergies[spinidx].append(moenergy)
             line = next(inputfile)
         return
+
+    def parse_gradient(self, inputfile, line):
+        """Parse the nuclear gradient section into a list of lists with shape
+        [natom, 3]. It handles the different header lines between
+        analytic and numerical gradients.
+        """
+        gradient_type = Psi4.GRADIENT_HEADERS[line.strip()]
+        self.skip_lines(inputfile, self.GRADIENT_SKIP_LINES[gradient_type])
+        line = next(inputfile)
+        gradient = []
+
+        while line.strip():
+            idx, x, y, z = line.split()
+            gradient.append((float(x), float(y), float(z)))
+            line = next(inputfile)
+        return gradient
 
     @staticmethod
     def parse_vibfreq(vibfreq):

--- a/test/regression.py
+++ b/test/regression.py
@@ -798,6 +798,11 @@ def testPsi4_Psi4_beta5_stopiter_psi_hf_out(logfile):
 def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
     """Ensure that finite difference gradients are parsed."""
     assert hasattr(logfile.data, 'grads')
+    assert logfile.data.grads.shape == (1, 3, 3)
+    assert abs(logfile.data.grads[0, 0, 2] - 0.05498126903657) < 1.0e-12
+    # In C2v symmetry, there are 5 unique displacements for the
+    # nuclear gradient, and this is at the MP2 level.
+    assert logfile.data.mpenergies.shape == (5, 1)
 
 # Q-Chem #
 


### PR DESCRIPTION
The only difference between an analytic and numerical gradient calculation is the number of blank lines, so remove all the duplicate code.

The numerical gradient regression test is also slightly more robust.