### PR TITLE
Infer natom from atomcoords in Turbomole output

### DIFF
--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -150,6 +150,7 @@ class Turbomole(logfileparser.Logfile):
 
             self.append_attribute('atomcoords', atomcoords)
             self.set_attribute('atomnos', atomnos)
+            self.set_attribute('natom', len(atomcoords))
 
         # Frequency values in aoforce.out
         #        mode               7        8        9       10       11       12

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -26,6 +26,10 @@ class GenericIRTest(unittest.TestCase):
         """Initialize the number of vibrational frequencies on a per molecule basis"""
         self.numvib = 3*len(self.data.atomnos) - 6
 
+    def testbasics(self):
+        """Are basic attributes correct?"""
+        self.assertEqual(self.data.natom, 20)
+
     def testvibdisps(self):
         """Are the dimensions of vibdisps consistent with numvib x N x 3"""
         self.assertEqual(len(self.data.vibfreqs), self.numvib)


### PR DESCRIPTION
This also adds a little check in testvib for natom to specifically address
https://github.com/cclib/cclib/issues/626