### PR TITLE
Properly skip CJSON stream test

### DIFF
--- a/test/io/testccio.py
+++ b/test/io/testccio.py
@@ -13,6 +13,8 @@ import unittest
 
 import cclib
 
+from six import StringIO
+
 
 __filedir__ = os.path.dirname(__file__)
 __filepath__ = os.path.realpath(__filedir__)
@@ -106,10 +108,10 @@ class ccopenTest(unittest.TestCase):
             self.ccopen([base_url + fname for fname in filenames], quiet=True)
                 .parse().getattributes(tolists=True))
 
-    # This should also work if cjsonreader supported streams.
-    #def test_cjson(self):
-    #    """Do we get a CJSON object then keyword argument used?"""
-    #    self.assertIsInstance(self.ccopen(StringIO.StringIO(""), cjson=True), cclib.io.cjsonreader.CJSON)
+    @unittest.skip("This should also work if cjsonreader supported streams.")
+    def test_cjson(self):
+        """Do we get a CJSON object then keyword argument used?"""
+        self.assertIsInstance(self.ccopen(StringIO(""), cjson=True), cclib.io.cjsonreader.CJSON)
 
 
 class _determine_output_formatTest(unittest.TestCase):


### PR DESCRIPTION
I tried enabling it and `ValueError` is raised, but it should be properly skipped rather than commented out.