### PR TITLE
Molcas: Added functionality to parse gbasis 

### DIFF
--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -45,8 +45,21 @@ class Molcas(logfileparser.Logfile):
         # Compile the dashes-and-or-spaces-only regex.
         self.re_dashes_and_spaces = re.compile('^[\s-]+$')
 
+    def _assing_gbasis_to_element(self, element, _array):
+        """Assign proper basis exponents and coefficients to element."""
+        mask = [element == possible_element
+                for possible_element in self.atomsymbols]
+        indices = [i for (i, x) in enumerate(mask) if x]
+        for index in indices:
+            self.gbasis[index] = _array
+
     def after_parsing(self):
-        pass
+        self.atomsymbols = [self.table.element[atomno]
+                                 for atomno in self.atomnos]
+        if hasattr(self, 'gbasis_array'):
+            self.gbasis = [[] for i in range(self.natom)]
+            for element, gbasis in self.gbasis_array:
+                self._assing_gbasis_to_element(element, gbasis)
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
@@ -724,6 +737,62 @@ class Molcas(logfileparser.Logfile):
                 if not hasattr(self, 'ccenergies'):
                     self.ccenergies= []
                 self.ccenergies.append(ccenergies)
+
+        #  ++    Primitive basis info:
+        #        ---------------------
+        #
+        #
+        #                      *****************************************************
+        #                      ******** Primitive Basis Functions (Valence) ********
+        #                      *****************************************************
+        #
+        #
+        #   Basis set:C.AUG-CC-PVQZ.........                                                          
+        #
+        #                    Type         
+        #                     s
+        #             No.      Exponent    Contraction Coefficients
+        #             1  0.339800000D+05   0.000091  -0.000019   0.000000   0.000000   0.000000   0.000000
+        #             2  0.508900000D+04   0.000704  -0.000151   0.000000   0.000000   0.000000   0.000000
+        # ...
+        # ...
+        #             29  0.424000000D+00   0.000000   1.000000
+        #
+        #   Number of primitives                                   93
+        #   Number of basis functions                              80
+        #
+        #  --
+        if '++    Primitive basis info:' in line:
+            self.skip_lines(inputfile, ['d', 'b', 'b', 's', 'header', 's', 'b'])
+            line = next(inputfile)
+            self.gbasis_array = []
+            while '--' not in line and '****' not in line:
+                if 'Basis set:' in line:
+                    basis_element = line.split()[1].split('.')[0].split(':')[1]
+                    basis_element = basis_element[0] + basis_element[1:].lower()
+                    self.gbasis_array.append((basis_element, []))
+
+                if 'Type' in line:
+                    exponents = []
+                    coefficients = []
+                    line = next(inputfile)
+                    _type = line.split()[0].upper()
+                    func_array = []
+                    self.skip_line(inputfile, 'headers')
+                    line = next(inputfile)
+                    while line.split():
+                        exponents.append(self.float(line.split()[1]))
+                        coefficients.append([self.float(i) for i in line.split()[2:]])
+                        line = next(inputfile)
+
+                    for i in range(len(coefficients[0])):
+                        func_tuple = (_type, [])
+                        for j in range(len(exponents)):
+                            if coefficients[j][i] != 0:
+                                func_tuple[1].append((exponents[j], coefficients[j][i]))
+                        self.gbasis_array[-1][1].append(func_tuple)
+
+                line = next(inputfile)
 
 
 if __name__ == '__main__':

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -35,13 +35,11 @@ class GenericBasisTest(unittest.TestCase):
     gbasis_C_2s_func0 = [2.9412, -0.1000]
     gbasis_C_2p_func0 = [2.9412, 0.1559]
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgbasis(self):
         """Is gbasis the right length?"""
         self.assertEquals(self.data.natom, len(self.data.gbasis))
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnames(self):
         """Are the name of basis set functions acceptable?"""
@@ -50,7 +48,6 @@ class GenericBasisTest(unittest.TestCase):
                 self.assert_(fns[0] in self.names,
                              "%s not one of S or P" % fns[0])
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testsizeofbasis(self):
         """Is the basis set the correct size?"""
@@ -63,7 +60,6 @@ class GenericBasisTest(unittest.TestCase):
 
         self.assertEquals(self.data.nbasis, total)
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcontractions(self):
         """Are the number of contractions on all atoms correct?"""
@@ -71,7 +67,6 @@ class GenericBasisTest(unittest.TestCase):
             atomno = self.data.atomnos[iatom]
             self.assertEquals(len(atom), self.contractions[atomno])
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testprimitives(self):
         """Are all primitives 2-tuples?"""
@@ -80,7 +75,6 @@ class GenericBasisTest(unittest.TestCase):
                 for primitive in contraction:
                     self.assertEquals(len(primitive), 2)
 
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcoeffs(self):
         """Are the atomic basis set exponents and coefficients correct?"""

--- a/test/testdata
+++ b/test/testdata
@@ -27,7 +27,6 @@ Basis     Gaussian    GenericBasisTest      basicGaussian09       dvb_sp.out
 Basis     Gaussian    GenericBasisTest      basicGaussian16       dvb_sp.out
 Basis     Jaguar      JaguarBasisTest       basicJaguar8.3        dvb_sp_hf.out
 Basis     Jaguar      JaguarBasisTest       basicJaguar8.3        dvb_sp_ks.out
-Basis     Molcas      GenericBasisTest      basicOpenMolcas18.0   dvb_sp.out
 Basis     Molpro      GenericBasisTest      basicMolpro2006       dvb_sphf.out
 Basis     Molpro      GenericBasisTest      basicMolpro2012       dvb_sphf.out
 Basis     NWChem      GenericBasisTest      basicNWChem6.0        dvb_sp_hf.out


### PR DESCRIPTION
So the `gbasis` are being parsed but the tests are failing because of the format of parsing. I still don't get how to identify which `S` exponents and coefficients are to be put in a separate tuple since `Molcas` doesn't print that explicitly.
@ATenderholt @langner @berquist Please have a look at my comment. Thanks!