### PR TITLE
Updates to the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-dist: trusty
 language: python
 python:
   - 2.7


### PR DESCRIPTION
- `sudo: false` is deprecated now that containers are the default: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
- Xenial is now the default build environment: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment