### PR TITLE
CJSON bond atom index should start from 0

### DIFF
--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -133,8 +133,8 @@ class CJSON(filewriter.Writer):
             cjson_dict['bonds']['connections'] = dict()
             cjson_dict['bonds']['connections']['index'] = []
             for bond in self.bond_connectivities:
-                cjson_dict['bonds']['connections']['index'].append(bond[0] + 1)
-                cjson_dict['bonds']['connections']['index'].append(bond[1] + 1)
+                cjson_dict['bonds']['connections']['index'].append(bond[0])
+                cjson_dict['bonds']['connections']['index'].append(bond[1])
             cjson_dict['bonds']['order'] = [bond[2] for bond in self.bond_connectivities]
 
         if _has_openbabel:

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -49,6 +49,13 @@ class CJSONTest(unittest.TestCase):
             sqrt(sum(data.moments[1] ** 2))
         )
 
+        # Ensure the bond connectivity index starts from 0
+        bonds = json_data.get('bonds', None)
+        self.assertIsNotNone(bonds)
+        indices = bonds['connections']['index']
+        self.assertEqual(min(indices), 0)
+        self.assertTrue(max(indices) < number_of_atoms)
+
     def test_zero_dipole_moment(self):
         """Does the CJSON writer handle zero dipole moment correctly?"""
         fpath = os.path.join(__datadir__, "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out")


### PR DESCRIPTION
In all the `cjson` examples I have seen so far, the atom index in the bonds connection array start from 0