### PR TITLE
Molcas Parser fix

### DIFF
--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -685,7 +685,10 @@ class Molcas(logfileparser.Logfile):
                 self.skip_line(inputfile, 'b')
 
                 # Symmetry is not currently supported, so this line can have one form.
-                line = next(inputfile)
+                while 'Molecular orbitals for symmetry species 1: a' not in line.strip():
+                    line = next(inputfile)
+
+                # Symmetry is not currently supported, so this line can have one form.
                 if line.strip() != 'Molecular orbitals for symmetry species 1: a':
                     return
                 

--- a/test/regression.py
+++ b/test/regression.py
@@ -627,7 +627,7 @@ def testMolcas_Molcas18_test_standard_001_out(logfile):
     assert logfile.data.nbasis == 30
     assert logfile.data.nmo == 30
 
-def testMolcas_Molcas18_test_stadard_003_out(logfile):
+def testMolcas_Molcas18_test_standard_003_out(logfile):
     """This logfile has extra charged monopoles (not part of the molecule)."""
     assert logfile.data.charge == 0
 


### PR DESCRIPTION
Small molcas parser fix. Mocoeffs were not parsed in regression tests because
of an extra comment line and extra blank line. This is fixed.

This implements the change discussed in #659 