### PR TITLE
Add some pretty printing to ccget

### DIFF
--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -16,6 +16,9 @@ import glob
 import logging
 import os.path
 import sys
+from functools import partial
+from pprint import pprint
+
 import numpy
 
 from cclib.parser import ccData
@@ -46,6 +49,14 @@ Additional options:
 # These are the options ccget accepts and their one letter versions.
 OPTS_LONG = ["help", "list", "json", "multi", "verbose", "future", "full"]
 OPTS_SHORT = "hljmvuf"
+
+
+# Set up options for pretty-printing output.
+if sys.version_info < (3, 4):
+    pprint = partial(pprint, width=120)
+else:
+    pprint = partial(pprint, width=120, compact=True)
+numpy.set_printoptions(linewidth=120)
 
 
 def ccget():
@@ -193,9 +204,9 @@ def ccget():
                         # List of attributes to be printed with new lines
                         if attr in data._listsofarrays and full:
                             for val in attr_val:
-                                print(val)
+                                pprint(val)
                         else:
-                            print(attr_val)
+                            pprint(attr_val)
                         continue
 
                 print("Could not parse %s from this file." % attr)


### PR DESCRIPTION
Closes https://github.com/cclib/cclib/issues/633.

This:
```
[array([[ 7.0027e-01,  3.1280e-02,  9.4000e-04, ..., -0.0000e+00,
        -2.2800e-03,  2.2000e-04],
       [ 7.0029e-01,  3.1080e-02,  7.1000e-04, ...,  0.0000e+00,
        -2.0300e-03,  1.1000e-04],
       [ 9.9400e-03, -7.6600e-03, -1.1100e-03, ..., -0.0000e+00,
         2.6000e-03, -1.6700e-03],
       ...,
       [ 2.0410e-02, -1.4481e-01, -2.9322e-01, ...,  0.0000e+00,
         1.4040e-01, -1.3490e-02],
       [ 5.4900e-03, -3.6130e-02, -2.9737e-01, ...,  0.0000e+00,
         2.0780e-02,  1.1360e-02],
       [ 4.0360e-02, -3.0538e-01, -5.3642e-01, ...,  0.0000e+00,
         6.1608e-01,  2.9064e-01]]), array([[ 7.0031e-01,  3.0970e-02,  9.2000e-04, ..., -0.0000e+00,
        -2.2500e-03,  2.3000e-04],
       [ 7.0033e-01,  3.0790e-02,  7.0000e-04, ...,  0.0000e+00,
        -2.0100e-03,  1.2000e-04],
       [ 1.0780e-02, -7.6200e-03, -1.1700e-03, ..., -0.0000e+00,
         2.6000e-03, -1.7200e-03],
       ...,
       [ 2.1680e-02, -1.5309e-01, -2.9553e-01, ...,  0.0000e+00,
         1.4542e-01, -1.1150e-02],
       [ 5.6800e-03, -3.7310e-02, -2.9524e-01, ..., -0.0000e+00,
         2.2160e-02,  9.8600e-03],
       [ 4.1730e-02, -3.1344e-01, -5.3676e-01, ...,  0.0000e+00,
         6.1443e-01,  2.8805e-01]])]
```
becomes
```
[array([[ 7.0027e-01,  3.1280e-02,  9.4000e-04, ..., -0.0000e+00, -2.2800e-03,  2.2000e-04],
       [ 7.0029e-01,  3.1080e-02,  7.1000e-04, ...,  0.0000e+00, -2.0300e-03,  1.1000e-04],
       [ 9.9400e-03, -7.6600e-03, -1.1100e-03, ..., -0.0000e+00,  2.6000e-03, -1.6700e-03],
       ...,
       [ 2.0410e-02, -1.4481e-01, -2.9322e-01, ...,  0.0000e+00,  1.4040e-01, -1.3490e-02],
       [ 5.4900e-03, -3.6130e-02, -2.9737e-01, ...,  0.0000e+00,  2.0780e-02,  1.1360e-02],
       [ 4.0360e-02, -3.0538e-01, -5.3642e-01, ...,  0.0000e+00,  6.1608e-01,  2.9064e-01]]),
 array([[ 7.0031e-01,  3.0970e-02,  9.2000e-04, ..., -0.0000e+00, -2.2500e-03,  2.3000e-04],
       [ 7.0033e-01,  3.0790e-02,  7.0000e-04, ...,  0.0000e+00, -2.0100e-03,  1.2000e-04],
       [ 1.0780e-02, -7.6200e-03, -1.1700e-03, ..., -0.0000e+00,  2.6000e-03, -1.7200e-03],
       ...,
       [ 2.1680e-02, -1.5309e-01, -2.9553e-01, ...,  0.0000e+00,  1.4542e-01, -1.1150e-02],
       [ 5.6800e-03, -3.7310e-02, -2.9524e-01, ..., -0.0000e+00,  2.2160e-02,  9.8600e-03],
       [ 4.1730e-02, -3.1344e-01, -5.3676e-01, ...,  0.0000e+00,  6.1443e-01,  2.8805e-01]])]
```