### PR TITLE
Fix deprecation warnings

### DIFF
--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -219,6 +219,6 @@ class JSONIndentEncoder(json.JSONEncoder):
             self.current_indent_str = "".join([" " for x in range(self.current_indent)])
             return "{\n" + ",\n".join(output) + "\n" + self.current_indent_str + "}"
         elif isinstance(o, np.generic):
-            return json.dumps(np.asscalar(o), cls=NumpyAwareJSONEncoder)
+            return json.dumps(o.item(), cls=NumpyAwareJSONEncoder)
         else:
             return json.dumps(o, cls=NumpyAwareJSONEncoder)

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -7,7 +7,12 @@
 
 """Calculation of electric multipole moments based on data parsed by cclib."""
 
-from collections import Iterable
+import sys
+
+if sys.version_info <= (3, 3):
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 import numpy
 

--- a/test/data/testBOMD.py
+++ b/test/data/testBOMD.py
@@ -27,19 +27,19 @@ class GenericBOMDTest(unittest.TestCase):
         """Are the number of parsed energies consistent with the number of MD
         steps?
         """
-        self.assertEquals(self.data.scfenergies.shape, (self.nenergies, ))
+        self.assertEqual(self.data.scfenergies.shape, (self.nenergies, ))
 
     def testdimatomcoords(self):
         """Are the number of parsed geometries consistent with the number of
         MD steps?
         """
-        self.assertEquals(self.data.atomcoords.shape, (self.nenergies, 20, 3))
+        self.assertEqual(self.data.atomcoords.shape, (self.nenergies, 20, 3))
 
     def testdimtime(self):
         """Are the number of time points consistent with the number of MD
         steps?
         """
-        self.assertEquals(self.data.time.shape, (self.nsteps, ))
+        self.assertEqual(self.data.time.shape, (self.nsteps, ))
 
 
 class GaussianBOMDTest(GenericBOMDTest):

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -38,14 +38,14 @@ class GenericBasisTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgbasis(self):
         """Is gbasis the right length?"""
-        self.assertEquals(self.data.natom, len(self.data.gbasis))
+        self.assertEqual(self.data.natom, len(self.data.gbasis))
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnames(self):
         """Are the name of basis set functions acceptable?"""
         for atom in self.data.gbasis:
             for fns in atom:
