### PR TITLE
Turbomole: Added functionality for moenergies and mocoeffs

### DIFF
--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -174,12 +174,10 @@ class GenericSPTest(unittest.TestCase):
         """Are correct number of SCF convergence criteria being parsed?"""
         self.assertEquals(len(self.data.scftargets[0]), self.num_scf_criteria)
 
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testlengthmoenergies(self):
         """Is the number of evalues equal to nmo?"""
         self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
 
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testtypemoenergies(self):
         """Is moenergies a list containing one numpy array?"""
         self.assertEquals(type(self.data.moenergies), type([]))
@@ -188,7 +186,6 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('DALTON', 'mocoeffs not implemented yet')
     @skipForLogfile('Jaguar/basicJaguar7', 'Data file does not contain enough information. Can we make a new one?')
     @skipForLogfile('Psi3/basicPsi3', 'MO coefficients are printed separately for each SALC')
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis?"""
         self.assertEquals(type(self.data.mocoeffs), type([]))

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -41,7 +41,6 @@ class GenericSPunTest(unittest.TestCase):
         self.assertEquals(self.data.atomcoords.shape,(1,self.data.natom,3))
 
     @skipForParser('Jaguar', 'Data file does not contain enough information')
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 2 x nmo x nbasis?"""
         self.assertEquals(type(self.data.mocoeffs), type([]))
@@ -64,7 +63,6 @@ class GenericSPunTest(unittest.TestCase):
         msg = "%s != array([34,33],'i')" % numpy.array_repr(self.data.homos)
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34,33],"i"), msg)
 
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 2 x nmo?"""
         self.assertEquals(len(self.data.moenergies), 2)

--- a/test/testdata
+++ b/test/testdata
@@ -261,6 +261,7 @@ SPun      Psi4        GenericROSPTest       basicPsi4-1.0         dvb_sp_rohf.ou
 SPun      Psi4        GenericSPunTest       basicPsi4-1.0         dvb_sp_uhf.out
 SPun      Psi4        GenericSPunTest       basicPsi4-1.0         dvb_sp_uks.out
 SPun      QChem       GenericSPunTest       basicQChem4.2         dvb_sp_un.out
+SPun      Turbomole   GenericSPunTest       basicTurbomole5.9     dvb_un_sp/basis    dvb_un_sp/control    dvb_un_sp/job.last    dvb_un_sp/coord    dvb_un_sp/alpha    dvb_un_sp/beta    dvb_un_sp/gradient
 
 TD        ADF         ADFTDDFTTest          basicADF2007.01       dvb_td.adfout
 TD        ADF         ADFTDDFTTest          basicADF2013.01       dvb_td.adfout


### PR DESCRIPTION
mocoeffs and moenergies are usually parsed from `mos, alpha and beta` files.

Removed tests from testSP.py: testdimmocoeffs, testlengthmoenergies, testtypemoenergies
Removed tests from testSPun.py: testdimmocoeffs, testmoenergies