### PR TITLE
Molcas: Added functionality for ccenergies 

### DIFF
--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -20,7 +20,6 @@ __filedir__ = os.path.realpath(os.path.dirname(__file__))
 class GenericCCTest(unittest.TestCase):
     """Generic coupled cluster unittest"""
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testsign(self):
         """Are the coupled cluster corrections negative?"""

--- a/test/testdata
+++ b/test/testdata
@@ -80,6 +80,7 @@ CC        Molpro      GenericCCTest         basicMolpro2006       h2o_ccsd.out
 CC        Molpro      GenericCCTest         basicMolpro2012       h2o_ccsd.out
 CC        Molpro      GenericCCTest         basicMolpro2006       h2o_ccsd(t).out
 CC        Molpro      GenericCCTest         basicMolpro2012       h2o_ccsdt.out
+CC        Molcas      GenericCCTest         basicOpenMolcas18.0   water_ccsd.out
 CC        NWChem      GenericCCTest         basicNWChem6.0        water_ccsd(t).out
 CC        NWChem      GenericCCTest         basicNWChem6.5        water_ccsd(t).out
 CC        Psi4        GenericCCTest         basicPsi4-1.0         water_ccsd.out


### PR DESCRIPTION
Also removed tests from testCC.py:
`1. testsign`

I also made some changes to the parsing of `++    Optimization specifications:` section as the `&RASSCF` section also has a `++    Optimization specifications:` section through which the while loop was unable to break, and the parsing was failing.
@ATenderholt @berquist @langner Please review. Thanks!
(The tests are failing as the files are not yet merged).