-                self.assert_(fns[0] in self.names,
+                self.assertTrue(fns[0] in self.names,
                              "%s not one of S or P" % fns[0])
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
@@ -58,14 +58,14 @@ class GenericBasisTest(unittest.TestCase):
             for (ftype, contraction) in atom:
                 total += multiple[ftype]
 
-        self.assertEquals(self.data.nbasis, total)
+        self.assertEqual(self.data.nbasis, total)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcontractions(self):
         """Are the number of contractions on all atoms correct?"""
         for iatom, atom in enumerate(self.data.gbasis):
             atomno = self.data.atomnos[iatom]
-            self.assertEquals(len(atom), self.contractions[atomno])
+            self.assertEqual(len(atom), self.contractions[atomno])
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testprimitives(self):
@@ -73,7 +73,7 @@ class GenericBasisTest(unittest.TestCase):
         for atom in self.data.gbasis:
             for ftype, contraction in atom:
                 for primitive in contraction:
-                    self.assertEquals(len(primitive), 2)
+                    self.assertEqual(len(primitive), 2)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcoeffs(self):

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -24,7 +24,7 @@ class GenericCCTest(unittest.TestCase):
     def testsign(self):
         """Are the coupled cluster corrections negative?"""
         corrections = self.data.ccenergies - self.data.scfenergies
-        self.failUnless(numpy.alltrue(corrections < 0.0))
+        self.assertTrue(numpy.alltrue(corrections < 0.0))
 
 
 if __name__ == "__main__":

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -57,11 +57,11 @@ class GenericCISTest(unittest.TestCase):
         triplets = [self.data.etenergies[i] for i in indices1]
         # All programs do singlets.
         singletdiff = singlets[:4] - self.etenergies0
-        self.failUnless(numpy.alltrue(singletdiff < 50))
+        self.assertTrue(numpy.alltrue(singletdiff < 50))
         # Not all programs do triplets (i.e. Jaguar).
         if len(triplets) >= 4:
             tripletdiff = triplets[:4] - self.etenergies1
-            self.failUnless(numpy.alltrue(tripletdiff < 50))
+            self.assertTrue(numpy.alltrue(tripletdiff < 50))
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
@@ -69,7 +69,7 @@ class GenericCISTest(unittest.TestCase):
         """Is the sum of etsecs close to 1?"""
         etsec = self.data.etsecs[2] # Pick one with several contributors
         sumofsec = sum([z*z for (x, y, z) in etsec])
-        self.assertAlmostEquals(sumofsec, 1.0, delta=0.02)
+        self.assertAlmostEqual(sumofsec, 1.0, delta=0.02)
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
@@ -86,7 +86,7 @@ class GenericCISTest(unittest.TestCase):
                 for s in singlets[i]:
                     if s[0][0] == exc[0] and s[1][0] == exc[1]:
                         found = True
-                        self.assertAlmostEquals(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
+                        self.assertAlmostEqual(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
                 if not found:
                     self.fail("Excitation %i->%s not found (singlet state %i)" %(exc[0], exc[1], i))
         # Not all programs do triplets (i.e. Jaguar).
@@ -97,7 +97,7 @@ class GenericCISTest(unittest.TestCase):
                     for s in triplets[i]:
                         if s[0][0] == exc[0] and s[1][0] == exc[1]:
                             found = True
-                            self.assertAlmostEquals(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
+                            self.assertAlmostEqual(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
                     if not found:
                         self.fail("Excitation %i->%s not found (triplet state %i)" %(exc[0], exc[1], i))
 
@@ -107,11 +107,11 @@ class GAMESSCISTest(GenericCISTest):
 
     def testnocoeffs(self):
         """Are natural orbital coefficients the right size?"""
-        self.assertEquals(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
+        self.assertEqual(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
 
     def testnooccnos(self):
         """Are natural orbital occupation numbers the right size?"""
-        self.assertEquals(self.data.nooccnos.shape, (self.data.nmo, ))
+        self.assertEqual(self.data.nooccnos.shape, (self.data.nmo, ))
 
 
 class GaussianCISTest(GenericCISTest):
@@ -120,11 +120,11 @@ class GaussianCISTest(GenericCISTest):
 
     def testnocoeffs(self):
         """Are natural orbital coefficients the right size?"""
-        self.assertEquals(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
+        self.assertEqual(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
 
     def testnooccnos(self):
         """Are natural orbital occupation numbers the right size?"""
-        self.assertEquals(self.data.nooccnos.shape, (self.data.nmo, ))
+        self.assertEqual(self.data.nooccnos.shape, (self.data.nmo, ))
 
 
 

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -43,23 +43,23 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
-        self.assertEquals(self.data.natom, 20)
+        self.assertEqual(self.data.natom, 20)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
         # This will work only for numpy
-        #self.assertEquals(self.data.atomnos.dtype.char, 'i')
+        #self.assertEqual(self.data.atomnos.dtype.char, 'i')
 
         atomnos_types = [numpy.issubdtype(atomno, numpy.signedinteger)
                          for atomno in self.data.atomnos]
-        self.failUnless(numpy.alltrue(atomnos_types))
+        self.assertTrue(numpy.alltrue(atomnos_types))
 
-        self.assertEquals(self.data.atomnos.shape, (20,) )
+        self.assertEqual(self.data.atomnos.shape, (20,) )
 
         count_C = sum(self.data.atomnos == 6)
         count_H = sum(self.data.atomnos == 1)
-        self.assertEquals(count_C + count_H, 20)
+        self.assertEqual(count_C + count_H, 20)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomcoords(self):
@@ -67,7 +67,7 @@ class GenericGeoOptTest(unittest.TestCase):
         natom = len(self.data.atomcoords[0])
         ref = self.data.natom
         msg = "natom is %d but len(atomcoords[0]) is %d" % (ref, natom)
-        self.assertEquals(natom, ref, msg)
+        self.assertEqual(natom, ref, msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomcoords_units(self):
@@ -80,14 +80,14 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
-        self.assertEquals(self.data.charge, 0)
-        self.assertEquals(self.data.mult, 1)
+        self.assertEqual(self.data.charge, 0)
+        self.assertEqual(self.data.mult, 1)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnbasis(self):
         """Is the number of basis set functions correct?"""
         count = sum([self.nbasisdict[n] for n in self.data.atomnos])
-        self.assertEquals(self.data.nbasis, count)
+        self.assertEqual(self.data.nbasis, count)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcoreelectrons(self):
@@ -113,8 +113,8 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testscfvaluetype(self):
         """Are scfvalues and its elements the right type?"""
-        self.assertEquals(type(self.data.scfvalues),type([]))
-        self.assertEquals(type(self.data.scfvalues[0]),type(numpy.array([])))
+        self.assertEqual(type(self.data.scfvalues),type([]))
+        self.assertEqual(type(self.data.scfvalues[0]),type(numpy.array([])))
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testscfenergy(self):
@@ -123,21 +123,21 @@ class GenericGeoOptTest(unittest.TestCase):
         ref = self.b3lyp_energy
         tol = self.b3lyp_tolerance
         msg = "Final scf energy: %f not %i +- %ieV" %(scf, ref, tol)
-        self.assertAlmostEquals(scf, ref, delta=40, msg=msg)
+        self.assertAlmostEqual(scf, ref, delta=40, msg=msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testscfenergydim(self):
         """Is the number of SCF energies consistent with atomcoords?"""
         count_scfenergies = self.data.scfenergies.shape[0] - self.extrascfs
         count_atomcoords = self.data.atomcoords.shape[0] - self.extracoords
-        self.assertEquals(count_scfenergies, count_atomcoords)
+        self.assertEqual(count_scfenergies, count_atomcoords)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testscftargetdim(self):
         """Do the scf targets have the right dimensions?"""
         dim_scftargets = self.data.scftargets.shape
         dim_scfvalues = (len(self.data.scfvalues),len(self.data.scfvalues[0][0]))
-        self.assertEquals(dim_scftargets, dim_scfvalues)
+        self.assertEqual(dim_scftargets, dim_scfvalues)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgeovalues_atomcoords(self):
@@ -145,21 +145,21 @@ class GenericGeoOptTest(unittest.TestCase):
         count_geovalues = len(self.data.geovalues)
         count_coords = len(self.data.atomcoords) - self.extracoords
         msg = "len(atomcoords) is %d but len(geovalues) is %d" % (count_coords, count_geovalues)
-        self.assertEquals(count_geovalues, count_coords, msg)
+        self.assertEqual(count_geovalues, count_coords, msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgeovalues_scfvalues(self):
         """Are scfvalues consistent with geovalues?"""
         count_scfvalues = len(self.data.scfvalues) - self.extrascfs
         count_geovalues = len(self.data.geovalues)
-        self.assertEquals(count_scfvalues, count_geovalues)
+        self.assertEqual(count_scfvalues, count_geovalues)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgeotargets(self):
         """Do the geo targets have the right dimensions?"""
         dim_geotargets = self.data.geotargets.shape
         dim_geovalues = (len(self.data.geovalues[0]), )
-        self.assertEquals(dim_geotargets, dim_geovalues)
+        self.assertEqual(dim_geotargets, dim_geovalues)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testoptdone(self):
@@ -190,9 +190,9 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are only the final MOs parsed?"""
-        self.assertEquals(len(self.data.moenergies), 1)
+        self.assertEqual(len(self.data.moenergies), 1)
         if hasattr(self.data, "mocoeffs"):
-            self.assertEquals(len(self.data.mocoeffs), 1)
+            self.assertEqual(len(self.data.mocoeffs), 1)
 
     @skipForParser("ADF", "Not implemented.")
     @skipForParser("DALTON", "Not implemented.")
@@ -204,7 +204,7 @@ class GenericGeoOptTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testgradsdim(self):
         """Do the grads have the right dimensions?"""
-        self.assertEquals(self.data.grads.shape,(len(self.data.geovalues),self.data.natom,3))
+        self.assertEqual(self.data.grads.shape,(len(self.data.geovalues),self.data.natom,3))
 
 
 class ADFGeoOptTest(GenericGeoOptTest):

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -33,7 +33,7 @@ class GenericMP2Test(unittest.TestCase):
             corrections = self.data.mpenergies[:,0] - self.data.scfenergies
         else:
             corrections = self.data.mpenergies[:,self.level-2] - self.data.mpenergies[:,self.level-3]
-        self.failUnless(numpy.alltrue(corrections < 0.0))
+        self.assertTrue(numpy.alltrue(corrections < 0.0))
         
 class GenericMP3Test(GenericMP2Test):
     """Generic MP3 unittest"""
@@ -57,11 +57,11 @@ class GaussianMP2Test(GenericMP2Test):
         
     def testnocoeffs(self):
         """Are natural orbital coefficients the right size?"""
-        self.assertEquals(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
+        self.assertEqual(self.data.nocoeffs.shape, (self.data.nmo, self.data.nbasis))
 
     def testnocoeffs(self):
         """Are natural orbital occupation numbers the right size?"""
-        self.assertEquals(self.data.nooccnos.shape, (self.data.nmo, ))
+        self.assertEqual(self.data.nooccnos.shape, (self.data.nmo, ))
 
 class GaussianMP3Test(GenericMP2Test):
     """Customized MP3 unittest"""

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -42,18 +42,18 @@ class GenericSPTest(unittest.TestCase):
 
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
-        self.assertEquals(self.data.natom, 20)
+        self.assertEqual(self.data.natom, 20)
 
     def testatomnos(self):
         """Are the atomnos correct?"""
 
         # The nuclear charges should be integer values in a NumPy array.
-        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
+        self.assertTrue(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
                                        for atomno in self.data.atomnos]))
-        self.assertEquals(self.data.atomnos.dtype.char, 'i')
+        self.assertEqual(self.data.atomnos.dtype.char, 'i')
 
-        self.assertEquals(self.data.atomnos.shape, (20,) )
-        self.assertEquals(sum(self.data.atomnos == 6) + sum(self.data.atomnos == 1), 20)
+        self.assertEqual(self.data.atomnos.shape, (20,) )
+        self.assertEqual(sum(self.data.atomnos == 6) + sum(self.data.atomnos == 1), 20)
 
     @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
     @skipForLogfile('Jaguar/basicJaguar7', 'We did not print the atomic partial charges in the unit tests for this version')
@@ -64,13 +64,13 @@ class GenericSPTest(unittest.TestCase):
         """Are atomcharges (at least Mulliken) consistent with natom and sum to zero?"""
         for type in set(['mulliken'] + list(self.data.atomcharges.keys())):
             charges = self.data.atomcharges[type]
-            self.assertEquals(len(charges), self.data.natom)
-            self.assertAlmostEquals(sum(charges), 0.0, delta=0.001)
+            self.assertEqual(len(charges), self.data.natom)
+            self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
 
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""
         expected_shape = (1, self.data.natom, 3)
-        self.assertEquals(self.data.atomcoords.shape, expected_shape)
+        self.assertEqual(self.data.atomcoords.shape, expected_shape)
 
     def testatomcoords_units(self):
         """Are atomcoords consistent with Angstroms?"""
@@ -82,14 +82,14 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
-        self.assertEquals(self.data.charge, 0)
-        self.assertEquals(self.data.mult, 1)
+        self.assertEqual(self.data.charge, 0)
+        self.assertEqual(self.data.mult, 1)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnbasis(self):
         """Is the number of basis set functions correct?"""
         count = sum([self.nbasisdict[n] for n in self.data.atomnos])
-        self.assertEquals(self.data.nbasis, count)
+        self.assertEqual(self.data.nbasis, count)
 
     @skipForParser('ADF', 'ADF parser does not extract atombasis')
     @skipForLogfile('Jaguar/basicJaguar7', 'Data file does not contain enough information. Can we make a new one?')
@@ -99,12 +99,12 @@ class GenericSPTest(unittest.TestCase):
         """Are the indices in atombasis the right amount and unique?"""
         all = []
         for i, atom in enumerate(self.data.atombasis):
-            self.assertEquals(len(atom), self.nbasisdict[self.data.atomnos[i]])
+            self.assertEqual(len(atom), self.nbasisdict[self.data.atomnos[i]])
             all += atom
         # Test if there are as many indices as atomic orbitals.
-        self.assertEquals(len(all), self.data.nbasis)
+        self.assertEqual(len(all), self.data.nbasis)
         # Check if all are different (every orbital indexed once).
-        self.assertEquals(len(set(all)), len(all))
+        self.assertEqual(len(set(all)), len(all))
 
     @skipForParser('GAMESS', 'atommasses not implemented yet')
     @skipForParser('GAMESSUK', 'atommasses not implemented yet')
@@ -120,7 +120,7 @@ class GenericSPTest(unittest.TestCase):
         """Do the atom masses sum up to the molecular mass?"""
         mm = 1000*sum(self.data.atommasses)
         msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
-        self.assertAlmostEquals(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
+        self.assertAlmostEqual(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcoreelectrons(self):
@@ -142,7 +142,7 @@ class GenericSPTest(unittest.TestCase):
     def testsymlabels(self):
         """Are all the symmetry labels either Ag/u or Bg/u?"""
         sumwronglabels = sum([x not in ['Ag', 'Bu', 'Au', 'Bg'] for x in self.data.mosyms[0]])
-        self.assertEquals(sumwronglabels, 0)
+        self.assertEqual(sumwronglabels, 0)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testhomos(self):
@@ -151,25 +151,25 @@ class GenericSPTest(unittest.TestCase):
 
     def testscfvaluetype(self):
         """Are scfvalues and its elements the right type??"""
-        self.assertEquals(type(self.data.scfvalues),type([]))
-        self.assertEquals(type(self.data.scfvalues[0]),type(numpy.array([])))
+        self.assertEqual(type(self.data.scfvalues),type([]))
+        self.assertEqual(type(self.data.scfvalues[0]),type(numpy.array([])))
 
     def testscfenergy(self):
         """Is the SCF energy within the target?"""
-        self.assertAlmostEquals(self.data.scfenergies[-1], self.b3lyp_energy, delta=40, msg="Final scf energy: %f not %i +- 40eV" %(self.data.scfenergies[-1], self.b3lyp_energy))
+        self.assertAlmostEqual(self.data.scfenergies[-1], self.b3lyp_energy, delta=40, msg="Final scf energy: %f not %i +- 40eV" %(self.data.scfenergies[-1], self.b3lyp_energy))
 
     def testscftargetdim(self):
         """Do the scf targets have the right dimensions?"""
-        self.assertEquals(self.data.scftargets.shape, (len(self.data.scfvalues), len(self.data.scfvalues[0][0])))
+        self.assertEqual(self.data.scftargets.shape, (len(self.data.scfvalues), len(self.data.scfvalues[0][0])))
 
     def testscftargets(self):
         """Are correct number of SCF convergence criteria being parsed?"""
-        self.assertEquals(len(self.data.scftargets[0]), self.num_scf_criteria)
+        self.assertEqual(len(self.data.scftargets[0]), self.num_scf_criteria)
 
     def testlengthmoenergies(self):
         """Is the number of evalues equal to nmo?"""
         if hasattr(self.data, "moenergies"):
-            self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
+            self.assertEqual(len(self.data.moenergies[0]), self.data.nmo)
 
     def testtypemoenergies(self):
         """Is moenergies a list containing one numpy array?"""
@@ -184,9 +184,9 @@ class GenericSPTest(unittest.TestCase):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis?"""
         if hasattr(self.data, "mocoeffs"):
             self.assertIsInstance(self.data.mocoeffs, list)
-            self.assertEquals(len(self.data.mocoeffs), 1)
-            self.assertEquals(self.data.mocoeffs[0].shape,
-                          (self.data.nmo, self.data.nbasis))
+            self.assertEqual(len(self.data.mocoeffs), 1)
+            self.assertEqual(self.data.mocoeffs[0].shape,
+                             (self.data.nmo, self.data.nbasis))
     
     @skipForParser('DALTON', 'mocoeffs not implemented yet')
     @skipForLogfile('Jaguar/basicJaguar7', 'Data file does not contain enough information. Can we make a new one?')
@@ -216,22 +216,22 @@ class GenericSPTest(unittest.TestCase):
     def testaooverlaps(self):
         """Are the dims and values of the overlap matrix correct?"""
 
-        self.assertEquals(self.data.aooverlaps.shape, (self.data.nbasis, self.data.nbasis))
+        self.assertEqual(self.data.aooverlaps.shape, (self.data.nbasis, self.data.nbasis))
 
         # The matrix is symmetric.
         row = self.data.aooverlaps[0,:]
         col = self.data.aooverlaps[:,0]
-        self.assertEquals(sum(col - row), 0.0)
+        self.assertEqual(sum(col - row), 0.0)
 
         # All values on diagonal should be exactly zero.
         for i in range(self.data.nbasis):
-            self.assertEquals(self.data.aooverlaps[i,i], 1.0)
+            self.assertEqual(self.data.aooverlaps[i,i], 1.0)
 
         # Check some additional values that don't seem to move around between programs.
-        self.assertAlmostEquals(self.data.aooverlaps[0, 1], self.overlap01, delta=0.01)
-        self.assertAlmostEquals(self.data.aooverlaps[1, 0], self.overlap01, delta=0.01)
-        self.assertEquals(self.data.aooverlaps[3,0], 0.0)
-        self.assertEquals(self.data.aooverlaps[0,3], 0.0)
+        self.assertAlmostEqual(self.data.aooverlaps[0, 1], self.overlap01, delta=0.01)
+        self.assertAlmostEqual(self.data.aooverlaps[1, 0], self.overlap01, delta=0.01)
+        self.assertEqual(self.data.aooverlaps[3,0], 0.0)
+        self.assertEqual(self.data.aooverlaps[0,3], 0.0)
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
@@ -250,47 +250,47 @@ class GenericSPTest(unittest.TestCase):
         # origin or center of mass. In this case, however, the center of mass
         # is at the origin, so we now what to expect.
         reference = self.data.moments[0]
-        self.assertEquals(len(reference), 3)
+        self.assertEqual(len(reference), 3)
         for x in reference:
-            self.assertEquals(x, 0.0)
+            self.assertEqual(x, 0.0)
 
         # Length and value of dipole moment should always be correct (zero for this test).
         dipole = self.data.moments[1]
-        self.assertEquals(len(dipole), 3)
+        self.assertEqual(len(dipole), 3)
         for d in dipole:
-            self.assertAlmostEquals(d, 0.0, places=7)
+            self.assertAlmostEqual(d, 0.0, places=7)
 
         # If the quadrupole is there, we can expect roughly -50B for the XX moment,
         # -50B for the YY moment and and -60B for the ZZ moment.
         if len(self.data.moments) > 2:
             quadrupole = self.data.moments[2]
-            self.assertEquals(len(quadrupole), 6)
-            self.assertAlmostEquals(quadrupole[0], -50, delta=2.5)
-            self.assertAlmostEquals(quadrupole[3], -50, delta=2.5)
-            self.assertAlmostEquals(quadrupole[5], -60, delta=3)
+            self.assertEqual(len(quadrupole), 6)
+            self.assertAlmostEqual(quadrupole[0], -50, delta=2.5)
+            self.assertAlmostEqual(quadrupole[3], -50, delta=2.5)
+            self.assertAlmostEqual(quadrupole[5], -60, delta=3)
 
         # If the octupole is there, it should have 10 components and be zero.
         if len(self.data.moments) > 3:
             octupole = self.data.moments[3]
-            self.assertEquals(len(octupole), 10)
+            self.assertEqual(len(octupole), 10)
             for m in octupole:
-                self.assertAlmostEquals(m, 0.0, delta=0.001)
+                self.assertAlmostEqual(m, 0.0, delta=0.001)
 
         # The hexadecapole should have 15 elements, an XXXX component of around -1900 Debye*ang^2,
         # a YYYY component of -330B and a ZZZZ component of -50B.
         if len(self.data.moments) > 4:
             hexadecapole = self.data.moments[4]
-            self.assertEquals(len(hexadecapole), 15)
-            self.assertAlmostEquals(hexadecapole[0], -1900, delta=90)
-            self.assertAlmostEquals(hexadecapole[10], -330, delta=11)
-            self.assertAlmostEquals(hexadecapole[14], -50, delta=2.5)
+            self.assertEqual(len(hexadecapole), 15)
+            self.assertAlmostEqual(hexadecapole[0], -1900, delta=90)
+            self.assertAlmostEqual(hexadecapole[10], -330, delta=11)
+            self.assertAlmostEqual(hexadecapole[14], -50, delta=2.5)
 
         # The are 21 unique 32-pole moments, and all are zero in this test case.
         if len(self.data.moments) > 5:
             moment32 = self.data.moments[5]
-            self.assertEquals(len(moment32), 21)
+            self.assertEqual(len(moment32), 21)
             for m in moment32:
-                self.assertEquals(m, 0.0)
+                self.assertEqual(m, 0.0)
 
     @skipForParser('ADF', 'Does not support metadata yet')
     @skipForParser('GAMESSUK', 'Does not support metadata yet')
@@ -329,18 +329,18 @@ class ADFSPTest(GenericSPTest):
     def testfoverlaps(self):
         """Are the dims and values of the fragment orbital overlap matrix correct?"""
 
-        self.assertEquals(self.data.fooverlaps.shape, (self.data.nbasis, self.data.nbasis))
+        self.assertEqual(self.data.fooverlaps.shape, (self.data.nbasis, self.data.nbasis))
 
         # The matrix is symmetric.
         row = self.data.fooverlaps[0,:]
         col = self.data.fooverlaps[:,0]
-        self.assertEquals(sum(col - row), 0.0)
+        self.assertEqual(sum(col - row), 0.0)
 
         # Although the diagonal elements are close to zero, the SFOs
         # are generally not normalized, so test for a few specific values.
-        self.assertAlmostEquals(self.data.fooverlaps[0, 0], self.foverlap00, delta=0.0001)
-        self.assertAlmostEquals(self.data.fooverlaps[1, 1], self.foverlap11, delta=0.0001)
-        self.assertAlmostEquals(self.data.fooverlaps[2, 2], self.foverlap22, delta=0.0001)
+        self.assertAlmostEqual(self.data.fooverlaps[0, 0], self.foverlap00, delta=0.0001)
+        self.assertAlmostEqual(self.data.fooverlaps[1, 1], self.foverlap11, delta=0.0001)
+        self.assertAlmostEqual(self.data.fooverlaps[2, 2], self.foverlap22, delta=0.0001)
 
 class GaussianSPTest(GenericSPTest):
     """Customized restricted single point unittest"""
@@ -358,7 +358,7 @@ class Jaguar7SPTest(JaguarSPTest):
     # Jaguar prints only 10 virtual MOs by default. Can we re-run with full output?
     def testlengthmoenergies(self):
         """Is the number of evalues equal to the number of occ. MOs + 10?"""
-        self.assertEquals(len(self.data.moenergies[0]), self.data.homos[0]+11)
+        self.assertEqual(len(self.data.moenergies[0]), self.data.homos[0]+11)
 
 class MolcasSPTest(GenericSPTest):
     """Customized restricted single point unittest"""

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -25,32 +25,32 @@ class GenericSPunTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnatom(self):
         """Is the number of atoms equal to 20?"""
-        self.assertEquals(self.data.natom, 20)
+        self.assertEqual(self.data.natom, 20)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomnos(self):
         """Are the atomnos correct?"""
-        self.failUnless(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
+        self.assertTrue(numpy.alltrue([numpy.issubdtype(atomno, numpy.signedinteger)
                                        for atomno in self.data.atomnos]))
-        self.assertEquals(self.data.atomnos.shape, (20,) )
-        self.assertEquals(sum(self.data.atomnos==6) + sum(self.data.atomnos==1), 20)
+        self.assertEqual(self.data.atomnos.shape, (20,) )
+        self.assertEqual(sum(self.data.atomnos==6) + sum(self.data.atomnos==1), 20)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""
-        self.assertEquals(self.data.atomcoords.shape,(1,self.data.natom,3))
+        self.assertEqual(self.data.atomcoords.shape,(1,self.data.natom,3))
 
     @skipForParser('Jaguar', 'Data file does not contain enough information')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 2 x nmo x nbasis?"""
         if hasattr(self.data, "mocoeffs"):
             self.assertIsInstance(self.data.mocoeffs, list)
-            self.assertEquals(len(self.data.mocoeffs), 2)
-            self.assertEquals(self.data.mocoeffs[0].shape,
-                          (self.data.nmo, self.data.nbasis))
-            self.assertEquals(self.data.mocoeffs[1].shape,
-                          (self.data.nmo, self.data.nbasis))
-    
+            self.assertEqual(len(self.data.mocoeffs), 2)
+            self.assertEqual(self.data.mocoeffs[0].shape,
+                             (self.data.nmo, self.data.nbasis))
+            self.assertEqual(self.data.mocoeffs[1].shape,
+                             (self.data.nmo, self.data.nbasis))
+
     @skipForParser('Jaguar', 'Data file does not contain enough information')
     @skipForParser('DALTON', 'mocoeffs not implemented yet')
     def testfornsoormo(self):
@@ -81,8 +81,8 @@ class GenericSPunTest(unittest.TestCase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
         """Are the charge and multiplicity correct?"""
-        self.assertEquals(self.data.charge, 1)
-        self.assertEquals(self.data.mult, 2)
+        self.assertEqual(self.data.charge, 1)
+        self.assertEqual(self.data.mult, 2)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testhomos(self):
@@ -93,9 +93,9 @@ class GenericSPunTest(unittest.TestCase):
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 2 x nmo?"""
         if hasattr(self.data, "moenergies"):
-            self.assertEquals(len(self.data.moenergies), 2)
-            self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
-            self.assertEquals(len(self.data.moenergies[1]), self.data.nmo)
+            self.assertEqual(len(self.data.moenergies), 2)
+            self.assertEqual(len(self.data.moenergies[0]), self.data.nmo)
+            self.assertEqual(len(self.data.moenergies[1]), self.data.nmo)
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', '?')
@@ -104,7 +104,7 @@ class GenericSPunTest(unittest.TestCase):
     def testmosyms(self):
         """Are the dims of the mosyms equals to 2 x nmo?"""
         shape = (len(self.data.mosyms), len(self.data.mosyms[0]))
-        self.assertEquals(shape, (2, self.data.nmo))
+        self.assertEqual(shape, (2, self.data.nmo))
 
 
 class GenericROSPTest(GenericSPunTest):
@@ -115,9 +115,9 @@ class GenericROSPTest(GenericSPunTest):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 1 x nmo x nbasis?"""
-        self.assertEquals(type(self.data.mocoeffs), type([]))
-        self.assertEquals(len(self.data.mocoeffs), 1)
-        self.assertEquals(self.data.mocoeffs[0].shape,
+        self.assertEqual(type(self.data.mocoeffs), type([]))
+        self.assertEqual(len(self.data.mocoeffs), 1)
+        self.assertEqual(self.data.mocoeffs[0].shape,
                           (self.data.nmo, self.data.nbasis))
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
@@ -134,15 +134,15 @@ class GenericROSPTest(GenericSPunTest):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 1 x nmo?"""
-        self.assertEquals(len(self.data.moenergies), 1)
-        self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
+        self.assertEqual(len(self.data.moenergies), 1)
+        self.assertEqual(len(self.data.moenergies[0]), self.data.nmo)
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testmosyms(self):
         """Are the dims of the mosyms equals to 1 x nmo?"""
         shape = (len(self.data.mosyms), len(self.data.mosyms[0]))
-        self.assertEquals(shape, (1, self.data.nmo))
+        self.assertEqual(shape, (1, self.data.nmo))
 
 
 class GamessUK70SPunTest(GenericSPunTest):
@@ -151,19 +151,19 @@ class GamessUK70SPunTest(GenericSPunTest):
     def testdimmocoeffs(self):
         """Are the dimensions of mocoeffs equal to 2 x (homos+6) x nbasis?"""
 
-        self.assertEquals(type(self.data.mocoeffs), type([]))
-        self.assertEquals(len(self.data.mocoeffs), 2)
+        self.assertEqual(type(self.data.mocoeffs), type([]))
+        self.assertEqual(len(self.data.mocoeffs), 2)
 
         # This is only an issue in version 7.0 (and before?), since in the version 8.0
         # logfile all eigenvectors are happily printed.
         shape_alpha = (self.data.homos[0]+6, self.data.nbasis)
         shape_beta = (self.data.homos[1]+6, self.data.nbasis)
-        self.assertEquals(self.data.mocoeffs[0].shape, shape_alpha)
-        self.assertEquals(self.data.mocoeffs[1].shape, shape_beta)
+        self.assertEqual(self.data.mocoeffs[0].shape, shape_alpha)
+        self.assertEqual(self.data.mocoeffs[1].shape, shape_beta)
 
     def testnooccnos(self):
         """Are natural orbital occupation numbers the right size?"""
-        self.assertEquals(self.data.nooccnos.shape, (self.data.nmo, ))
+        self.assertEqual(self.data.nooccnos.shape, (self.data.nmo, ))
 
 
 class GamessUK80SPunTest(GenericSPunTest):
@@ -171,7 +171,7 @@ class GamessUK80SPunTest(GenericSPunTest):
 
     def testnooccnos(self):
         """Are natural orbital occupation numbers the right size?"""
-        self.assertEquals(self.data.nooccnos.shape, (self.data.nmo, ))
+        self.assertEqual(self.data.nooccnos.shape, (self.data.nmo, ))
 
 
 class GaussianSPunTest(GenericSPunTest):
@@ -180,7 +180,7 @@ class GaussianSPunTest(GenericSPunTest):
     def testatomnos(self):
         """Does atomnos have the right dimension (20)?"""
         size = len(self.data.atomnos)
-        self.assertEquals(size, 20)
+        self.assertEqual(size, 20)
 
 
 class JaguarSPunTest(GenericSPunTest):
@@ -188,16 +188,16 @@ class JaguarSPunTest(GenericSPunTest):
 
     def testmoenergies(self):
         """Are the dims of the moenergies equal to 2 x homos+11?"""
-        self.assertEquals(len(self.data.moenergies), 2)
-        self.assertEquals(len(self.data.moenergies[0]), self.data.homos[0]+11)
-        self.assertEquals(len(self.data.moenergies[1]), self.data.homos[1]+11)
+        self.assertEqual(len(self.data.moenergies), 2)
+        self.assertEqual(len(self.data.moenergies[0]), self.data.homos[0]+11)
+        self.assertEqual(len(self.data.moenergies[1]), self.data.homos[1]+11)
 
     def testmosyms(self):
         """Are the dims of the mosyms equals to 2 x nmo?"""
         shape0 = (len(self.data.mosyms), len(self.data.mosyms[0]))
         shape1 = (len(self.data.mosyms), len(self.data.mosyms[1]))
-        self.assertEquals(shape0, (2, self.data.homos[0]+11))
-        self.assertEquals(shape1, (2, self.data.homos[1]+11))
+        self.assertEqual(shape0, (2, self.data.homos[0]+11))
+        self.assertEqual(shape1, (2, self.data.homos[1]+11))
 
 
 if __name__=="__main__":

--- a/test/data/testScan.py
+++ b/test/data/testScan.py
@@ -43,7 +43,7 @@ class GenericScanTest_optdone_bool(GenericScanTestBase):
     def testoptdone(self):
         """Is the optimization finished?"""
         self.assertIsInstance(self.data.optdone, bool)
-        self.assertEquals(self.data.optdone, True)
+        self.assertEqual(self.data.optdone, True)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
@@ -74,7 +74,7 @@ class GenericScanTest(GenericScanTestBase):
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testnumindices(self):
         """Do the number of indices match number of scan points."""
-        self.assertEquals(len(self.data.optdone), 12 + self.extra)
+        self.assertEqual(len(self.data.optdone), 12 + self.extra)
 
     @skipForParser("Jaguar", "Does not work as expected")    
     @skipForParser('Molcas','The parser is still being developed so we skip this test')

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -64,7 +64,7 @@ class GenericTDTest(unittest.TestCase):
         t = [(c*c, s, e) for (s, e, c) in sec]
         t.sort()
         t.reverse()
-        self.assert_(t[0][1][0] == self.data.homos[0] or
+        self.assertTrue(t[0][1][0] == self.data.homos[0] or
                      t[0][2][0] == self.data.homos[0]+1, t[0])
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')    

--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -25,8 +25,8 @@ class VolumeTest(unittest.TestCase):
     def test_scinotation(self):
         """Does the scientific notation writer work as expected?"""
 
-        self.assertEquals(volume.scinotation(1./654), ' 1.52905E-03')
-        self.assertEquals(volume.scinotation(-1./654), '-1.52905E-03')
+        self.assertEqual(volume.scinotation(1./654), ' 1.52905E-03')
+        self.assertEqual(volume.scinotation(-1./654), '-1.52905E-03')
 
     def test_wavefunction(self):
         """Does the volume occupied by the HOMO integrate to the correct

--- a/test/regression.py
+++ b/test/regression.py
@@ -1669,8 +1669,8 @@ class ADFSPTest_nosyms(ADFSPTest, GenericSPTest_nosym):
 class ADFSPTest_nosyms_valence(ADFSPTest_nosyms):
     def testlengthmoenergies(self):
         """Only valence orbital energies were printed here."""
-        self.assertEquals(len(self.data.moenergies[0]), 45)
-        self.assertEquals(self.data.moenergies[0][0], 99999.0)
+        self.assertEqual(len(self.data.moenergies[0]), 45)
+        self.assertEqual(self.data.moenergies[0][0], 99999.0)
 
 class DALTONBigBasisTest_aug_cc_pCVQZ(GenericBigBasisTest):
     contractions = { 6: 29 }
@@ -1684,7 +1684,7 @@ class DALTONSPTest_nosyms_nolabels(GenericSPTest_nosym):
 class GAMESSUSSPunTest_charge0(GenericSPunTest):
     def testcharge_and_mult(self):
         """The charge in the input was wrong."""
-        self.assertEquals(self.data.charge, 0)
+        self.assertEqual(self.data.charge, 0)
     @unittest.skip('HOMOs were incorrect due to charge being wrong')
     def testhomos(self):
         """HOMOs were incorrect due to charge being wrong."""
@@ -1728,12 +1728,12 @@ class JaguarSPTest_6_31gss(JaguarSPTest):
 class JaguarSPunTest_nmo_all(JaguarSPunTest):
     def testmoenergies(self):
         """Some tests printed all MO energies apparently."""
-        self.assertEquals(len(self.data.moenergies[0]), self.data.nmo)
+        self.assertEqual(len(self.data.moenergies[0]), self.data.nmo)
 
 class JaguarGeoOptTest_nmo45(GenericGeoOptTest):
     def testlengthmoenergies(self):
         """Without special options, Jaguar only print Homo+10 orbital energies."""
-        self.assertEquals(len(self.data.moenergies[0]), 45)
+        self.assertEqual(len(self.data.moenergies[0]), 45)
 
 class JaguarGeoOptTest_6_31gss(GenericGeoOptTest):
     nbasisdict = {1: 5, 6: 15}
@@ -1758,7 +1758,7 @@ class OrcaGeoOptTest_3_21g(OrcaGeoOptTest):
 class OrcaSPunTest_charge0(GenericSPunTest):
     def testcharge_and_mult(self):
         """The charge in the input was wrong."""
-        self.assertEquals(self.data.charge, 0)
+        self.assertEqual(self.data.charge, 0)
     @unittest.skip('HOMOs were incorrect due to charge being wrong.')
     def testhomos(self):
         """HOMOs were incorrect due to charge being wrong."""
@@ -1770,7 +1770,7 @@ class OrcaTDDFTTest_error(OrcaTDDFTTest):
     def testoscs(self):
         """These values used to be less accurate, probably due to wrong coordinates."""
         self.assertEqual(len(self.data.etoscs), self.number)
-        self.assertAlmostEquals(max(self.data.etoscs), 1.0, delta=0.2)
+        self.assertAlmostEqual(max(self.data.etoscs), 1.0, delta=0.2)
 
 class OrcaIRTest_old_coordsOK(OrcaIRTest):
 


### PR DESCRIPTION
- NumPy `asscalar` is deprecated
- Imports should be from `collections.abc` and not `collections`
- There are a number of renamed methods in `unittest`