### PR TITLE
GAMESS: fix for parsing EOM-CC output (etenergies ignored)

### DIFF
--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -290,8 +290,8 @@ class GAMESS(logfileparser.Logfile):
             mult = int(line.split()[-1])
             self.set_attribute('mult', mult)
 
-        # Electronic transitions (etenergies) for CIS runs. The outputs
-        # for TD-DFT and EOM look very different.
+        # Electronic transitions (etenergies) for CIS runs and TD-DFT, which
+        # have very similar outputs. The outputs EOM look very differentm, though.
         #
         #  ---------------------------------------------------------------------
         #                    CI-SINGLES EXCITATION ENERGIES
@@ -299,7 +299,7 @@ class GAMESS(logfileparser.Logfile):
         #  ---------------------------------------------------------------------
         #   1A''   0.1677341781     4.5643    105.2548      36813.40     271.64
         #   ...
-        if line.strip() == "CI-SINGLES EXCITATION ENERGIES":
+        if re.match("(CI-SINGLES|TDDFT) EXCITATION ENERGIES", line.strip()):
 
             if not hasattr(self, "etenergies"):
                 self.etenergies = []

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -290,8 +290,16 @@ class GAMESS(logfileparser.Logfile):
             mult = int(line.split()[-1])
             self.set_attribute('mult', mult)
 
-        # etenergies (originally used only for CIS runs, but now also TD-DFT)
-        if "EXCITATION ENERGIES" in line and line.find("DONE WITH") < 0:
+        # Electronic transitions (etenergies) for CIS runs. The outputs
+        # for TD-DFT and EOM look very different.
+        #
+        #  ---------------------------------------------------------------------
+        #                    CI-SINGLES EXCITATION ENERGIES
+        #  STATE       HARTREE        EV      KCAL/MOL       CM-1         NM
+        #  ---------------------------------------------------------------------
+        #   1A''   0.1677341781     4.5643    105.2548      36813.40     271.64
+        #   ...
+        if line.strip() == "CI-SINGLES EXCITATION ENERGIES":
 
             if not hasattr(self, "etenergies"):
                 self.etenergies = []

--- a/test/regression.py
+++ b/test/regression.py
@@ -286,6 +286,10 @@ def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
     assert numpy.count_nonzero(logfile.data.mocoeffs[0][80-1: 0:]) == 0
     assert logfile.data.mocoeffs[0].all() == logfile.data.mocoeffs[1].all()
 
+def testGAMESS_GAMESS_US2018_exam45_log(logfile):
+    """This logfile has EOM-CC electronic transitions (not currently supported)."""
+    assert not hasattr(logfile.data, 'etenergies')
+
 def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     """Do some basic checks for this old unit test that was failing.
 


### PR DESCRIPTION
I simply made the condition that triggers to code very specific to CIS output.

This will need to go in once cclib/cclib#97 is merged.