### PR TITLE
Alpha & beta electrons

### DIFF
--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -19,7 +19,7 @@ class Electrons(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
-        self.required_attrs = ('atomnos','charge','coreelectrons')
+        self.required_attrs = ('atomnos','charge','coreelectrons','homos')
 
         super(Electrons, self).__init__(data, progress, loglevel, logname)
 
@@ -30,6 +30,20 @@ class Electrons(Method):
     def __repr__(self):
         """Returns a representation of the object."""
         return "Electrons"
+
+    def alpha(self):
+        """Number of alpha electrons"""
+        homos = self.data.homos
+        if len(homos) == 1:
+            return homos[0] + 1
+        return homos[0] + 1
+
+    def beta(self):
+        """Number of beta electrons"""
+        homos = self.data.homos
+        if len(homos) == 1:
+            return homos[0] + 1
+        return homos[1] + 1
 
     def count(self, core=False):
         """Returns the electron count in system.

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -33,18 +33,12 @@ class Electrons(Method):
 
     def alpha(self):
         """Number of alpha electrons"""
-        homos = self.data.homos
-        if len(homos) == 1:
-            return homos[0] + 1
-        return homos[0] + 1
+        return self.data.homos[0] + 1
 
     def beta(self):
         """Number of beta electrons"""
-        homos = self.data.homos
-        if len(homos) == 1:
-            return homos[0] + 1
-        return homos[1] + 1
-
+        return self.data.homos[-1] + 1
+        
     def count(self, core=False):
         """Returns the electron count in system.
 

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -43,6 +43,22 @@ class ElectronsTest(unittest.TestCase):
         self.assertEqual(Electrons(data).count(), 120)
         self.assertEqual(Electrons(data).count(core=True), 188)
 
+    def test_alpha_beta(self):
+        """Test number of alpha and beta electrons"""
+        # Systems with alpha == beta
+        data, logfile = getdatafile(QChem, "basicQChem4.2", ["water_mp4sdq.out"])
+        self.assertEqual(Electrons(data).alpha(), 5)
+        self.assertEqual(Electrons(data).beta(), 5)
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["water_cis.log"])
+        self.assertEqual(Electrons(data).alpha(), 5)
+        self.assertEqual(Electrons(data).beta(), 5)
+        # Systems with alpha != beta
+        data, logfile = getdatafile(QChem, "basicQChem4.2", ["dvb_sp_un.out"])
+        self.assertEqual(Electrons(data).alpha(), 35)
+        self.assertEqual(Electrons(data).beta(), 34)
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["dvb_un_sp.log"])
+        self.assertEqual(Electrons(data).alpha(), 35)
+        self.assertEqual(Electrons(data).beta(), 34)
 
 if __name__ == "__main__":
     unittest.TextTestRunner(verbosity=2).run(unittest.makeSuite(ElectronsTest))

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -30,16 +30,16 @@ class ElectronsTest(unittest.TestCase):
 
     def test_count(self):
         """Test electron count for logfiles without pseudopotentials."""
-        data, logfile = getdatafile(QChem, "basicQChem4.2", "water_mp4sdq.out")
+        data, logfile = getdatafile(QChem, "basicQChem4.2", ["water_mp4sdq.out"])
         self.assertEqual(Electrons(data).count(), 10)
         self.assertEqual(Electrons(data).count(core=True), 10)
-        data, logfile = getdatafile(Gaussian, "basicGaussian09", "water_cis.log")
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["water_cis.log"])
         self.assertEqual(Electrons(data).count(), 10)
         self.assertEqual(Electrons(data).count(core=True), 10)
 
     def test_count_pseudopotential(self):
         """Test electron count for logfiles with pseudopotentials."""
-        data, logfile = getdatafile(Gaussian, "basicGaussian09", "Mo4OCl4-sp.log")
+        data, logfile = getdatafile(Gaussian, "basicGaussian09", ["Mo4OCl4-sp.log"])
         self.assertEqual(Electrons(data).count(), 120)
         self.assertEqual(Electrons(data).count(core=True), 188)
 

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -13,6 +13,7 @@ import unittest
 sys.path.insert(1, "method")
 
 from .method.testcda import *
+from .method.testelectrons import *
 from .method.testmbo import *
 from .method.testnuclear import *
 from .method.testorbitals import *


### PR DESCRIPTION
As discussed in PR #295, this implements `alpha` and `beta` electrons in `cclib.method.electrons`. Tests are included. By the way, writing those tests I realized that `testelectrons` were not being imported in `test_method`. Since those weren't being tested, there was an error in the `getdatafile` calls that I have also fixed with this PR.

I have also tried to add convenience properties to `ccData`, but there is this issue with the newlines. Git still marks some lines as changed, even though I did not trim anything with the editor. Anyway, the code is trivial:

In `cclib.parser.data.ccData`:

```
    @property
    def alpha_electrons(self):
        return Electrons(self).alpha()

    @property
    def beta_electrons(self):
        return Electrons(self).beta()
```

At the end of `tests.method.testelectrons.ElectronsTest.test_alpha_beta`:

```
        # Test ccData properties
        self.assertEqual(data.alpha_electrons, 35)
        self.assertEqual(data.beta_electrons, 34)

```