### PR TITLE
Add method to calculate electric multipole moments

### DIFF
--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -14,6 +14,7 @@ from cclib.method.electrons import Electrons
 from cclib.method.fragments import FragmentAnalysis
 from cclib.method.lpa import LPA
 from cclib.method.mbo import MBO
+from cclib.method.moments import Moments
 from cclib.method.mpa import MPA
 from cclib.method.nuclear import Nuclear
 from cclib.method.opa import OPA

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -72,12 +72,12 @@ class Moments(Method):
         Keyword Args:
             masses - if None, then use default atomic masses. Otherwise,
                 the user-provided will be used.
-            decimals - a number of decimal places that atomic charges are
-                to be truncated to without rounding.
 
         Returns:
             A list where the first element is the origin of
-            coordinates, while other elements are multipole moments.
+            coordinates, while other elements are dipole and
+            quadrupole moments expressed in terms of Debye and
+            Buckingham units respectively.
 
         """
         coords = self.data.atomcoords[-1]

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Calculation of electric multipole moments based on data parsed by cclib."""
+
+import numpy
+
+from cclib.parser.utils import convertor
+from cclib.method.calculationmethod import Method
+
+
+class Moments(Method):
+    def __init__(self, data):
+        self.required_attrs = ('atomcoords', 'atomcharges')
+
+        super(Moments, self).__init__(data)
+
+    def __str__(self):
+        """Returns a string representation of the object."""
+        return "Multipole moments of %s" % (self.data)
+
+    def __repr__(self):
+        """Returns a representation of the object."""
+        return 'Moments("%s")' % (self.data)
+
+    def calculate(self, gauge='nuccharge', population='mulliken', **kwargs):
+        """Calculate electric dipole moment using parsed partial atomic
+        charges.
+        
+        Args:
+            gauge - a choice of gauge origin. Can be either a string or
+                a three-element iterable. If iterable, then it
+                explicitly defines the origin. If string, then the
+                value can be any one of the following and it describes
+                what is used as the origin:
+                    * 'nuccharge' -- center of positive nuclear charge
+                    * 'mass' -- center of mass
+
+        Keyword Args:
+            masses - if None, then use default atomic masses. Otherwise,
+                the user-provided will be used.
+            decimals - a number of decimal places that atomic charges are
+                to be truncated to without rounding.
+
+        Returns:
+            A list where the first element is the origin of coordinates,
+            while other elements are multipole moments expressed in Debye
+            units.
+        """
+        coords = self.data.atomcoords[-1]
+        try:
+            charges = self.data.atomcharges[population]
+        except KeyError:
+            raise ValueError
+
+        if hasattr(gauge, '__iter__') and not isinstance(gauge, str):
+            origin = numpy.asarray(gauge)
+        elif gauge == 'nuccharge':
+            origin = numpy.average(coords, weights=self.data.atomnos, axis=0)
+        elif gauge == 'mass':
+            if 'masses' in kwargs:
+                atommasses = numpy.asarray(kwargs.get('masses'))
+            else:
+                atommasses = self.data.atommasses
+            origin = numpy.average(coords, weights=atommasses, axis=0)
+        else:
+            raise ValueError
+
+        one_debye = convertor(1, 'Angstrom', 'bohr') * convertor(1, 'ebohr', 'Debye')
+        if self.data.charge == 0:
+            dipole = numpy.dot(charges, coords) * one_debye
+        else:
+            dipole = numpy.dot(charges, coords - origin) * one_debye
+
+        moments = [origin, dipole]
+        return moments

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -72,6 +72,9 @@ class Moments(Method):
         Keyword Args:
             masses - if None, then use default atomic masses. Otherwise,
                 the user-provided will be used.
+            overwrite - it defines whether to modify the data object or
+                just return results. If `moments` attribute already exists,
+                the old value will be fully replaced. 
 
         Returns:
             A list where the first element is the origin of
@@ -101,6 +104,13 @@ class Moments(Method):
 
         dipole = self._calculate_dipole(charges, coords, origin)
         quadrupole = self._calculate_quadrupole(charges, coords, origin)
-
         moments = [origin, dipole, quadrupole]
