### PR TITLE
Fixes for Gaussian98 G3 job from NIST CCCBDB

### DIFF
--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -412,6 +412,22 @@ class Logfile(object):
 
         return float(number.replace("D", "E"))
 
+    def new_internal_job(self):
+        """Delete attributes that can be problematic in multistep jobs.
+
+        TODO: instead of this hack, parse each job in a multistep comptation
+        as a different ccData object (this is for 2.x).
+
+        Some computations are actually sequences of several jobs, and some
+        attributes won't work well if parsed across jobs. There include:
+            mpenergies: if different jobs go to different orders then
+                        these won't be consistent and can't be converted
+                        to an array easily
+        """
+        for name in ("mpenergies",):
+            if hasattr(self, name):
+                delattr(self, name)
+
     def set_attribute(self, name, value, check=True):
         """Set an attribute and perform a check when it already exists.
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -330,6 +330,17 @@ def testGaussian_Gaussian98_C_bigmult_log(logfile):
     assert logfile.data.homos[0] == 8
     assert logfile.data.homos[1] == -1 # No occupied beta orbitals
 
+def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
+    """A G3 computation is a sequence of jobs."""
+
+    # All steps deal with the same molecule, so we extract the coordinates
+    # from all steps.
+    assert len(logfile.data.atomcoords) == 10
+
+    # Different G3 steps do perturbation to different orders, and so
+    # we expect only the last MP2 energy to be extracted.
+    assert len(logfile.data.mpenergies) == 1
+
 def testGaussian_Gaussian98_test_Cu2_log(logfile):
     """An example of the number of basis set function changing."""
     assert logfile.data.nbasis == 38


### PR DESCRIPTION
These are several minor quick fixes to get this file parsing, with a basic regression test.

The major issue is that G3 is actually a sequence of jobs. So until we have better support for that I just wanted to get the file parsing with useful data. Deleting only some attributes (`mpenergies` here) from previous steps is maybe not the best thing to do, but it seemed like a better option than deleting all attributes.