### PR TITLE
ORCA: fix for input file with embedding potentials

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1470,9 +1470,11 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 
         line = next(inputfile)
         while not should_stop(line):
-            charges.append(float(line[start:stop]))
-            if has_spins:
-                spins.append(float(line[stop:]))
+            # Don't add point charges or embedding potentials.
+            if "Q :" not in line:
+                charges.append(float(line[start:stop]))
+                if has_spins:
+                    spins.append(float(line[stop:]))
             line = next(inputfile)
 
         self.atomcharges[chargestype] = charges

--- a/test/regression.py
+++ b/test/regression.py
@@ -1115,6 +1115,19 @@ def testORCA_ORCA4_0_IrCl6_sp_out(logfile):
     numpy.testing.assert_almost_equal(logfile.data.scfvalues[0][0], vals_first)
     numpy.testing.assert_almost_equal(logfile.data.scfvalues[0][-1], vals_last)
 
+
+def testORCA_ORCA4_1_725_out(logfile):
+    """This file uses embedding potentials, which requires `>` after atom names in
+    the input file and that confuses different parts of the parser.
+
+    In #725 we decided to not include these potentials in the parsed results.
+    """
+    assert logfile.data.natom == 7
+    numpy.testing.assert_equal(logfile.data.atomnos, numpy.array([20, 17, 17, 17, 17, 17, 17], dtype=int))
+    assert len(logfile.data.atomcharges["mulliken"]) == 7
+    assert len(logfile.data.atomcharges["lowdin"]) == 7
+
+
 # PSI #
 
 


### PR DESCRIPTION
Closes https://github.com/cclib/cclib/issues/725.

This only makes it so that embedding potentials specified in the input file are ignored. Point charges and ghost atoms are still not handled.