### PR TITLE
Add Stoichiometry method

### DIFF
--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -37,7 +37,8 @@ class Nuclear(Method):
         pt = PeriodicTable()
         formula = ""
         for ano in sorted(set(self.data.atomnos), reverse=True):
-            formula += "%s%i" % (pt.element[ano], self.data.atomnos.count(ano))
+            count = numpy.count_nonzero(self.data.atomnos == ano)
+            formula += "%s%i" % (pt.element[ano], count)
         return formula
 
     def repulsion_energy(self):

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -32,13 +32,18 @@ class Nuclear(Method):
         """Return a representation of the object."""
         return "Nuclear"
 
-    def stoichoimetry(self):
+    def stoichiometry(self):
         """Return the stoichemistry of the object."""
         pt = PeriodicTable()
         formula = ""
         for ano in sorted(set(self.data.atomnos), reverse=True):
             count = numpy.count_nonzero(self.data.atomnos == ano)
             formula += "%s%i" % (pt.element[ano], count)
+        if hasattr(self.data, 'charge'):
+            if self.data.charge == 1:
+                formula += "(+1)"
+            elif self.data.charge == -1:
+                formula += "(-1)"
         return formula
 
     def repulsion_energy(self):

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -20,7 +20,7 @@ class Nuclear(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
-        self.required_attrs = ('natom','atomcoords','atomnos')
+        self.required_attrs = ('natom','atomcoords','atomnos','charge')
 
         super(Nuclear, self).__init__(data, progress, loglevel, logname)
 

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -39,11 +39,10 @@ class Nuclear(Method):
         for ano in sorted(set(self.data.atomnos), reverse=True):
             count = numpy.count_nonzero(self.data.atomnos == ano)
             formula += "%s%i" % (pt.element[ano], count)
-        if hasattr(self.data, 'charge'):
-            if self.data.charge == 1:
-                formula += "(+1)"
-            elif self.data.charge == -1:
-                formula += "(-1)"
+        if getattr(self.data, 'charge', 0):
+            magnitude = abs(self.data.charge)
+            sign = "+" if self.data.charge > 0 else "-"
+            formula += "(%s%i)" % (sign, magnitude)
         return formula
 
     def repulsion_energy(self):

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -33,12 +33,22 @@ class Nuclear(Method):
         return "Nuclear"
 
     def stoichiometry(self):
-        """Return the stoichemistry of the object."""
+        """Return the stoichemistry of the object according to the Hill system"""
         pt = PeriodicTable()
+        elements = [pt.element[ano] for ano in self.data.atomnos]
+        counts = {el: elements.count(el) for el in set(elements)}
+
         formula = ""
-        for ano in sorted(set(self.data.atomnos), reverse=True):
-            count = numpy.count_nonzero(self.data.atomnos == ano)
-            formula += "%s%i" % (pt.element[ano], count)
+        elcount = lambda el, c: "%s%i" % (el, c) if c > 1 else el
+        if 'C' in elements:
+            formula += elcount('C', counts['C'])
+            counts.pop('C')
+            if 'H' in elements:
+              formula += elcount('H', counts['H'])
+              counts.pop('H')
+        for el, c in sorted(counts.items()):
+            formula += elcount(el, c)
+
         if getattr(self.data, 'charge', 0):
             magnitude = abs(self.data.charge)
             sign = "+" if self.data.charge > 0 else "-"

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -12,6 +12,7 @@ import logging
 import numpy
 
 from cclib.method.calculationmethod import Method
+from cclib.parser.utils import PeriodicTable
 
 
 class Nuclear(Method):
@@ -30,6 +31,14 @@ class Nuclear(Method):
     def __repr__(self):
         """Return a representation of the object."""
         return "Nuclear"
+
+    def stoichoimetry(self):
+        """Return the stoichemistry of the object."""
+        pt = PeriodicTable()
+        formula = ""
+        for ano in sorted(set(self.data.atomnos), reverse=True):
+            formula += "%s%i" % (pt.element[ano], self.data.atomnos.count(ano))
+        return formula
 
     def repulsion_energy(self):
         """Return the nuclear repulsion energy."""

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -32,7 +32,9 @@ class NuclearTest(unittest.TestCase):
         data = ccData()
 
         def check(atomnos, formula, charge=0):
+            data.natom = len(atomnos)
             data.atomnos = numpy.array(atomnos)
+            data.atomcoords = numpy.zeros((data.natom, 3))
             data.charge = charge
             self.assertEqual(Nuclear(data).stoichiometry(), formula)
 

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -36,6 +36,10 @@ class NuclearTest(unittest.TestCase):
         self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+1)")
         data.charge = -1
         self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(-1)")
