### PR TITLE
Add ccframe, a script that writes data table files from logfiles

### DIFF
--- a/cclib/io/__init__.py
+++ b/cclib/io/__init__.py
@@ -16,10 +16,12 @@ from cclib.io.xyzreader import XYZ as XYZReader
 from cclib.io.xyzwriter import XYZ as XYZWriter
 
 # This allows users to type:
+#   from cclib.io import ccframe
 #   from cclib.io import ccopen
 #   from cclib.io import ccread
 #   from cclib.io import ccwrite
 #   from cclib.io import URL_PATTERN
+from cclib.io.ccio import ccframe
 from cclib.io.ccio import ccopen
 from cclib.io.ccio import ccread
 from cclib.io.ccio import ccwrite

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -23,6 +23,10 @@ from cclib.io import ccframe
 
 
 def main():
+    if not _has_pandas:
+        print("You need to have pandas installed")
+        sys.exit(1)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-O', '--output',
                         help=('the output document to write, including an '

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument('-O', '--output',
                         help=('the output document to write, including an '
                               'extension supported by pandas '
-                              '(csv, hdf/hdf5, json/cjson, pickle/pkl, xlsx)'))
+                              '(csv, h5/hdf/hdf5, json, pickle/pkl, xlsx)'))
     parser.add_argument('compchemlogfiles', metavar='compchemlogfile',
                         nargs='+',
                         help=('one or more computational chemistry output '
@@ -54,9 +54,9 @@ def main():
 
         if outputtype in {'csv'}:
             df.to_csv(output)
-        elif outputtype in {'hdf', 'hdf5'}:
+        elif outputtype in {'h5', 'hdf', 'hdf5'}:
             df.to_hdf(output, key=identifier)
-        elif outputtype in {'json', 'cjson'}:
+        elif outputtype in {'json'}:
             df.to_json(output)
         elif outputtype in {'pickle', 'pkl'}:
             df.to_pickle(output)

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Script for writing data tables from computational chemistry files."""
+
+import sys
+import os.path
+import argparse
+
+try:
+    import pandas as pd
+    _has_pandas = True
+except ImportError:
+    _has_pandas = False
+
+from cclib.io import ccopen
+from cclib.io import ccframe
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-O', '--outputdest',
+                        help=('the output document to write, including an '
+                              'extension supported by pandas '
+                              '(csv, hdf/hdf5, json/cjson, pickle/pkl, xlsx)'))
+    parser.add_argument('compchemlogfile',
+                        nargs='+',
+                        help=('one or more computational chemistry output '
+                              'files to parse and convert'))
+    parser.add_argument('--identifier',
+                        default='logfiles',
+                        help=('name of sheet which will contain DataFrame, if '
+                              'writing to an Excel file, or identifier for '
+                              'the group in HDFStore, if writing a HDF file'))
+    args = parser.parse_args()
+
+    outputdest = args.outputdest
+    identifier = args.identifier
+    filenames = args.compchemlogfile
+
+    df = ccframe([ccopen(path) for path in filenames])
+
+    if outputdest is not None:
+        outputtype = os.path.splitext(os.path.basename(outputdest))[1][1:]
+
+        if outputtype in {'csv'}:
+            df.to_csv(outputdest)
+        elif outputtype in {'hdf', 'hdf5'}:
+            df.to_hdf(outputdest, key=identifier)
+        elif outputtype in {'json', 'cjson'}:
+            df.to_json(outputdest)
+        elif outputtype in {'pickle', 'pkl'}:
+            df.to_pickle(outputdest)
+        elif outputtype in {'xlsx'}:
+            writer = pd.ExcelWriter(outputdest)
+            # This overwrites previous sheets
+            # (see https://stackoverflow.com/a/42375263/4039050)
+            df.to_excel(writer, sheet_name=identifier)
+            writer.save()
+    else:
+        print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -24,11 +24,11 @@ from cclib.io import ccframe
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-O', '--outputdest',
+    parser.add_argument('-O', '--output',
                         help=('the output document to write, including an '
                               'extension supported by pandas '
                               '(csv, hdf/hdf5, json/cjson, pickle/pkl, xlsx)'))
-    parser.add_argument('compchemlogfile',
+    parser.add_argument('compchemlogfiles', metavar='compchemlogfile',
                         nargs='+',
                         help=('one or more computational chemistry output '
                               'files to parse and convert'))
@@ -39,25 +39,25 @@ def main():
                               'the group in HDFStore, if writing a HDF file'))
     args = parser.parse_args()
 
-    outputdest = args.outputdest
+    output = args.output
     identifier = args.identifier
-    filenames = args.compchemlogfile
+    filenames = args.compchemlogfiles
 
     df = ccframe([ccopen(path) for path in filenames])
 
-    if outputdest is not None:
-        outputtype = os.path.splitext(os.path.basename(outputdest))[1][1:]
+    if output is not None:
+        outputtype = os.path.splitext(os.path.basename(output))[1][1:]
 
         if outputtype in {'csv'}:
-            df.to_csv(outputdest)
+            df.to_csv(output)
         elif outputtype in {'hdf', 'hdf5'}:
-            df.to_hdf(outputdest, key=identifier)
+            df.to_hdf(output, key=identifier)
         elif outputtype in {'json', 'cjson'}:
-            df.to_json(outputdest)
+            df.to_json(output)
         elif outputtype in {'pickle', 'pkl'}:
-            df.to_pickle(outputdest)
+            df.to_pickle(output)
         elif outputtype in {'xlsx'}:
-            writer = pd.ExcelWriter(outputdest)
+            writer = pd.ExcelWriter(output)
             # This overwrites previous sheets
             # (see https://stackoverflow.com/a/42375263/4039050)
             df.to_excel(writer, sheet_name=identifier)

--- a/doc/sphinx/how_to_parse.rst
+++ b/doc/sphinx/how_to_parse.rst
@@ -20,13 +20,14 @@ Importing cclib and parsing a file is a few lines of Python code, making it simp
 From command line
 +++++++++++++++++
 
-The cclib package provides three scripts to parse and write data i.e. ``ccget``, ``ccwrite``, and ``cda``
+The cclib package provides four scripts to parse and write data i.e. ``ccget``, ``ccwrite``, ``cda``, and ``ccframe``
 
 1. **ccget** is used to parse attribute data from output files.
 2. **ccwrite** has the ability to list out all valid attribute data that can be parsed from an output format. It has the added feature of writing the output file into four different formats i.e. ``json``, ``cjson``, ``cml``, ``xyz``.
 3. **cda** is used for the chemical decomposition analysis of output files.
+4. **ccframe** is used to write data tables from output files.
 
-This page describes how to use the ccget and ccwrite scripts to obtain data from output files.
+This page describes how to use the ccget, ccwrite and ccframe scripts to obtain data from output files.
 
 ccget
 -----
@@ -218,3 +219,20 @@ Using ``xyz`` as the <OutputFileFormat> with Benzeneselenol.out, we obtain the f
     H     -2.7028960000   -2.1530750000    0.0036640000
     Se     1.8210800000   -0.0433780000   -0.0038760000
     H      2.0043580000    1.4100070000    0.1034490000
+
+ccframe
+-------
+
+This script creates complete tables of data from output files in some of the formats supported by pandas_.
+Since the pandas library is not a dependency of cclib, `it must be installed <https://pandas.pydata.org/pandas-docs/stable/install.html>`_ separately.
+
+.. _pandas: https://pandas.pydata.org/
+
+A complete data table can be parsed from many output files by following this format
+
+.. code-block:: bash
+
+    ccframe -O <OutputDest> <CompChemLogFile> [<CompChemLogFile>...]
+
+The argument for ``-O`` indicates the data file to be written and its extesion specifies the filetype (e.g. csv, hdf/hdf5, json/cjson, pickle/pkl, xlsx).
+Since higher-dimensional attributes (e.g. ``atomcoords``) are handled as plain text in some file formats (such as Excel XLSX or CSV), we recommend storing JSON or HDF5 files.

--- a/doc/sphinx/how_to_parse.rst
+++ b/doc/sphinx/how_to_parse.rst
@@ -234,5 +234,5 @@ A complete data table can be parsed from many output files by following this for
 
     ccframe -O <OutputDest> <CompChemLogFile> [<CompChemLogFile>...]
 
-The argument for ``-O`` indicates the data file to be written and its extesion specifies the filetype (e.g. csv, hdf/hdf5, json/cjson, pickle/pkl, xlsx).
+The argument for ``-O`` indicates the data file to be written and its extesion specifies the filetype (e.g. csv, h5/hdf/hdf5, json, pickle/pkl, xlsx).
 Since higher-dimensional attributes (e.g. ``atomcoords``) are handled as plain text in some file formats (such as Excel XLSX or CSV), we recommend storing JSON or HDF5 files.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def setup_cclib():
         packages=setuptools.find_packages(exclude=['*test*']),
         entry_points={
             'console_scripts': [
+                'ccframe=cclib.scripts.ccframe:main',
                 'ccget=cclib.scripts.ccget:ccget',
                 'ccwrite=cclib.scripts.ccwrite:main',
                 'cda=cclib.scripts.cda:main'

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -109,6 +109,7 @@ class ccframeTest(unittest.TestCase):
         "cclib.scripts.ccframe.sys.argv",
         ["ccframe", INPUT_FILE]
     )
+    @patch("cclib.scripts.ccframe._has_pandas", True)
     def test_ccframe_call(self, mock_ccframe):
         """is ccframe called with the given parameters?"""
         self.main()
@@ -116,6 +117,16 @@ class ccframeTest(unittest.TestCase):
         self.assertEqual(mock_ccframe.call_count, 1)
         ccframe_call_args, ccframe_call_kwargs = mock_ccframe.call_args
         self.assertEqual(ccframe_call_args[0][0].filename, INPUT_FILE)
+
+    @patch(
+        "cclib.scripts.ccframe.sys.argv",
+        ["ccframe", INPUT_FILE]
+    )
+    @patch("cclib.scripts.ccframe._has_pandas", False)
+    def test_ccframe_call_without_pandas(self, mock_ccframe):
+        """does ccframe fails cleanly if pandas can't be imported?"""
+        with self.assertRaises(SystemExit):
+            self.main()
 
 
 if __name__ == "__main__":

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -88,5 +88,35 @@ class ccwriteTest(unittest.TestCase):
         self.assertEqual(ccwrite_call_args[2], CJSON_OUTPUT_FILENAME)
 
 
+@patch("cclib.scripts.ccframe.ccframe")
+class ccframeTest(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            from cclib.scripts import ccframe
+        except ImportError:
+            self.fail("ccframe cannot be imported")
+
+        self.main = ccframe.main
+
+    @patch('cclib.scripts.ccframe.sys.argv', ['ccframe'])
+    def test_empty_argv(self, mock_ccframe):
+        """Does the script fail as expected if called without parameters?"""
+        with self.assertRaises(SystemExit):
+            self.main()
+
+    @patch(
+        "cclib.scripts.ccframe.sys.argv",
+        ["ccframe", INPUT_FILE]
+    )
+    def test_ccframe_call(self, mock_ccframe):
+        """is ccframe called with the given parameters?"""
+        self.main()
+
+        self.assertEqual(mock_ccframe.call_count, 1)
+        ccframe_call_args, ccframe_call_kwargs = mock_ccframe.call_args
+        self.assertEqual(ccframe_call_args[0][0].filename, INPUT_FILE)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR is related to #580 and adds:

- a function (`cclib.io.ccframe`) that produces a pandas.DataFrame out of attributes parsed by cclib.
- a script that wraps the function above and writes complete data table files in many formats (currently CSV, HDF5, JSON, Pickle and Excel XLSX).
- a test for the script.
- simple usage description in the documentation.

Please let me know if anything needs to change.