### PR TITLE
DALTON: fix version parsing of never development versions

### DIFF
--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -81,6 +81,27 @@ class DALTON(logfileparser.Logfile):
 
         # Extract the version number and optionally the Git revision
         # number.
+        #
+        # Example strings that at least the major version is parsed from:
+        #                            
+        # This is output from DALTON 2013.2
+        #                            2013.4
+        #                            2014.0
+        #                            2014.alpha
+        #                            2015.0
+        #                            2016.alpha
+        #                            (Release 1.1, September 2000)
+        #                            Release 2011 (DEVELOPMENT VERSION)
+        #                            Release 2011 (Rev. 0, Dec. 2010)
+        #                            Release 2011 (Rev. 0, Mar. 2011)
+        #                            (Release 2.0 rev. 0, Mar. 2005)
+        #                            (Release Dalton2013 patch 0)
+        #                            release Dalton2017.alpha (2016)
+        #                            release Dalton2017.alpha (2017)
+        #                            release Dalton2018.0 (2018)
+        #                            release Dalton2018.0-rc (2018)
+        #                            release Dalton2018.alpha (2018)
+        #                            release Dalton2019.alpha (2018)
         if line[4:30] == "This is output from DALTON":
             rs = (r"from DALTON \(?(?:Release|release)?\s?(?:Dalton)?"
                   r"(\d+\.?[\w\d\-]*)"

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -82,10 +82,12 @@ class DALTON(logfileparser.Logfile):
         # Extract the version number and optionally the Git revision
         # number.
         if line[4:30] == "This is output from DALTON":
-            rs = r"([0-9]{4})\D\s?\w*\s?([0-9]{1})"
+            rs = (r"from DALTON \(?(?:Release|release)?\s?(?:Dalton)?"
+                  r"(\d+\.?[\w\d\-]*)"
+                  r"(?:[\s,]\(?)?")
             match = re.search(rs, line)
-            package_version = ".".join(match.groups())
-            self.metadata["package_version"] = package_version
+            if match:
+                self.metadata["package_version"] = match.groups()[0]
         # Don't add revision information to the main package version for now.
         if "Last Git revision" in line:
             revision = line.split()[4]

--- a/test/regression.py
+++ b/test/regression.py
@@ -215,6 +215,16 @@ def testDALTON_DALTON_2016_Trp_polar_response_diplnx_out(logfile):
     assert abs(logfile.data.polarizabilities[0][0, 0] - 95.11540019) < 1.0e-8
     assert numpy.count_nonzero(numpy.isnan(logfile.data.polarizabilities)) == 8
 
+def testDALTON_DALTON_2018_dft_properties_nosym_H2O_cc_pVDZ_out(logfile):
+    """The "simple" version string in newer development versions of DALTON wasn't
+    being parsed properly.
+
+    This file is in DALTON-2018, rather than DALTON-2019, because 2018.0 was
+    just released.
+    """
+    assert "package_version" in logfile.data.metadata
+    assert logfile.data.metadata["package_version"] == "2019.alpha"
+
 # Firefly #
 
 def testGAMESS_Firefly8_0_dvb_gopt_a_unconverged_out(logfile):


### PR DESCRIPTION
The file for https://github.com/cclib/cclib/issues/667 and https://github.com/cclib/cclib-data/pull/103.

This needs to go in **before** https://github.com/cclib/cclib-data/pull/103.