### PR TITLE
Add value checking of data, and add check for negative etenergies

### DIFF
--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2019, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
 """Classes and tools for storing and handling parsed data"""
 
+import logging
+from collections import namedtuple
 
 import numpy
-from collections import namedtuple
 
 from cclib.method import Electrons
 from cclib.method import orbitals
@@ -289,6 +290,15 @@ class ccData(object):
             except ValueError:
                 args = (attr, type(val), self._attributes[attr].type)
                 raise TypeError("attribute %s is %s instead of %s and could not be converted" % args)
+
+    def check_values(self, logger=logging):
+        """Perform custom checks on the values of attributes."""
+        if hasattr(self, "etenergies") and any(e < 0 for e in self.etenergies):
+            negative_values = [e for e in self.etenergies if e < 0]
+            msg = ("At least one excitation energy is negative. "
+                   "\nNegative values: %s\nFull etenergies: %s"
+                   % (negative_values, self.etenergies))
+            logger.error(msg)
 
     def write(self, filename=None, indices=None, *args, **kwargs):
         """Write parsed attributes to a file.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -372,6 +372,9 @@ class Logfile(object):
             if not attr in _nodelete:
                 self.__delattr__(attr)
 
+        # Perform final checks on values of attributes.
+        data.check_values(logger=self.logger)
+
         # Update self.progress as done.
         if hasattr(self, "progress"):
             self.progress.update(inputfile.size, "Done")
@@ -434,19 +437,28 @@ class Logfile(object):
             if hasattr(self, name):
                 delattr(self, name)
 
-    def set_attribute(self, name, value, check=True):
-        """Set an attribute and perform a check when it already exists.
+    def set_attribute(self, name, value, check_change=True):
+        """Set an attribute and perform an optional check when it already exists.
 
         Note that this can be used for scalars and lists alike, whenever we want
-        to set a value for an attribute. By default we want to check that
-        the value does not change if the attribute already exists, and this function
-        is a good place to add more tests in the future.
+        to set a value for an attribute.
+        
+        Parameters
+        ----------
+        name: str
+            The name of the attribute.
+        value: str
+            The value for the attribute.
+        check_change: bool
+            By default we want to check that the value does not change
+            if the attribute already exists.
         """
-        if check and hasattr(self, name):
+        if check_change and hasattr(self, name):
             try:
                 numpy.testing.assert_equal(getattr(self, name), value)
             except AssertionError:
                 self.logger.warning("Attribute %s changed value (%s -> %s)" % (name, getattr(self, name), value))
+
         setattr(self, name, value)
 
     def append_attribute(self, name, value):

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -9,15 +9,14 @@
 
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 
 from cclib.method import Moments
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
 
 
 class TestIdealizedInputs(unittest.TestCase):

--- a/test/parser/testdata.py
+++ b/test/parser/testdata.py
@@ -7,12 +7,15 @@
 
 """Unit tests for parser data module."""
 
-import mock
 import unittest
 
 import numpy
 
 import cclib
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))
+from six.moves import mock
 
 
 class AnyStringWith(str):

--- a/test/parser/testdata.py
+++ b/test/parser/testdata.py
@@ -18,7 +18,7 @@ add_move(MovedModule('mock', 'mock', 'unittest.mock'))
 from six.moves import mock
 
 
-class AnyStringWith(str):
+class StringContains(str):
     def __eq__(self, other):
         return self in other
 
@@ -42,7 +42,7 @@ class ccDataTest(unittest.TestCase):
         self.data.etenergies = [1, -1]
         self.data.check_values(logger=self.mock_logger)
         self.mock_logger.error.assert_called_once_with(
-            AnyStringWith("At least one excitation energy is negative"))
+            StringContains("At least one excitation energy is negative"))
 
     def test_listify_ndarray(self):
         """Does the method convert ndarrays as expected?"""

--- a/test/parser/testdata.py
+++ b/test/parser/testdata.py
@@ -1,17 +1,23 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2019, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
 """Unit tests for parser data module."""
 
+import mock
 import unittest
 
 import numpy
 
 import cclib
+
+
+class AnyStringWith(str):
+    def __eq__(self, other):
+        return self in other
 
 
 class ccDataTest(unittest.TestCase):
@@ -23,10 +29,17 @@ class ccDataTest(unittest.TestCase):
 
     def setUp(self):
         self.data = cclib.parser.logfileparser.ccData()
+        self.mock_logger = mock.Mock()
 
     def _set_attributes(self, names, val):
         for n in names:
             setattr(self.data, n, val)
+
+    def test_valuecheck_negative_etenergies(self):
+        self.data.etenergies = [1, -1]
+        self.data.check_values(logger=self.mock_logger)
+        self.mock_logger.error.assert_called_once_with(
+            AnyStringWith("At least one excitation energy is negative"))
 
     def test_listify_ndarray(self):
         """Does the method convert ndarrays as expected?"""

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2019, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -8,8 +8,10 @@
 """Unit tests for the logfileparser module."""
 
 import io
+import mock
 import os
 import sys
+import tempfile
 import unittest
 
 # The structure of urllib changed in Python3.
@@ -114,6 +116,22 @@ class LogfileTest(unittest.TestCase):
         """Does this method raise an error in the base class?"""
         normalisesym = cclib.parser.logfileparser.Logfile('').normalisesym
         self.assertRaises(NotImplementedError, normalisesym, 'Ag')
+
+    def test_parse_check_values(self):
+        """Are custom checks performed after parsing finishes?
+        
+        The purpose of this test is not to comprehensively cover all the checks,
+        but rather to make sure the call and logging works. The unit tests
+        for the data class should have comprehensive coverage.
+        """
+        _, path = tempfile.mkstemp()
+        parser = cclib.parser.logfileparser.Logfile(path)
+        parser.extract = lambda self, inputfile, line: None
+        parser.logger = mock.Mock()
+
+        parser.etenergies = [1, -1]
+        parser.parse()
+        parser.logger.error.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This implements a pattern for the data checks described in #237, and adds a check for negative values in `etenergies`. Initially I added `check_values` to the parser class, but I think checks like negative `etenergies` are not specific to any one parser and so belong in the data class. And, they are probably best done after parsing is done, since things may change during parsing. That being said, there may be things in #237 that clearly belong on the parser side (we have some already). Let's deal with that on a case by case basis.

If this looks OK I'll add more checks.