+        
+        if 'overwrite' in kwargs:
+            if hasattr(self.data, 'moments'):
+                msg = ("Overwriting existing moments attribute values "
+                       "with newly calculated ones.")
+                self.logger.info(msg)
+            self.data.moments = moments
+
         return moments

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Test the Moments method in cclib"""
+
+from __future__ import print_function
+
+import sys
+import os
+import logging
+import unittest
+
+import numpy
+from numpy.testing import assert_almost_equal
+
+from cclib.method import Moments, MPA
+from cclib.parser import Gaussian
+
+sys.path.insert(1, "..")
+
+from ..test_data import getdatafile
+
+
+class MomentsTest(unittest.TestCase):
+    def test_results(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate()
+        assert_almost_equal(x, [[0,0,0], [0,0, -0.91543]], 5)
+
+    def test_origin_displacement(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate()
+        y = Moments(data).calculate(gauge=(2e7,18,28))
+        assert_almost_equal(x[1], y[1])
+
+    def test_origin_at_center_of_nuclear_charge(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate(gauge="nuccharge")
+        assert_almost_equal(x[0], [0, 0, 0], 6)
+
+    def test_origin_at_center_of_mass(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate(gauge="mass")
+        assert_almost_equal(x[0], [0, 0, 0.0524806])
+
+    def test_user_provided_origin(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate(gauge=(1,1,1))
+        assert_almost_equal(x[0], [1, 1, 1])
+                            
+    def test_user_provided_masses(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        x = Moments(data).calculate(masses=[15.9949146,1.007825,1.007825], gauge="mass")
+        x = Moments(data).calculate(masses=[1,1,1], gauge="mass")
+        assert_almost_equal(x[0], [0, 0, -0.2780383])
+        
+
+        
+if __name__ == "__main__":
+    unittest.TextTestRunner(verbosity=2).run(unittest.makeSuite(MomentsTest))

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -16,7 +16,7 @@ import numpy
 from numpy.testing import assert_almost_equal
 
 from cclib.method import Moments
-from cclib.parser import Gaussian
+from cclib.parser import Gaussian, NWChem
 
 sys.path.insert(1, "..")
 
@@ -54,11 +54,19 @@ class MomentsTest(unittest.TestCase):
                             
     def test_user_provided_masses(self):
         data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
-        x = Moments(data).calculate(masses=[15.9949146,1.007825,1.007825], gauge="mass")
         x = Moments(data).calculate(masses=[1,1,1], gauge="mass")
         assert_almost_equal(x[0], [0, 0, -0.2780383])
-        
 
+    def test_inplace_modifying(self):
+        data, _ = getdatafile(NWChem, "basicNWChem6.5", ["water_mp2.out"])
+        assert not hasattr(data, "moments")        
+        Moments(data).calculate(overwrite=True)
+        assert hasattr(data, "moments")
+
+    def test_inplace_modifying2(self):
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
+        Moments(data).calculate(overwrite=True)
+        assert_almost_equal(data.moments[1], [0,0, -0.91543], 5)
         
 if __name__ == "__main__":
     unittest.TextTestRunner(verbosity=2).run(unittest.makeSuite(MomentsTest))

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -27,7 +27,6 @@ class MomentsTest(unittest.TestCase):
     def test_results(self):
         data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
         x = Moments(data).calculate()
-        print(x[2])
         assert_almost_equal(x[0], [0,0,0], 5)
         assert_almost_equal(x[1], [0,0, -0.91543], 5)
         assert_almost_equal(x[2][0] + x[2][3] + x[2][5], 0)

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -10,14 +10,12 @@
 from __future__ import print_function
 
 import sys
-import os
-import logging
 import unittest
 
 import numpy
 from numpy.testing import assert_almost_equal
 
-from cclib.method import Moments, MPA
+from cclib.method import Moments
 from cclib.parser import Gaussian
 
 sys.path.insert(1, "..")
@@ -29,7 +27,10 @@ class MomentsTest(unittest.TestCase):
     def test_results(self):
         data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])
         x = Moments(data).calculate()
-        assert_almost_equal(x, [[0,0,0], [0,0, -0.91543]], 5)
+        print(x[2])
+        assert_almost_equal(x[0], [0,0,0], 5)
+        assert_almost_equal(x[1], [0,0, -0.91543], 5)
+        assert_almost_equal(x[2][0] + x[2][3] + x[2][5], 0)
 
     def test_origin_displacement(self):
         data, _ = getdatafile(Gaussian, "basicGaussian16", ["water_mp2.log"])

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -14,6 +14,7 @@ sys.path.insert(1, "method")
 
 from .method.testcda import *
 from .method.testmbo import *
+from .method.testmoments import *
 from .method.testnuclear import *
 from .method.testorbitals import *
 from .method.testpopulation import *


### PR DESCRIPTION
This adds a new `Moments` method and closes #311. It allows to calculate dipole and traceless quadrupole moments using parsed atomic charges and coordinates. Using input parameters, the choice of origin, the type of population analysis, and the necessity of updating parsed data object with calculated values can be specified.