+        data.charge = 2
+        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+2)")
+        data.charge = 9
+        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+9)")
 
     def test_nre(self):
         """Testing nuclear repulsion energy for one logfile where it is printed."""

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -16,6 +16,7 @@ import unittest
 import numpy
 
 from cclib.method import Nuclear
+from cclib.parser import ccData
 from cclib.parser import QChem
 from cclib.parser import utils
 
@@ -25,6 +26,12 @@ from ..test_data import getdatafile
 
 
 class NuclearTest(unittest.TestCase):
+
+    def test_stoichiometry(self):
+        """Testing stoichoimetry generation."""
+        data = ccData()
+        data.atomnos = [6, 1, 6, 1, 1, 1]
+        self.assertEqual(Nuclear(data).stoichoimetry(), "C2H4")
 
     def test_nre(self):
         """Testing nuclear repulsion energy for one logfile where it is printed."""

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -30,7 +30,7 @@ class NuclearTest(unittest.TestCase):
     def test_stoichiometry(self):
         """Testing stoichoimetry generation."""
         data = ccData()
-        data.atomnos = [6, 1, 6, 1, 1, 1]
+        data.atomnos = numpy.areray([6, 1, 6, 1, 1, 1])
         self.assertEqual(Nuclear(data).stoichoimetry(), "C2H4")
 
     def test_nre(self):

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -30,16 +30,32 @@ class NuclearTest(unittest.TestCase):
     def test_stoichiometry(self):
         """Testing stoichoimetry generation."""
         data = ccData()
-        data.atomnos = numpy.array([6, 1, 6, 1, 1, 1])
-        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4")
-        data.charge = 1
-        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+1)")
-        data.charge = -1
-        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(-1)")
-        data.charge = 2
-        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+2)")
-        data.charge = 9
-        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+9)")
+
+        def check(atomnos, formula, charge=0):
+            data.atomnos = numpy.array(atomnos)
+            data.charge = charge
+            self.assertEqual(Nuclear(data).stoichiometry(), formula)
+
+        # Basics and permutations.
+        check([], "")
+        check([6, 1, 6, 1, 1, 1], "C2H4")
+        check([1, 1, 1, 6, 1, 6], "C2H4")
+       
+        # Charges.
+        check([8], "O", charge=0)
+        check([8], "O(+1)", charge=1)
+        check([8], "O(-1)", charge=-1)
+        check([8], "O(+2)", charge=2)
+        check([8], "O(+9)", charge=9)
+
+        # Element counts.
+        check([6, 1], "CH")
+        check([6] * 60, "C60")
+
+        # Test the Hill system.
+        check([8, 1, 1], "H2O")
+        check([6, 8, 8, 1, 1], "CH2O2")
+        check([16, 16, 8, 8], "O2S2")
 
     def test_nre(self):
         """Testing nuclear repulsion energy for one logfile where it is printed."""

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -30,8 +30,12 @@ class NuclearTest(unittest.TestCase):
     def test_stoichiometry(self):
         """Testing stoichoimetry generation."""
         data = ccData()
-        data.atomnos = numpy.areray([6, 1, 6, 1, 1, 1])
-        self.assertEqual(Nuclear(data).stoichoimetry(), "C2H4")
+        data.atomnos = numpy.array([6, 1, 6, 1, 1, 1])
+        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4")
+        data.charge = 1
+        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(+1)")
+        data.charge = -1
+        self.assertEqual(Nuclear(data).stoichiometry(), "C2H4(-1)")
 
     def test_nre(self):
         """Testing nuclear repulsion energy for one logfile where it is printed."""


### PR DESCRIPTION
This PR adds a `.stoichiometry()` method to `nuclear.Nuclear`. Cherry-picked from @langner's commits on PR #295 and updated to pass the current tests.

---

List of cherry-picked commits (as taken from [original PR](https://github.com/cclib/cclib/pull/295/commits)):

- 6e192f8ae01a6e528529501016b48d77308e8f60
- 6bad3bf820c55dbecc800116716c89f85e376ac9
- 086cc13e0675732559cf0628629dd63e81b1bfa5
- 336e16dcfa5d62d746467cb5d789d966de9226e0
- bb35f0e19d93c611ac984c75a22014b88603a4a4
- ff47a9fa705a7811ab6b482718d2df146c6d2ff3

---

PS: I deliberately left out the commits related to `ccData.stoichiometry` convenience property because cherry-picking those adds some strange newlines to `cclib.parser.data`. In fact, VS Code detects that file as CRLF-ended, while other files in the project are LF. Forcing the file to end with LF results in all lines being changed in diff view. No clue...
