### PR TITLE
ORCA: fix for missing * terminator in echoed input file

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -169,7 +169,7 @@ class ORCA(logfileparser.Logfile):
                         for line in lines_iter:
                             if not line:
                                 continue
-                            if line[0] == '*':
+                            if line[0] == '*' or "end" in line:
                                 break
                             # Strip basis specification that can appear after coordinates
                             line = line.split('newGTO')[0].strip()


### PR DESCRIPTION
Closes https://github.com/cclib/cclib/issues/650.

This needs to go in _before_ https://github.com/cclib/cclib-data/pull/98.