### PR TITLE
Metadata: full package versions

### DIFF
--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -133,6 +133,8 @@ class ADF(logfileparser.Logfile):
             match = re.search(r"([\d\.]{4,7})", trimmed_line)
             if match:
                 package_version = match.groups()[0]
+                # Use YYYY.MM as a short version.
+                self.metadata["legacy_package_version"] = package_version
             else:
                 # This isn't as well-defined, but the field shouldn't be left
                 # empty. Grab whatever is there and parse it out in the
@@ -158,6 +160,7 @@ class ADF(logfileparser.Logfile):
                     year = tokens[1].split("-")[0]
                     self.metadata["package_version_description"] = package_version
                     package_version = '{}dev{}'.format(year, tokens[0][1:])
+                    self.metadata["legacy_package_version"] = year
                 self.metadata["package_version_date"] = tokens[1]
             self.metadata["package_version"] = package_version
 

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -135,7 +135,8 @@ class ADF(logfileparser.Logfile):
                 package_version = match.groups()[0]
             else:
                 # This isn't as well-defined, but the field shouldn't be left
-                # empty.
+                # empty. Grab whatever is there and parse it out in the
+                # following lines.
                 package_version = trimmed_line.strip()
             # More detailed information can be found before "A D F", even if
             # the above package version isn't numeric.
@@ -152,9 +153,12 @@ class ADF(logfileparser.Logfile):
                 # it should take precedence, otherwise use the more detailed
                 # version first.
                 if match:
-                    package_version = '.'.join([package_version, tokens[0], tokens[1]])
+                    package_version = '{}dev{}'.format(package_version, tokens[0][1:])
                 else:
-                    package_version = '.'.join([tokens[1], tokens[0], package_version])
+                    year = tokens[1].split("-")[0]
+                    self.metadata["package_version_description"] = package_version
+                    package_version = '{}dev{}'.format(year, tokens[0][1:])
+                self.metadata["package_version_date"] = tokens[1]
             self.metadata["package_version"] = package_version
 
         # In ADF 2014.01, there are (INPUT FILE) messages, so we need to use just

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -144,9 +144,8 @@ class ADF(logfileparser.Logfile):
             # Get the contents between the star border.
             tokens = line.split()[1:-1]
             assert len(tokens) >= 1
-            print(tokens)
             if tokens[0] == "Build":
-                package_version += ".b{}".format(tokens[1])
+                package_version += "+{}".format(tokens[1])
             else:
                 assert tokens[0][0] == "r"
                 # If a year-type version has already been parsed (YYYY(.nn)),

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -112,6 +112,9 @@ class DALTON(logfileparser.Logfile):
         # Don't add revision information to the main package version for now.
         if "Last Git revision" in line:
             revision = line.split()[4]
+            package_version = self.metadata.get("package_version")
+            if package_version:
+                self.metadata["package_version"] = "{}+{}".format(package_version, revision)
 
         # Is the basis set from a single library file, or is it
         # manually specified? See before_parsing().

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -108,7 +108,9 @@ class DALTON(logfileparser.Logfile):
                   r"(?:[\s,]\(?)?")
             match = re.search(rs, line)
             if match:
-                self.metadata["package_version"] = match.groups()[0]
+                package_version = match.groups()[0]
+                self.metadata["package_version"] = package_version
+                self.metadata["legacy_package_version"] = package_version
         # Don't add revision information to the main package version for now.
         if "Last Git revision" in line:
             revision = line.split()[4]

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -96,12 +96,21 @@ class GAMESS(logfileparser.Logfile):
             # ...so avoid overwriting it if Firefly already set this field.
             if "package_version" not in self.metadata:
                 tokens = line.split()
-                self.metadata["package_version"] = ' '.join(tokens[4:-1])
+                day, month, year = tokens[4:7]
+                possible_release = tokens[-2]
+                # There may not be a (Rn) for the nth release that year, in
+                # which case this index is the same as 7 (the year).
+                if possible_release == year:
+                    release = "1"
+                else:
+                    # `(R23)` -> 23
+                    release = possible_release[2:-1]
+                self.metadata["package_version"] = '{}.r{}'.format(year, release)
 
         if line[1:12] == "INPUT CARD>":
             return
 
-        # extract the methods 
+        # extract the methods
         if line[1:7] == "SCFTYP":
             method = line.split()[0][7:]
             if len(self.metadata["methods"]) == 0:

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -82,7 +82,7 @@ class GAMESS(logfileparser.Logfile):
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
-        
+
         # Extract the version number. If the calculation is from
         # Firefly, its version number comes before a line that looks
         # like the normal GAMESS version number...
@@ -90,7 +90,7 @@ class GAMESS(logfileparser.Logfile):
             match = re.search(r"Firefly version\s([\d.]*)\D*(\d*)\s*\*", line)
             if match:
                 version, build = match.groups()
-                package_version = "{}.b{}".format(version, build)
+                package_version = "{}+{}".format(version, build)
                 self.metadata["package_version"] = package_version
         if "GAMESS VERSION" in line:
             # ...so avoid overwriting it if Firefly already set this field.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -89,10 +89,11 @@ class GAMESS(logfileparser.Logfile):
         if "Firefly version" in line:
             match = re.search(r"Firefly version\s([\d.]*)\D*(\d*)\s*\*", line)
             if match:
-                version, build = match.groups()
-                package_version = "{}+{}".format(version, build)
+                base_version, build = match.groups()
+                package_version = "{}+{}".format(base_version, build)
                 self.metadata["package_version"] = package_version
-        if "GAMESS VERSION" in line:
+                self.metadata["legacy_package_version"] = base_version
+        if "GAMESS VERSION =" in line:
             # ...so avoid overwriting it if Firefly already set this field.
             if "package_version" not in self.metadata:
                 tokens = line.split()
@@ -106,6 +107,7 @@ class GAMESS(logfileparser.Logfile):
                     # `(R23)` -> 23
                     release = possible_release[2:-1]
                 self.metadata["package_version"] = '{}.r{}'.format(year, release)
+                self.metadata["legacy_package_version"] = "{}R{}".format(year, release)
 
         if line[1:12] == "INPUT CARD>":
             return

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -54,11 +54,10 @@ class GAMESSUK(logfileparser.Logfile):
                 self.metadata["package_version"] = search.groups()[0]
         if "Revision" in line:
             revision = line.split()[1]
-            # Don't add revision information to the main package version for now.
-            # if "package_version" in self.metadata:
-            #     package_version = "{}.r{}".format(self.metadata["package_version"],
-            #                                       revision)
-            #     self.metadata["package_version"] = package_version
+            package_version = self.metadata.get("package_version")
+            if package_version:
+                package_version = "{}.r{}".format(package_version, revision)
+                self.metadata["package_version"] = package_version
 
         if line[1:22] == "total number of atoms":
             natom = int(line.split()[-1])

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -56,8 +56,9 @@ class GAMESSUK(logfileparser.Logfile):
             revision = line.split()[1]
             package_version = self.metadata.get("package_version")
             if package_version:
-                package_version = "{}.r{}".format(package_version, revision)
-                self.metadata["package_version"] = package_version
+                self.metadata["package_version"] = "{}+{}".format(
+                    package_version, revision
+                )
 
         if line[1:22] == "total number of atoms":
             natom = int(line.split()[-1])

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -51,7 +51,9 @@ class GAMESSUK(logfileparser.Logfile):
         if "version" in line:
             search = re.search(r"\sversion\s*(\d\.\d)", line)
             if search:
-                self.metadata["package_version"] = search.groups()[0]
+                package_version = search.groups()[0]
+                self.metadata["package_version"] = package_version
+                self.metadata["legacy_package_version"] = package_version
         if "Revision" in line:
             revision = line.split()[1]
             package_version = self.metadata.get("package_version")

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -152,6 +152,16 @@ class Gaussian(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
+        # Extract the version number: "Gaussian 09, Revision D.01"
+        # becomes "09revisionD.01".
+        if line.strip() == "Cite this work as:":
+            tokens = next(inputfile).split()
+            self.metadata["legacy_package_version"] = ''.join([
+                tokens[1][:-1],
+                'revision',
+                tokens[-1][:-1],
+            ])
+
         # Extract the version number: "Gaussian 98: x86-Linux-G98RevA.11.3
         # 5-Feb-2002" becomes "1998+A.11.3", and "Gaussian 16:
         # ES64L-G16RevA.03 25-Dec-2016" becomes "2016+A.03".

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -76,9 +76,6 @@ class Gaussian(logfileparser.Logfile):
 
     def before_parsing(self):
 
-        # Used to index self.scftargets[].
-        SCFRMS, SCFMAX, SCFENERGY = list(range(3))
-
         # Extract only well-formed numbers in scientific notation.
         self.re_scinot = re.compile('(\w*)=\s*(-?\d\.\d{2}D[+-]\d{2})')
         # Extract only well-formed numbers in traditional

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -9,6 +9,7 @@
 
 
 from __future__ import print_function
+
 import re
 
 import numpy
@@ -53,6 +54,25 @@ class Gaussian(logfileparser.Logfile):
 
         ans = label.replace("U", "u").replace("G", "g")
         return ans
+
+    # Use to map from the usual year suffixed to full years so package
+    # versions can be sorted properly after parsing with
+    # `packaging.parse.version`.
+    YEAR_SUFFIXES_TO_YEARS = {
+        '70': '1970',
+        '76': '1976',
+        '80': '1980',
+        '82': '1982',
+        '86': '1986',
+        '88': '1988',
+        '90': '1990',
+        '92': '1992',
+        '94': '1994',
+        '98': '1998',
+        '03': '2003',
+        '09': '2009',
+        '16': '2016',
+    }
 
     def before_parsing(self):
 
@@ -135,16 +155,22 @@ class Gaussian(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
-        # Extract the version number: "Gaussian 09, Revision D.01"
-        # becomes "09revisionD.01".
-        if line.strip() == "Cite this work as:":
-            line = inputfile.next()
-            tokens = line.split()
-            self.metadata["package_version"] = ''.join([
-                tokens[1][:-1],
-                'revision',
-                tokens[-1][:-1],
-            ])
+        # Extract the version number: "Gaussian 98: x86-Linux-G98RevA.11.3
+        # 5-Feb-2002" becomes "1998+A.11.3", and "Gaussian 16:
+        # ES64L-G16RevA.03 25-Dec-2016" becomes "2016+A.03".
+        if "Gaussian, Inc.," in line:
+            self.skip_lines(inputfile, ["b", "s"])
+            _, _, platform_full_version, compile_date = next(inputfile).split()
+            run_date = next(inputfile).strip()
+            platform_full_version_tokens = platform_full_version.split("-")
+            full_version = platform_full_version_tokens[-1]
+            platform = "-".join(platform_full_version_tokens[:-1])
+            year_suffix = full_version[1:3]
+            revision = full_version[6:]
+            self.metadata["package_version"] = "{}+{}".format(
+                self.YEAR_SUFFIXES_TO_YEARS[year_suffix], revision
+            )
+            self.metadata["platform"] = platform
 
         if line.strip().startswith("Link1:  Proceeding to internal job step number"):
             self.new_internal_job()

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -63,7 +63,7 @@ class Jaguar(logfileparser.Logfile):
         # Extract the package version number.
         if "Jaguar version" in line:
             tokens = line.split()
-            package_version = "{}.r{}".format(tokens[3][:-1], tokens[5])
+            package_version = "{}+{}".format(tokens[3][:-1], tokens[5])
             self.metadata["package_version"] = package_version
 
         # Extract the basis set name

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -63,8 +63,10 @@ class Jaguar(logfileparser.Logfile):
         # Extract the package version number.
         if "Jaguar version" in line:
             tokens = line.split()
-            package_version = "{}+{}".format(tokens[3][:-1], tokens[5])
+            base_version = tokens[3][:-1]
+            package_version = "{}+{}".format(base_version, tokens[5])
             self.metadata["package_version"] = package_version
+            self.metadata["legacy_package_version"] = base_version
 
         # Extract the basis set name
         if line[2:12] == "basis set:":

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -63,10 +63,7 @@ class Jaguar(logfileparser.Logfile):
         # Extract the package version number.
         if "Jaguar version" in line:
             tokens = line.split()
-            # Don't add revision information to the main package
-            # version for now.
-            # package_version = "{}.r{}".format(tokens[3][:-1], tokens[5])
-            package_version = tokens[3][:-1]
+            package_version = "{}.r{}".format(tokens[3][:-1], tokens[5])
             self.metadata["package_version"] = package_version
 
         # Extract the basis set name

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -43,6 +43,8 @@ class Molcas(logfileparser.Logfile):
             self._assign_coreelectrons_to_element(element, ncore)
 
         if "package_version" in self.metadata:
+            # Use the short version as the legacy version.
+            self.metadata["legacy_package_version"] = self.metadata["package_version"]
             # If there is both a tag and the full hash, place the tag
             # first. Both are chosen to be local, since there isn't a
             # distinction between development and release builds in their

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -71,13 +71,18 @@ class Molcas(logfileparser.Logfile):
             if match:
                 package_version = match.groups()[0]
                 self.metadata["package_version"] = package_version
-        # Don't add revision information to the main package version for now.
         if "tag" in line:
             tag = line.split()[-1]
+            package_version = self.metadata.get("package_version")
+            if package_version:
+                self.metadata["package_version"] = package_version + "." + tag
         if "build" in line:
             match = re.search(r"\*\s*build\s(\S*)\s*\*", line)
             if match:
                 revision = match.groups()[0]
+                package_version = self.metadata.get("package_version")
+                if package_version:
+                    self.metadata["package_version"] = package_version + "+" + revision
 
         ## This section is present when executing &GATEWAY.
         # ++    Molecular structure info:

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -272,8 +272,11 @@ class Molpro(logfileparser.Logfile):
         # Only take the less-specific version if it doesn't already exist.
         if "Version" in line:
             package_version = self.metadata.get("package_version")
+            less_specific_package_version = line.split()[1]
             if not package_version:
-                self.metadata["package_version"] = line.split()[1]
+                self.metadata["package_version"] = less_specific_package_version
+            # ...but use it for the legacy (short) version.
+            self.metadata["legacy_package_version"] = less_specific_package_version
         if "SHA1" in line:
             package_version = self.metadata.get("package_version")
             if package_version:

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -265,9 +265,21 @@ class Molpro(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
-        # Extract the package version number.
+        # Extract the package version number. The one associated with NAME may
+        # be more specific.
+        if line.strip()[:4] == "NAME":
+            self.metadata["package_version"] = line.split()[-1]
+        # Only take the less-specific version if it doesn't already exist.
         if "Version" in line:
-            self.metadata["package_version"] = line.split()[1]
+            package_version = self.metadata.get("package_version")
+            if not package_version:
+                self.metadata["package_version"] = line.split()[1]
+        if "SHA1" in line:
+            package_version = self.metadata.get("package_version")
+            if package_version:
+                self.metadata["package_version"] = ''.join([
+                    package_version, "+", line.split()[-1]
+                ])
 
         if line[1:19] == "ATOMIC COORDINATES":
 

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -90,6 +90,11 @@ class MOPAC(logfileparser.Logfile):
         if "For non-commercial use only" in line:
             # Ignore the platorm information for now (the last character).
             self.metadata["package_version"] = line.split()[8][:-1]
+            # Use the year as the legacy (short) package version.
+            self.skip_lines(
+                inputfile, ["Stewart Computational Chemistry", "s", "s", "s", "s"]
+            )
+            self.metadata["legacy_package_version"] = next(inputfile).split()[1][5:]
 
         # Extract the atomic numbers and coordinates from the optimized geometry
         # note that cartesian coordinates section occurs multiple times in the file, and we want to end up using the last instance

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -86,17 +86,7 @@ class MOPAC(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
-        if "(Version:" in line:
-            # Part of the full version can be extracted from here, but is
-            # missing information about the bitness.
-            package_version = line[line.find("MOPAC") + 5:line.find("(")]
-            package_version = package_version[:4]
-            if "BETA" in line:
-                package_version = package_version + " BETA"
-            self.metadata["package_version"] = package_version
-
-        # Don't use the full package version until we know its field
-        # yet.
+        # Extract the package version.
         if "For non-commercial use only" in line:
             tokens = line.split()
             tokens = tokens[8:]
@@ -104,6 +94,7 @@ class MOPAC(logfileparser.Logfile):
             package_version_full = tokens[0]
             if tokens[1] != "**":
                 package_version_full = '-'.join(tokens)[:-2]
+            self.metadata["package_version"] = package_version_full
 
         # Extract the atomic numbers and coordinates from the optimized geometry
         # note that cartesian coordinates section occurs multiple times in the file, and we want to end up using the last instance

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -88,13 +88,8 @@ class MOPAC(logfileparser.Logfile):
 
         # Extract the package version.
         if "For non-commercial use only" in line:
-            tokens = line.split()
-            tokens = tokens[8:]
-            assert len(tokens) == 2
-            package_version_full = tokens[0]
-            if tokens[1] != "**":
-                package_version_full = '-'.join(tokens)[:-2]
-            self.metadata["package_version"] = package_version_full
+            # Ignore the platorm information for now (the last character).
+            self.metadata["package_version"] = line.split()[8][:-1]
 
         # Extract the atomic numbers and coordinates from the optimized geometry
         # note that cartesian coordinates section occurs multiple times in the file, and we want to end up using the last instance

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -45,7 +45,9 @@ class NWChem(logfileparser.Logfile):
         # Extract the version number and the version control information, if
         # it exists.
         if "nwchem branch" in line:
-            self.metadata["package_version"] = line.split()[3]
+            base_package_version = line.split()[3]
+            self.metadata["legacy_package_version"] = base_package_version
+            self.metadata["package_version"] = base_package_version
             line = next(inputfile)
             if "nwchem revision" in line:
                 self.metadata["package_version"] = "{}+{}".format(

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -42,12 +42,15 @@ class NWChem(logfileparser.Logfile):
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 
-        # Extract the version number.
+        # Extract the version number and the version control information, if
+        # it exists.
         if "nwchem branch" in line:
             self.metadata["package_version"] = line.split()[3]
-        # Don't add revision information to the main package version for now.
-        if "nwchem revision" in line:
-            revision = line.split()[3]
+            line = next(inputfile)
+            if "nwchem revision" in line:
+                self.metadata["package_version"] = "{}+{}".format(
+                    self.metadata["package_version"], line.split()[3].split("-")[-1]
+                )
 
         # This is printed in the input module, so should always be the first coordinates,
         # and contains some basic information we want to parse as well. However, this is not

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -55,7 +55,8 @@ class ORCA(logfileparser.Logfile):
         # Extract the version number.
         if "Program Version" == line.strip()[:15]:
             # Handle development versions.
-            self.metadata["package_version"] = line.split()[2].replace(".x", "dev")
+            self.metadata["legacy_package_version"] = line.split()[2]
+            self.metadata["package_version"] = self.metadata["legacy_package_version"].replace(".x", "dev")
             possible_revision_line = next(inputfile)
             if "SVN: $Rev" in possible_revision_line:
                 self.metadata["package_version"] += "+{}".format(

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -37,7 +37,7 @@ class Psi3(logfileparser.Logfile):
         """Extract information from the file object inputfile."""
 
         if "Version" in line:
-            self.metadata["package_version"] = ' '.join(line.split()[1:])
+            self.metadata["package_version"] = ''.join(line.split()[1:]).lower()
 
         # Psi3 prints the coordinates in several configurations, and we will parse the
         # the canonical coordinates system in Angstroms as the first coordinate set,

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -77,6 +77,7 @@ class Psi4(logfileparser.Logfile):
             version_line = next(inputfile)
             tokens = version_line.split()
             package_version = tokens[1].split("-")[-1]
+            self.metadata["legacy_package_version"] = package_version
             # Keep track of early versions of Psi4.
             if "beta" in package_version:
                 self.version_4_beta = True

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -440,7 +440,9 @@ cannot be determined. Rerun without `$molecule read`."""
             if match:
                 groups = [s for s in match.groups() if s is not None]
                 assert len(groups) == 1
-                self.metadata["package_version"] = groups[0]
+                package_version = groups[0]
+                self.metadata["package_version"] = package_version
+                self.metadata["legacy_package_version"] = package_version
         # Avoid "Last SVN revision" entry.
         if "SVN revision" in line and "Last" not in line:
             svn_revision = line.split()[3]

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -447,8 +447,8 @@ cannot be determined. Rerun without `$molecule read`."""
             line = next(inputfile)
             svn_branch = line.split()[3].replace("/", "_")
             if "package_version" in self.metadata:
-                self.metadata["package_version"] = "{}dev{}+{}".format(
-                    self.metadata["package_version"], svn_revision, svn_branch
+                self.metadata["package_version"] = "{}dev+{}-{}".format(
+                    self.metadata["package_version"], svn_branch, svn_revision
                 )
 
         # Disable/enable parsing for fragment sections.

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -421,13 +421,35 @@ cannot be determined. Rerun without `$molecule read`."""
 
         # Extract the version number and optionally the version
         # control info.
-        if "Q-Chem" in line:
-            match = re.search(r"Q-Chem\s([0-9\.]*)\sfor", line)
+        if any(version_trigger in line for version_trigger in ("Q-Chem", "Unrecognized platform", "Version")):
+            # Part 1 matches
+            #   - `Q-Chem 4.3.0 for Intel X86 EM64T Linux`
+            # Part 2 matches
+            #   - `Unrecognized platform!!! 4.0.0.1`
+            # Part 3 matches
+            #   - `Intel X86 EM64T Linux Version 4.1.0.1 `
+            #   but not
+            #   - `Additional authors for Version 3.1:`
+            #   - `Q-Chem, Version 4.1, Q-Chem, Inc., Pittsburgh, PA (2013).`
+            match = re.search(
+                r"Q-Chem\s([\d\.]*)\sfor|"
+                r"Unrecognized platform!!!\s([\d\.]*)\b|"
+                r"Version\s([\d\.]*)\s*$",
+                line
+            )
             if match:
-                self.metadata["package_version"] = match.groups()[0]
-        # Don't add revision information to the main package version for now.
-        if "SVN revision" in line:
-            revision = line.split()[3]
+                groups = [s for s in match.groups() if s is not None]
+                assert len(groups) == 1
+                self.metadata["package_version"] = groups[0]
+        # Avoid "Last SVN revision" entry.
+        if "SVN revision" in line and "Last" not in line:
+            svn_revision = line.split()[3]
+            line = next(inputfile)
+            svn_branch = line.split()[3].replace("/", "_")
+            if "package_version" in self.metadata:
+                self.metadata["package_version"] = "{}dev{}+{}".format(
+                    self.metadata["package_version"], svn_revision, svn_branch
+                )
 
         # Disable/enable parsing for fragment sections.
         if any(message in line for message in self.fragment_section_headers):

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -116,9 +116,9 @@ class Turbomole(logfileparser.Logfile):
             package_version = tokens[0][1:].replace("-", ".")
             self.metadata["package_version"] = package_version
             self.metadata["legacy_package_version"] = package_version
-            # Don't add revision information to the main package version for now.
             if tokens[1] == "(":
                 revision = tokens[2]
+                self.metadata["package_version"] = "{}.r{}".format(package_version, revision)
 
         ## Atomic coordinates in job.last:
         #              +--------------------------------------------------+

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -113,7 +113,9 @@ class Turbomole(logfileparser.Logfile):
         if index > -1:
             line = line[index + len(searchstr):]
             tokens = line.split()
-            self.metadata["package_version"] = tokens[0][1:].replace("-", ".")
+            package_version = tokens[0][1:].replace("-", ".")
+            self.metadata["package_version"] = package_version
+            self.metadata["legacy_package_version"] = package_version
             # Don't add revision information to the main package version for now.
             if tokens[1] == "(":
                 revision = tokens[2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging>=19.0
 numpy
 # We need this as long as we need support both Python 2 and 3.
 six

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ def setup_cclib():
             ]
         },
         install_requires=[
+            "packaging>=19.0",
             "numpy",
             "six",
         ],

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -295,14 +295,14 @@ class GenericSPTest(unittest.TestCase):
 
     @skipForParser('ADF', 'Does not support metadata yet')
     @skipForParser('GAMESSUK', 'Does not support metadata yet')
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
+    @skipForParser('Molcas', 'The parser is still being developed so we skip this test')
     @skipForParser('Molpro', 'Does not support metadata yet')
     @skipForParser('NWChem', 'Does not support metadata yet')
     @skipForParser('ORCA', 'Does not support metadata yet')
     @skipForParser('Psi3', 'Does not support metadata yet')
     @skipForParser('Psi4', 'Does not support metadata yet')
     @skipForParser('QChem', 'Does not support metadata yet')
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
+    @skipForParser('Turbomole', 'The parser is still being developed so we skip this test')
     def testmetadata(self):
         """Does metadata have expected keys and values?"""
         self.assertTrue(hasattr(self.data, "metadata"))
@@ -313,6 +313,7 @@ class GenericSPTest(unittest.TestCase):
             self.assertIn("input_file_contents", self.data.metadata)
         self.assertIn("methods", self.data.metadata)
         self.assertIn("package", self.data.metadata)
+        self.assertIn("legacy_package_version", self.data.metadata)
         self.assertIn("package_version", self.data.metadata)
         self.assertIsInstance(
             packaging.version.parse(self.data.metadata["package_version"]),

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -11,6 +11,7 @@ import os
 import unittest
 
 import numpy
+import packaging
 
 from common import get_minimum_carbon_separation
 
@@ -313,6 +314,11 @@ class GenericSPTest(unittest.TestCase):
         self.assertIn("methods", self.data.metadata)
         self.assertIn("package", self.data.metadata)
         self.assertIn("package_version", self.data.metadata)
+        self.assertIsInstance(
+            packaging.version.parse(self.data.metadata["package_version"]),
+            packaging.version.Version
+        )
+
 
 class ADFSPTest(GenericSPTest):
     """Customized restricted single point unittest"""

--- a/test/regression.py
+++ b/test/regression.py
@@ -99,10 +99,14 @@ def testADF_ADF2004_01_Fe_ox3_final_out(logfile):
     """Make sure HOMOS are correct."""
     assert logfile.data.homos[0] == 59 and logfile.data.homos[1] == 54
 
+    assert logfile.data.metadata["package_version"] == "2004.01+200410211341"
+
 
 def testADF_ADF2013_01_dvb_gopt_b_unconverged_adfout(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
 
 
 def testADF_ADF2013_01_stopiter_dvb_sp_adfout(logfile):
@@ -111,11 +115,15 @@ def testADF_ADF2013_01_stopiter_dvb_sp_adfout(logfile):
     # len(logfile.data.scfvalues[0]) == 10
     assert not hasattr(logfile.data, "scfvalues")
 
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
+
 
 def testADF_ADF2013_01_stopiter_dvb_sp_b_adfout(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     # Why is this not 3?
     assert len(logfile.data.scfvalues[0]) == 2
+
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
 
 
 def testADF_ADF2013_01_stopiter_dvb_sp_c_adfout(logfile):
@@ -124,12 +132,16 @@ def testADF_ADF2013_01_stopiter_dvb_sp_c_adfout(logfile):
     # len(logfile.data.scfvalues[0]) == 6
     assert not hasattr(logfile.data, "scfvalues")
 
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
+
 
 def testADF_ADF2013_01_stopiter_dvb_sp_d_adfout(logfile):
     """This logfile has not SCF test lines so we have no way to check what happens."""
     # This is what we would have checked:
     # len(logfile.data.scfvalues[0]) == 7
     assert not hasattr(logfile.data, "scfvalues")
+
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
 
 
 def testADF_ADF2013_01_stopiter_dvb_un_sp_adfout(logfile):
@@ -138,6 +150,8 @@ def testADF_ADF2013_01_stopiter_dvb_un_sp_adfout(logfile):
     # len(logfile.data.scfvalues[0]) == 7
     assert not hasattr(logfile.data, "scfvalues")
 
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
+
 
 def testADF_ADF2013_01_stopiter_dvb_un_sp_c_adfout(logfile):
     """This logfile has not SCF test lines so we have no way to check what happens."""
@@ -145,12 +159,16 @@ def testADF_ADF2013_01_stopiter_dvb_un_sp_c_adfout(logfile):
     # len(logfile.data.scfvalues[0]) == 10
     assert not hasattr(logfile.data, "scfvalues")
 
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
+
 
 def testADF_ADF2013_01_stopiter_MoOCl4_sp_adfout(logfile):
     """This logfile has not SCF test lines so we have no way to check what happens."""
     # This is what we would have checked:
     # len(logfile.data.scfvalues[0]) == 11
     assert not hasattr(logfile.data, "scfvalues")
+
+    assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
 
 
 def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
@@ -166,11 +184,27 @@ def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
     isotropic_ref = 51.3359
     assert abs(isotropic_calc - isotropic_ref) < 1.0e-4
 
+    assert logfile.data.metadata["package_version"] == "2014dev42059"
+    assert logfile.data.metadata["package_version_date"] == "2014-06-11"
+    assert logfile.data.metadata["package_version_description"] == "development version"
+
+
+def testADF_ADF2016_166_tddft_0_31_new_out(logfile):
+    """This file led to StopIteration (#430)."""
+    assert logfile.data.metadata["package_version"] == "2016dev53619"
+    assert logfile.data.metadata["package_version_date"] == "2016-07-21"
+    assert "package_version_description" not in logfile.data.metadata
+
 
 def testADF_ADF2016_fa2_adf_out(logfile):
     """This logfile, without symmetry, should get atombasis parsed."""
     assert hasattr(logfile.data, "atombasis")
     assert [b for ab in logfile.data.atombasis for b in ab] == list(range(logfile.data.nbasis))
+
+    assert logfile.data.metadata["package_version"] == "2016dev50467"
+    assert logfile.data.metadata["package_version_date"] == "2016-02-17"
+    assert logfile.data.metadata["package_version_description"] == "branches/AndrewAtkins/ADF-Shar"
+
 
 # DALTON #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1224,6 +1224,8 @@ def testQChem_QChem4_2_CH3___Na__RS_out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
     assert len(logfile.data.moenergies) == 2
@@ -1253,6 +1255,8 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
     This is to ensure only the supersystem is printed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.1.0.1"
+
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
     assert len(logfile.data.moenergies) == 2
@@ -1280,6 +1284,8 @@ def testQChem_QChem4_2_CH4___Na__out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.2.0"
+
     assert logfile.data.charge == 1
     assert logfile.data.mult == 1
     assert len(logfile.data.moenergies) == 1
@@ -1306,6 +1312,8 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
 
     This is to ensure only the supersystem is parsed.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.3.0"
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
@@ -1335,6 +1343,8 @@ def testQChem_QChem4_2_CH3___Na__RS_noprint_out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
     assert len(logfile.data.moenergies) == 2
@@ -1361,6 +1371,8 @@ def testQChem_QChem4_2_CH4___Na__noprint_out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     assert logfile.data.charge == 1
     assert logfile.data.mult == 1
     assert len(logfile.data.moenergies) == 1
@@ -1381,6 +1393,9 @@ def testQChem_QChem4_2_CO2_out(logfile):
     """A job containing a specific number of orbitals requested for
     printing.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 45
     nmo = 45
     nalpha = 11
@@ -1397,6 +1412,9 @@ def testQChem_QChem4_2_CO2_out(logfile):
 def testQChem_QChem4_2_CO2_cation_UHF_out(logfile):
     """A job containing a specific number of orbitals requested for
     printing."""
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 45
     nmo = 45
     nalpha = 11
@@ -1418,6 +1436,9 @@ def testQChem_QChem4_2_CO2_cation_UHF_out(logfile):
 def testQChem_QChem4_2_CO2_cation_ROHF_bigprint_allvirt_out(logfile):
     """A job containing a specific number of orbitals requested for
     printing."""
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 45
     nmo = 45
     nalpha = 11
@@ -1438,6 +1459,9 @@ def testQChem_QChem4_2_CO2_cation_ROHF_bigprint_allvirt_out(logfile):
 
 def testQChem_QChem4_2_CO2_linear_dependence_printall_out(logfile):
     """A job with linear dependency and all MOs printed."""
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 138
     nmo = 106
     assert logfile.data.nbasis == nbasis
@@ -1454,6 +1478,9 @@ def testQChem_QChem4_2_CO2_linear_dependence_printall_final_out(logfile):
     The increased precision is due to the presence of `scf_final_print
     = 3` giving a separate block with more decimal places.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 138
     nmo = 106
     assert logfile.data.nbasis == nbasis
@@ -1471,6 +1498,9 @@ def testQChem_QChem4_2_CO2_linear_dependence_printdefault_out(logfile):
     """A job with linear dependency and the default number of MOs printed
     (all occupieds and 5 virtuals).
     """
+
+    assert logfile.data.metadata["package_version"] == "4.2.2"
+
     nbasis = 138
     nmo = 106
     assert logfile.data.nbasis == nbasis
@@ -1483,6 +1513,7 @@ def testQChem_QChem4_2_CO2_linear_dependence_printdefault_out(logfile):
 
 def testQChem_QChem4_2_dvb_gopt_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
 
@@ -1492,6 +1523,7 @@ def testQChem_QChem4_2_dvb_sp_multipole_10_out(logfile):
     Since this example has various formats for the moment ranks, we can test
     the parser by making sure the first moment (pure X) is as expected.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert hasattr(logfile.data, 'moments') and len(logfile.data.moments) == 11
     tol = 1.0e-6
     assert logfile.data.moments[1][0] < tol
@@ -1510,6 +1542,7 @@ def testQChem_QChem4_2_MoOCl4_sp_noprint_builtin_mixed_all_Cl_out(logfile):
     """ECP on all Cl atoms, but iprint is off, so coreelectrons must be
     guessed.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert hasattr(logfile.data, 'coreelectrons')
@@ -1523,6 +1556,7 @@ def testQChem_QChem4_2_MoOCl4_sp_noprint_builtin_mixed_both_out(logfile):
 
     Uses `ecp = gen`.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert not hasattr(logfile.data, 'coreelectrons')
@@ -1530,6 +1564,7 @@ def testQChem_QChem4_2_MoOCl4_sp_noprint_builtin_mixed_both_out(logfile):
 
 def testQChem_QChem4_2_MoOCl4_sp_noprint_builtin_mixed_single_Mo_out(logfile):
     """ECP on Mo, but iprint is off, so coreelectrons must be guessed."""
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert hasattr(logfile.data, 'coreelectrons')
@@ -1543,6 +1578,7 @@ def testQChem_QChem4_2_MoOCl4_sp_noprint_builtin_out(logfile):
 
     Uses `ecp = <builtin>`.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert not hasattr(logfile.data, 'coreelectrons')
@@ -1552,6 +1588,7 @@ def testQChem_QChem4_2_MoOCl4_sp_noprint_user_Mo_builtin_all_Cl_out(logfile):
     """ECP on Mo and all Cl atoms, but iprint is off; the coreelectrons
     count is given for Mo, and Cl can be guessed.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert hasattr(logfile.data, 'coreelectrons')
@@ -1566,6 +1603,7 @@ def testQChem_QChem4_2_MoOCl4_sp_print_builtin_mixed_single_Mo_single_Cl_out(log
     This was intended to only have an ECP on a single Cl, but Q-Chem
     silently puts it on all.
     """
+    assert logfile.data.metadata["package_version"] == "4.2.0"
     assert logfile.data.charge == -2
     assert logfile.data.mult == 1
     assert hasattr(logfile.data, 'coreelectrons')
@@ -1578,6 +1616,8 @@ def testQChem_QChem4_2_print_frgm_false_opt_out(logfile):
 
     Fragment sections are not printed.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.3.0"
 
     assert logfile.data.charge == -1
     assert logfile.data.mult == 1
@@ -1592,6 +1632,8 @@ def testQChem_QChem4_2_print_frgm_true_opt_out(logfile):
     Fragment sections are printed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     assert logfile.data.charge == -1
     assert logfile.data.mult == 1
 
@@ -1605,6 +1647,8 @@ def testQChem_QChem4_2_print_frgm_false_sp_out(logfile):
     Fragment sections are not printed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     assert logfile.data.charge == -1
     assert logfile.data.mult == 1
 
@@ -1617,6 +1661,8 @@ def testQChem_QChem4_2_print_frgm_true_sp_out(logfile):
     Fragment sections are printed.
     """
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     assert logfile.data.charge == -1
     assert logfile.data.mult == 1
 
@@ -1628,6 +1674,8 @@ def testQChem_QChem4_2_print_frgm_true_sp_ccsdt_out(logfile):
 
     Fragment sections are printed.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.3.0"
 
     assert len(logfile.data.mpenergies[0]) == 1
     assert len(logfile.data.ccenergies) == 1
@@ -1644,6 +1692,9 @@ def testQChem_QChem4_2_qchem_tddft_rpa_out(logfile):
     Currently cclib will store the second set of transitions (RPA), but this
     could change in the future if we support multistep jobs.
     """
+
+    assert logfile.data.metadata["package_version"] == "4.2.0"
+
     assert len(logfile.data.etsecs) == 10
     assert len(logfile.data.etsecs[0]) == 13
 
@@ -1667,6 +1718,8 @@ def testQChem_QChem4_2_read_molecule_out(logfile):
     """A two-calculation output with the charge/multiplicity not specified
     in the user section."""
 
+    assert logfile.data.metadata["package_version"] == "4.3.0"
+
     # These correspond to the second calculation.
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
@@ -1679,6 +1732,7 @@ def testQChem_QChem4_2_read_molecule_out(logfile):
 
 def testQChem_QChem4_2_stopiter_qchem_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
+    assert logfile.data.metadata["package_version"] == "4.0.0.1"
     assert len(logfile.data.scfvalues[0]) == 7
 
 
@@ -1686,6 +1740,7 @@ def testQChem_QChem4_3_R_propylene_oxide_force_ccsd_out(logfile):
     """Check to see that the CCSD gradient (not the HF gradient) is being
     parsed.
     """
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     assert hasattr(logfile.data, 'grads')
     assert logfile.data.grads.shape == (1, logfile.data.natom, 3)
     # atom 9, y-coordinate.
@@ -1697,14 +1752,16 @@ def testQChem_QChem4_3_R_propylene_oxide_force_hf_numerical_energies_out(logfile
     """Check to see that the HF numerical gradient (from energies) is
     being parsed.
     """
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     # This isn't implemented yet.
-    pass
+    assert not hasattr(logfile.data, "grads")
 
 
 def testQChem_QChem4_3_R_propylene_oxide_force_mp2_out(logfile):
     """Check to see that the MP2 gradient (not the HF gradient) is
     being parsed.
     """
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     assert hasattr(logfile.data, 'grads')
     assert logfile.data.grads.shape == (1, logfile.data.natom, 3)
     # atom 9, y-coordinate.
@@ -1716,6 +1773,7 @@ def testQChem_QChem4_3_R_propylene_oxide_force_rimp2_out(logfile):
     """Check to see that the RI-MP2 gradient (not the HF gradient) is
     being parsed.
     """
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     assert hasattr(logfile.data, 'grads')
     assert logfile.data.grads.shape == (1, logfile.data.natom, 3)
     # atom 9, y-coordinate.
@@ -1726,7 +1784,7 @@ def testQChem_QChem4_3_R_propylene_oxide_force_rimp2_out(logfile):
 def testQChem_QChem4_3_R_propylene_oxide_freq_ccsd_out(logfile):
     """Check to see that the CCSD (numerical) Hessian is being parsed.
     """
-
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     # The gradient of the initial geometry in a Hessian calculated
     # from finite difference of gradients should be the same as in a
     # force calculation.
@@ -1747,14 +1805,15 @@ def testQChem_QChem4_3_R_propylene_oxide_freq_ccsd_out(logfile):
 def testQChem_QChem4_3_R_propylene_oxide_freq_hf_numerical_gradients_out(logfile):
     """Check to see that the HF Hessian (from gradients) is being parsed.
     """
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     # This isn't implemented yet.
-    pass
+    assert not hasattr(logfile.data, "freq")
 
 
 def testQChem_QChem4_3_R_propylene_oxide_freq_mp2_out(logfile):
     """Check to see that the MP2 (numerical) Hessian is being parsed.
     """
-
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     # The gradient of the initial geometry in a Hessian calculated
     # from finite difference of gradients should be the same as in a
     # force calculation.
@@ -1775,7 +1834,7 @@ def testQChem_QChem4_3_R_propylene_oxide_freq_mp2_out(logfile):
 def testQChem_QChem4_3_R_propylene_oxide_freq_rimp2_out(logfile):
     """Check to see that the RI-MP2 (numerical) Hessian is being parsed.
     """
-
+    assert logfile.data.metadata["package_version"] == "4.3.0"
     # The gradient of the initial geometry in a Hessian calculated
     # from finite difference of gradients should be the same as in a
     # force calculation.
@@ -1798,6 +1857,7 @@ def testQChem_QChem4_4_full_2_out(logfile):
     """The polarizability section may not be parsed due to something
     appearing just beforehand from a frequency-type calculation.
     """
+    assert logfile.data.metadata["package_version"] == "4.4.2"
     assert hasattr(logfile.data, 'polarizabilities')
 
 
@@ -1805,6 +1865,7 @@ def testQChem_QChem4_4_srtlg_out(logfile):
     """Some lines in the MO coefficients require fixed-width parsing. See
     #349 and #381.
     """
+    assert logfile.data.metadata["package_version"] == "4.4.0"
     # There is a linear dependence problem.
     nbasis, nmo = 1129, 1115
     assert len(logfile.data.mocoeffs) == 2
@@ -1824,11 +1885,13 @@ def testQChem_QChem4_4_Trp_polar_ideriv0_out(logfile):
     compare to reference results as 2nd-order finite difference can have
     large errors.
     """
+    assert logfile.data.metadata["package_version"] == "4.4.2"
     assert hasattr(logfile.data, 'polarizabilities')
 
 
 def testQChem_QChem4_4_top_out(logfile):
     """This job has fewer MOs (7) than would normally be printed (15)."""
+    assert logfile.data.metadata["package_version"] == "4.4.2"
     nbasis = 7
     nmo = 7
     assert logfile.data.nbasis == nbasis
@@ -1842,6 +1905,7 @@ def testQChem_QChem5_0_438_out(logfile):
     """This job has an ECP on Pt, replacing 60 of 78 electrons, and was
     showing the charge as 60.
     """
+    assert logfile.data.metadata["package_version"] == "5.0.0"
     assert logfile.data.charge == 0
     assert logfile.data.coreelectrons[0] == 60
 
@@ -1850,12 +1914,19 @@ def testQChem_QChem5_0_argon_out(logfile):
     """This job has unit specifications at the end of 'Total energy for
     state' lines.
     """
+    assert logfile.data.metadata["package_version"] == "5.0.1"
     nroots = 12
     assert len(logfile.data.etenergies) == nroots
     state_0_energy = -526.6323968555
     state_1_energy = -526.14663738
     assert logfile.data.scfenergies[0] == convertor(state_0_energy, 'hartree', 'eV')
     assert abs(logfile.data.etenergies[0] - convertor(state_1_energy - state_0_energy, 'hartree', 'wavenumber')) < 1.0e-1
+
+
+def testQChem_QChem5_1_old_final_print_1_out(logfile):
+    """This job has was run from a development version."""
+    assert logfile.data.metadata["package_version"] == "5.1.0dev27553+branches_libresponse"
+
 
 # Turbomole
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1168,9 +1168,12 @@ def testMOPAC_MOPAC2016_9S3_uuu_Cs_cation_freq_PM7_out(logfile):
 
 # NWChem #
 
+
 def testNWChem_NWChem6_0_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+    assert logfile.data.metadata["package_version"] == "6.0"
 
 
 def testNWChem_NWChem6_0_dvb_sp_hf_moments_only_quadrupole_out(logfile):
@@ -1180,6 +1183,8 @@ def testNWChem_NWChem6_0_dvb_sp_hf_moments_only_quadrupole_out(logfile):
     assert not logfile.data.moments[1].shape
     assert len(logfile.data.moments[2]) == 6
 
+    assert logfile.data.metadata["package_version"] == "6.0"
+
 
 def testNWChem_NWChem6_0_dvb_sp_hf_moments_only_octupole_out(logfile):
     """Quadrupole moments are printed/parsed, but not lower moments (no shape)."""
@@ -1188,6 +1193,8 @@ def testNWChem_NWChem6_0_dvb_sp_hf_moments_only_octupole_out(logfile):
     assert not logfile.data.moments[1].shape
     assert not logfile.data.moments[2].shape
     assert len(logfile.data.moments[3]) == 10
+
+    assert logfile.data.metadata["package_version"] == "6.0"
 
 
 def testNWChem_NWChem6_0_hydrogen_atom_ROHF_cc_pVDZ_out(logfile):
@@ -1203,6 +1210,8 @@ def testNWChem_NWChem6_0_hydrogen_atom_ROHF_cc_pVDZ_out(logfile):
     assert logfile.data.homos.shape == (2,)
     assert logfile.data.homos[0] == 0
     assert logfile.data.homos[1] == -1
+
+    assert logfile.data.metadata["package_version"] == "6.0"
 
 
 def testNWChem_NWChem6_0_hydrogen_atom_UHF_cc_pVDZ_out(logfile):
@@ -1223,25 +1232,32 @@ def testNWChem_NWChem6_0_hydrogen_atom_UHF_cc_pVDZ_out(logfile):
     assert logfile.data.homos[0] == 0
     assert logfile.data.homos[1] == -1
 
+    assert logfile.data.metadata["package_version"] == "6.0"
+
 
 def testNWChem_NWChem6_5_stopiter_nwchem_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 3
 
+    assert logfile.data.metadata["package_version"] == "6.5+26243"
+
 
 def testNWChem_NWChem6_5_stopiter_nwchem_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
-    assert logfile.data.metadata["package_version"] == "6.5+26243"
     assert len(logfile.data.scfvalues[0]) == 2
+
+    assert logfile.data.metadata["package_version"] == "6.5+26243"
 
 
 def testNWChem_NWChem6_8_526_out(logfile):
     """If `print low` is present in the input, SCF iterations are not
     printed.
     """
-    assert logfile.data.metadata["package_version"] == "6.8.1+g08bf49b"
     assert not hasattr(logfile.data, "scftargets")
     assert not hasattr(logfile.data, "scfvalues")
+
+    assert logfile.data.metadata["package_version"] == "6.8.1+g08bf49b"
+
 
 # ORCA #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -497,12 +497,16 @@ def testGAMESS_GAMESS_US2008_N2_UMP2_out(logfile):
     assert len(logfile.data.mpenergies) == 1
     assert abs(logfile.data.mpenergies[0] + 2975.97) < 0.01
 
+    assert logfile.data.metadata["package_version"] == "2008.r1"
+
 
 def testGAMESS_GAMESS_US2008_N2_ROMP2_out(logfile):
     """Check that the new format for GAMESS MP2 is parsed."""
     assert hasattr(logfile.data, "mpenergies")
     assert len(logfile.data.mpenergies) == 1
     assert abs(logfile.data.mpenergies[0] + 2975.97) < 0.01
+
+    assert logfile.data.metadata["package_version"] == "2008.r1"
 
 
 def testGAMESS_GAMESS_US2009_open_shell_ccsd_test_log(logfile):
@@ -511,6 +515,8 @@ def testGAMESS_GAMESS_US2009_open_shell_ccsd_test_log(logfile):
     assert len(logfile.data.ccenergies) == 1
     assert abs(logfile.data.ccenergies[0] + 3501.50) < 0.01
 
+    assert logfile.data.metadata["package_version"] == "2009.r3"
+
 
 def testGAMESS_GAMESS_US2009_paulo_h2o_mp2_out(logfile):
     """Check that the new format for GAMESS MP2 is parsed."""
@@ -518,20 +524,28 @@ def testGAMESS_GAMESS_US2009_paulo_h2o_mp2_out(logfile):
     assert len(logfile.data.mpenergies) == 1
     assert abs(logfile.data.mpenergies[0] + 2072.13) < 0.01
 
+    assert logfile.data.metadata["package_version"] == "2009.r3"
+
 
 def testGAMESS_GAMESS_US2012_dvb_gopt_a_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+    assert logfile.data.metadata["package_version"] == "2012.r2"
 
 
 def testGAMESS_GAMESS_US2012_stopiter_gamess_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 10
 
+    assert logfile.data.metadata["package_version"] == "2012.r1"
+
 
 def testGAMESS_GAMESS_US2013_N_UHF_out(logfile):
     """An UHF job that has an LZ value analysis between the alpha and beta orbitals."""
     assert len(logfile.data.moenergies) == 2
+
+    assert logfile.data.metadata["package_version"] == "2013.r1"
 
 
 def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
@@ -541,9 +555,15 @@ def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
     assert numpy.count_nonzero(logfile.data.mocoeffs[0][80-1: 0:]) == 0
     assert logfile.data.mocoeffs[0].all() == logfile.data.mocoeffs[1].all()
 
+    assert logfile.data.metadata["package_version"] == "2014.r1"
+
+
 def testGAMESS_GAMESS_US2018_exam45_log(logfile):
     """This logfile has EOM-CC electronic transitions (not currently supported)."""
     assert not hasattr(logfile.data, 'etenergies')
+
+    assert logfile.data.metadata["package_version"] == "2018.r2"
+
 
 def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     """Do some basic checks for this old unit test that was failing.

--- a/test/regression.py
+++ b/test/regression.py
@@ -445,34 +445,48 @@ def testDALTON_DALTON_2018_tdpbe_normal_sym_out(logfile):
 
 # Firefly #
 
+
 def testGAMESS_Firefly8_0_dvb_gopt_a_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+    assert logfile.data.metadata["package_version"] == "8.0.1+8540"
 
 
 def testGAMESS_Firefly8_0_h2o_log(logfile):
     """Check that molecular orbitals are parsed correctly (cclib/cclib#208)."""
     assert logfile.data.mocoeffs[0][0][0] == -0.994216
 
+    assert logfile.data.metadata["package_version"] == "8.0.0+7651"
+
 
 def testGAMESS_Firefly8_0_stopiter_firefly_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 6
 
+    assert logfile.data.metadata["package_version"] == "8.0.1+8540"
+
 
 def testGAMESS_Firefly8_1_benzene_am1_log(logfile):
-	"""Molecular orbitals were not parsed (cclib/cclib#228)."""
-	assert hasattr(logfile.data, 'mocoeffs')
+    """Molecular orbitals were not parsed (cclib/cclib#228)."""
+    assert hasattr(logfile.data, 'mocoeffs')
+
+    assert logfile.data.metadata["package_version"] == "8.1.0+9035"
 
 
 def testGAMESS_Firefly8_1_naphtalene_t_0_out(logfile):
-	"""Molecular orbitals were not parsed (cclib/cclib#228)."""
-	assert hasattr(logfile.data, 'mocoeffs')
+    """Molecular orbitals were not parsed (cclib/cclib#228)."""
+    assert hasattr(logfile.data, 'mocoeffs')
+
+    assert logfile.data.metadata["package_version"] == "8.1.1+9295"
 
 
 def testGAMESS_Firefly8_1_naphtalene_t_0_SP_out(logfile):
-	"""Molecular orbitals were not parsed (cclib/cclib#228)."""
-	assert hasattr(logfile.data, 'mocoeffs')
+    """Molecular orbitals were not parsed (cclib/cclib#228)."""
+    assert hasattr(logfile.data, 'mocoeffs')
+
+    assert logfile.data.metadata["package_version"] == "8.1.1+9295"
+
 
 # GAMESS #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -46,6 +46,8 @@ import traceback
 import unittest
 
 import numpy
+from packaging.version import parse as parse_version
+from packaging.version import Version
 
 from cclib.parser.utils import convertor
 
@@ -100,6 +102,9 @@ def testADF_ADF2004_01_Fe_ox3_final_out(logfile):
     assert logfile.data.homos[0] == 59 and logfile.data.homos[1] == 54
 
     assert logfile.data.metadata["package_version"] == "2004.01+200410211341"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testADF_ADF2013_01_dvb_gopt_b_unconverged_adfout(logfile):
@@ -107,6 +112,9 @@ def testADF_ADF2013_01_dvb_gopt_b_unconverged_adfout(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testADF_ADF2013_01_stopiter_dvb_sp_adfout(logfile):
@@ -185,6 +193,9 @@ def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
     assert abs(isotropic_calc - isotropic_ref) < 1.0e-4
 
     assert logfile.data.metadata["package_version"] == "2014dev42059"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert logfile.data.metadata["package_version_date"] == "2014-06-11"
     assert logfile.data.metadata["package_version_description"] == "development version"
 
@@ -192,6 +203,9 @@ def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
 def testADF_ADF2016_166_tddft_0_31_new_out(logfile):
     """This file led to StopIteration (#430)."""
     assert logfile.data.metadata["package_version"] == "2016dev53619"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert logfile.data.metadata["package_version_date"] == "2016-07-21"
     assert "package_version_description" not in logfile.data.metadata
 
@@ -202,6 +216,9 @@ def testADF_ADF2016_fa2_adf_out(logfile):
     assert [b for ab in logfile.data.atombasis for b in ab] == list(range(logfile.data.nbasis))
 
     assert logfile.data.metadata["package_version"] == "2016dev50467"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert logfile.data.metadata["package_version_date"] == "2016-02-17"
     assert logfile.data.metadata["package_version_description"] == "branches/AndrewAtkins/ADF-Shar"
 
@@ -252,6 +269,9 @@ def testDALTON_DALTON_2013_dvb_td_normalprint_out(logfile):
     assert hasattr(logfile.data, "etoscs")
 
     assert logfile.data.metadata["package_version"] == "2013.4+7abef2ada27562fe5e02849d6caeaa67c961732f"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testDALTON_DALTON_2015_dalton_atombasis_out(logfile):
@@ -263,6 +283,9 @@ def testDALTON_DALTON_2015_dalton_atombasis_out(logfile):
     assert hasattr(logfile.data, "atombasis")
 
     assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testDALTON_DALTON_2015_dalton_intgrl_out(logfile):
@@ -311,6 +334,9 @@ def testDALTON_DALTON_2016_huge_neg_polar_freq_out(logfile):
     assert abs(logfile.data.polarizabilities[2][0, 0] - 183.6308) < 1.0e-5
 
     assert logfile.data.metadata["package_version"] == "2016.2+7db4647eac203e51aae7da3cbc289f55146b30e9"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testDALTON_DALTON_2016_huge_neg_polar_stat_out(logfile):
@@ -345,6 +371,9 @@ def testDALTON_DALTON_2018_dft_properties_nosym_H2O_cc_pVDZ_out(logfile):
     just released.
     """
     assert logfile.data.metadata["package_version"] == "2019.alpha"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testDALTON_DALTON_2018_tdhf_2000_out(logfile):
@@ -357,6 +386,9 @@ def testDALTON_DALTON_2018_tdhf_2000_out(logfile):
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), -0.9733558768]
 
     assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testDALTON_DALTON_2018_tdhf_2000_sym_out(logfile):
@@ -451,6 +483,9 @@ def testGAMESS_Firefly8_0_dvb_gopt_a_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "8.0.1+8540"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_Firefly8_0_h2o_log(logfile):
@@ -458,6 +493,9 @@ def testGAMESS_Firefly8_0_h2o_log(logfile):
     assert logfile.data.mocoeffs[0][0][0] == -0.994216
 
     assert logfile.data.metadata["package_version"] == "8.0.0+7651"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_Firefly8_0_stopiter_firefly_out(logfile):
@@ -472,6 +510,9 @@ def testGAMESS_Firefly8_1_benzene_am1_log(logfile):
     assert hasattr(logfile.data, 'mocoeffs')
 
     assert logfile.data.metadata["package_version"] == "8.1.0+9035"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_Firefly8_1_naphtalene_t_0_out(logfile):
@@ -479,6 +520,9 @@ def testGAMESS_Firefly8_1_naphtalene_t_0_out(logfile):
     assert hasattr(logfile.data, 'mocoeffs')
 
     assert logfile.data.metadata["package_version"] == "8.1.1+9295"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_Firefly8_1_naphtalene_t_0_SP_out(logfile):
@@ -498,6 +542,9 @@ def testGAMESS_GAMESS_US2008_N2_UMP2_out(logfile):
     assert abs(logfile.data.mpenergies[0] + 2975.97) < 0.01
 
     assert logfile.data.metadata["package_version"] == "2008.r1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_GAMESS_US2008_N2_ROMP2_out(logfile):
@@ -516,6 +563,9 @@ def testGAMESS_GAMESS_US2009_open_shell_ccsd_test_log(logfile):
     assert abs(logfile.data.ccenergies[0] + 3501.50) < 0.01
 
     assert logfile.data.metadata["package_version"] == "2009.r3"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_GAMESS_US2009_paulo_h2o_mp2_out(logfile):
@@ -532,6 +582,9 @@ def testGAMESS_GAMESS_US2012_dvb_gopt_a_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "2012.r2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_GAMESS_US2012_stopiter_gamess_out(logfile):
@@ -546,6 +599,9 @@ def testGAMESS_GAMESS_US2013_N_UHF_out(logfile):
     assert len(logfile.data.moenergies) == 2
 
     assert logfile.data.metadata["package_version"] == "2013.r1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
@@ -556,6 +612,9 @@ def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
     assert logfile.data.mocoeffs[0].all() == logfile.data.mocoeffs[1].all()
 
     assert logfile.data.metadata["package_version"] == "2014.r1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_GAMESS_US2018_exam45_log(logfile):
@@ -563,6 +622,9 @@ def testGAMESS_GAMESS_US2018_exam45_log(logfile):
     assert not hasattr(logfile.data, 'etenergies')
 
     assert logfile.data.metadata["package_version"] == "2018.r2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
@@ -581,6 +643,9 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     assert len(logfile.data.etsecs) == number
 
     assert logfile.data.metadata["package_version"] == "2007.r1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 # GAMESS-UK #
@@ -590,6 +655,9 @@ def testGAMESS_UK_GAMESS_UK8_0_dvb_gopt_hf_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "8.0+6248"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGAMESS_UK_GAMESS_UK8_0_stopiter_gamessuk_dft_out(logfile):
@@ -635,6 +703,9 @@ def testGaussian_Gaussian16_naturalspinorbitals_parsing_log(logfile):
     assert logfile.data.atombasis[1][0] == 23
 
     assert logfile.data.metadata["package_version"] == "2016+A.03"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian98_C_bigmult_log(logfile):
@@ -648,6 +719,9 @@ def testGaussian_Gaussian98_C_bigmult_log(logfile):
     assert logfile.data.homos[1] == -1 # No occupied beta orbitals
 
     assert logfile.data.metadata["package_version"] == "1998+A.11.3"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
@@ -662,6 +736,9 @@ def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
     assert len(logfile.data.mpenergies) == 1
 
     assert logfile.data.metadata["package_version"] == "1998+A.7"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m23b6_out(logfile):
@@ -678,6 +755,9 @@ def testGaussian_Gaussian98_test_Cu2_log(logfile):
     assert logfile.data.nbasis == 38
 
     assert logfile.data.metadata["package_version"] == "1998+A.11.4"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian98_test_H2_log(logfile):
@@ -709,6 +789,9 @@ def testGaussian_Gaussian03_AM1_SP_out(logfile):
     assert len(logfile.data.scfvalues[0]) == 13
 
     assert logfile.data.metadata["package_version"] == "2003+E.01"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian03_anthracene_log(logfile):
@@ -716,6 +799,9 @@ def testGaussian_Gaussian03_anthracene_log(logfile):
     assert len(logfile.data.vibsyms) == len(logfile.data.vibfreqs)
 
     assert logfile.data.metadata["package_version"] == "2003+C.02"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian03_borane_opt_log(logfile):
@@ -734,6 +820,9 @@ def testGaussian_Gaussian03_chn1_log(logfile):
     assert not hasattr(logfile.data, "mocoeffs")
 
     assert logfile.data.metadata["package_version"] == "2003+B.04"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian03_cyclopropenyl_rhf_g03_cut_log(logfile):
@@ -757,6 +846,9 @@ def testGaussian_Gaussian03_DCV4T_C60_log(logfile):
     assert logfile.data.coreelectrons[101] == 2
 
     assert logfile.data.metadata["package_version"] == "2003+D.02"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian03_dvb_gopt_symmfollow_log(logfile):
@@ -768,6 +860,9 @@ def testGaussian_Gaussian03_dvb_gopt_symmfollow_log(logfile):
     assert len(logfile.data.atomcoords) == len(logfile.data.geovalues)
 
     assert logfile.data.metadata["package_version"] == "2003+C.01"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian03_mendes_out(logfile):
@@ -810,6 +905,9 @@ def testGaussian_Gaussian09_100_g09(logfile):
     assert logfile.data.homos == [104]
 
     assert logfile.data.metadata["package_version"] == "2009+B.01"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian09_25DMF_HRANH_log(logfile):
@@ -829,6 +927,9 @@ def testGaussian_Gaussian09_2D_PES_all_converged_log(logfile):
     assert ccData.OPT_UNCONVERGED not in logfile.data.optstatus
 
     assert logfile.data.metadata["package_version"] == "2009+D.01"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian09_2D_PES_one_unconverged_log(logfile):
@@ -844,6 +945,9 @@ def testGaussian_Gaussian09_534_out(logfile):
     assert abs(logfile.data.etenergies[0] - 20920.55328) < 1.0
 
     assert logfile.data.metadata["package_version"] == "2009+A.02"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testGaussian_Gaussian09_BSL_opt_freq_DFT_out(logfile):
@@ -1027,6 +1131,9 @@ def testJaguar_Jaguar8_3_stopiter_jaguar_dft_out(logfile):
     assert len(logfile.data.scfvalues[0]) == 4
 
     assert logfile.data.metadata["package_version"] == "8.3+13"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testJaguar_Jaguar8_3_stopiter_jaguar_hf_out(logfile):
@@ -1045,6 +1152,9 @@ def testMolcas_Molcas18_test_standard_000_out(logfile):
     assert not hasattr(logfile.data, "mocoeffs")
 
     assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testMolcas_Molcas18_test_standard_001_out(logfile):
@@ -1119,6 +1229,9 @@ def testMolpro_Molpro2008_ch2o_molpro_casscf_out(logfile):
     assert logfile.data.nooccnos[27] == 1.95640
 
     assert logfile.data.metadata["package_version"] == "2012.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testMolpro_Molpro2012_CHONHSH_HF_STO_3G_out(logfile):
@@ -1133,6 +1246,9 @@ def testMolpro_Molpro2012_CHONHSH_HF_STO_3G_out(logfile):
     assert len(logfile.data.gbasis[6]) == 1 # H
 
     assert logfile.data.metadata["package_version"] == "2012.1.23+f8cfea266908527a8826bdcd5983aaf62e47d3bf"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testMolpro_Molpro2012_dvb_gopt_unconverged_out(logfile):
@@ -1140,6 +1256,9 @@ def testMolpro_Molpro2012_dvb_gopt_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "2012.1.12+e112a8ab93d81616c1987a1f1ef3707d874b6803"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testMolpro_Molpro2012_stopiter_molpro_dft_out(logfile):
@@ -1147,6 +1266,9 @@ def testMolpro_Molpro2012_stopiter_molpro_dft_out(logfile):
     assert len(logfile.data.scfvalues[0]) == 6
 
     assert logfile.data.metadata["package_version"] == "2012.1+c18f7d37f9f045f75d4f3096db241dde02ddca0a"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testMolpro_Molpro2012_stopiter_molpro_hf_out(logfile):
@@ -1164,6 +1286,9 @@ def testMOPAC_MOPAC2016_9S3_uuu_Cs_cation_freq_PM7_out(logfile):
     assert hasattr(logfile.data, 'vibfreqs')
 
     assert logfile.data.metadata["package_version"] == "16.175"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 # NWChem #
@@ -1174,6 +1299,9 @@ def testNWChem_NWChem6_0_dvb_gopt_hf_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "6.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testNWChem_NWChem6_0_dvb_sp_hf_moments_only_quadrupole_out(logfile):
@@ -1240,6 +1368,9 @@ def testNWChem_NWChem6_5_stopiter_nwchem_dft_out(logfile):
     assert len(logfile.data.scfvalues[0]) == 3
 
     assert logfile.data.metadata["package_version"] == "6.5+26243"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testNWChem_NWChem6_5_stopiter_nwchem_hf_out(logfile):
@@ -1257,6 +1388,9 @@ def testNWChem_NWChem6_8_526_out(logfile):
     assert not hasattr(logfile.data, "scfvalues")
 
     assert logfile.data.metadata["package_version"] == "6.8.1+g08bf49b"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 # ORCA #
@@ -1278,6 +1412,9 @@ def testORCA_ORCA2_8_co_cosmo_out(logfile):
     assert hasattr(logfile.data, "scfenergies") and len(logfile.data.scfenergies) == 4
 
     assert logfile.data.metadata["package_version"] == "2.8+2287"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA2_9_job_out(logfile):
@@ -1289,6 +1426,9 @@ def testORCA_ORCA2_9_job_out(logfile):
     assert all([abs(sum(v)-1.0) < 0.0001 for k, v in logfile.data.atomspins.items()])
 
     assert logfile.data.metadata["package_version"] == "2.9.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA2_9_qmspeedtest_hf_out(logfile):
@@ -1298,6 +1438,9 @@ def testORCA_ORCA2_9_qmspeedtest_hf_out(logfile):
     assert abs(energy - expected) < 10**-6
 
     assert logfile.data.metadata["package_version"] == "2.9.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA3_0_chelpg_out(logfile):
@@ -1314,6 +1457,9 @@ def testORCA_ORCA3_0_dvb_gopt_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
     assert logfile.data.metadata["package_version"] == "3.0.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA3_0_polar_rhf_cg_out(logfile):
@@ -1321,6 +1467,9 @@ def testORCA_ORCA3_0_polar_rhf_cg_out(logfile):
     assert hasattr(logfile.data, 'polarizabilities')
 
     assert logfile.data.metadata["package_version"] == "3.0.3"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA3_0_polar_rhf_diis_out(logfile):
@@ -1354,6 +1503,9 @@ def testORCA_ORCA4_0_1_ttt_td_out(logfile):
     assert logfile.data.etrotats[13] == -0.03974
 
     assert logfile.data.metadata["package_version"] == "4.0.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA4_0_hydrogen_fluoride_numfreq_out(logfile):
@@ -1381,6 +1533,9 @@ def testORCA_ORCA4_0_invalid_literal_for_float_out(logfile):
     assert logfile.data.mocoeffs[0][107][378] == -92.159399
 
     assert logfile.data.metadata["package_version"] == "4.0.1.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA4_0_IrCl6_sp_out(logfile):
@@ -1398,6 +1553,9 @@ def testORCA_ORCA4_0_comment_or_blank_line_out(logfile):
     assert logfile.data.atomcoords.shape == (1, 8, 3)
 
     assert logfile.data.metadata["package_version"] == "4.0.0.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA4_1_725_out(logfile):
@@ -1412,6 +1570,9 @@ def testORCA_ORCA4_1_725_out(logfile):
     assert len(logfile.data.atomcharges["lowdin"]) == 7
 
     assert logfile.data.metadata["package_version"] == "4.1dev+13440"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testORCA_ORCA4_1_orca_from_issue_736_out(logfile):
@@ -1441,6 +1602,9 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
     assert [len(ab) for ab in logfile.data.atombasis] == [15, 5, 5]
 
     assert logfile.data.metadata["package_version"] == "3.4alpha"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 # PSI 4 #
@@ -1449,17 +1613,26 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
 def testPsi4_Psi4_beta5_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert logfile.data.metadata["package_version"] == "0!0.beta5"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
 
 def testPsi4_Psi4_beta5_sample_cc54_0_01_0_1_0_1_out(logfile):
     """TODO"""
     assert logfile.data.metadata["package_version"] == "0!0.beta2.dev+fa5960b375b8ca2a5e4000a48cb95e7f218c579a"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testPsi4_Psi4_beta5_stopiter_psi_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert logfile.data.metadata["package_version"] == "0!0.beta5"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert len(logfile.data.scfvalues[0]) == 7
 
 
@@ -1472,11 +1645,17 @@ def testPsi4_Psi4_beta5_stopiter_psi_hf_out(logfile):
 def testPsi4_Psi4_0_5_sample_scf5_out(logfile):
     """TODO"""
     assert logfile.data.metadata["package_version"] == "1!0.5.dev+master-dbe9080"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
     """Ensure that finite difference gradients are parsed."""
     assert logfile.data.metadata["package_version"] == "1!1.2a1.dev429+fixsym-7838fc1-dirty"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert hasattr(logfile.data, 'grads')
     assert logfile.data.grads.shape == (1, 3, 3)
     assert abs(logfile.data.grads[0, 0, 2] - 0.05498126903657) < 1.0e-12
@@ -1488,6 +1667,9 @@ def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
 def testPsi4_Psi4_1_2_ch4_hf_opt_freq_out(logfile):
     """Ensure that molecular orbitals and normal modes are parsed in Psi4 1.2"""
     assert logfile.data.metadata["package_version"] == "1!1.2.1.dev+HEAD-406f4de"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert hasattr(logfile.data, 'mocoeffs')
     assert hasattr(logfile.data, 'vibdisps')
     assert hasattr(logfile.data, 'vibfreqs')
@@ -1507,6 +1689,9 @@ def testQChem_QChem4_2_CH3___Na__RS_out(logfile):
     """
 
     assert logfile.data.metadata["package_version"] == "4.2.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
@@ -1538,6 +1723,9 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
     """
 
     assert logfile.data.metadata["package_version"] == "4.1.0.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
@@ -1567,6 +1755,9 @@ def testQChem_QChem4_2_CH4___Na__out(logfile):
     """
 
     assert logfile.data.metadata["package_version"] == "4.2.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 1
@@ -1596,6 +1787,9 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
     """
 
     assert logfile.data.metadata["package_version"] == "4.3.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
     assert logfile.data.charge == 1
     assert logfile.data.mult == 2
@@ -2015,6 +2209,9 @@ def testQChem_QChem4_2_read_molecule_out(logfile):
 def testQChem_QChem4_2_stopiter_qchem_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert logfile.data.metadata["package_version"] == "4.0.0.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert len(logfile.data.scfvalues[0]) == 7
 
 
@@ -2140,6 +2337,9 @@ def testQChem_QChem4_4_full_2_out(logfile):
     appearing just beforehand from a frequency-type calculation.
     """
     assert logfile.data.metadata["package_version"] == "4.4.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert hasattr(logfile.data, 'polarizabilities')
 
 
@@ -2148,6 +2348,9 @@ def testQChem_QChem4_4_srtlg_out(logfile):
     #349 and #381.
     """
     assert logfile.data.metadata["package_version"] == "4.4.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     # There is a linear dependence problem.
     nbasis, nmo = 1129, 1115
     assert len(logfile.data.mocoeffs) == 2
@@ -2188,6 +2391,9 @@ def testQChem_QChem5_0_438_out(logfile):
     showing the charge as 60.
     """
     assert logfile.data.metadata["package_version"] == "5.0.0"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert logfile.data.charge == 0
     assert logfile.data.coreelectrons[0] == 60
 
@@ -2197,6 +2403,9 @@ def testQChem_QChem5_0_argon_out(logfile):
     state' lines.
     """
     assert logfile.data.metadata["package_version"] == "5.0.1"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     nroots = 12
     assert len(logfile.data.etenergies) == nroots
     state_0_energy = -526.6323968555
@@ -2208,6 +2417,9 @@ def testQChem_QChem5_0_argon_out(logfile):
 def testQChem_QChem5_1_old_final_print_1_out(logfile):
     """This job has was run from a development version."""
     assert logfile.data.metadata["package_version"] == "5.1.0dev+branches_libresponse-27553"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
 
 
 # Turbomole
@@ -2215,6 +2427,9 @@ def testQChem_QChem5_1_old_final_print_1_out(logfile):
 
 def testTurbomole_Turbomole7_2_dvb_gopt_b3_lyp_Gaussian__(logfile):
     assert logfile.data.metadata["package_version"] == "7.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
     assert logfile.data.natom == 20
 
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1277,6 +1277,8 @@ def testORCA_ORCA2_8_co_cosmo_out(logfile):
     """
     assert hasattr(logfile.data, "scfenergies") and len(logfile.data.scfenergies) == 4
 
+    assert logfile.data.metadata["package_version"] == "2.8+2287"
+
 
 def testORCA_ORCA2_9_job_out(logfile):
     """First output file and request to parse atomic spin densities.
@@ -1286,12 +1288,16 @@ def testORCA_ORCA2_9_job_out(logfile):
     """
     assert all([abs(sum(v)-1.0) < 0.0001 for k, v in logfile.data.atomspins.items()])
 
+    assert logfile.data.metadata["package_version"] == "2.9.0"
+
 
 def testORCA_ORCA2_9_qmspeedtest_hf_out(logfile):
-	"""Check precision of SCF energies (cclib/cclib#210)."""
-	energy = logfile.data.scfenergies[-1]
-	expected = -17542.5188694
-	assert abs(energy - expected) < 10**-6
+    """Check precision of SCF energies (cclib/cclib#210)."""
+    energy = logfile.data.scfenergies[-1]
+    expected = -17542.5188694
+    assert abs(energy - expected) < 10**-6
+
+    assert logfile.data.metadata["package_version"] == "2.9.1"
 
 
 def testORCA_ORCA3_0_chelpg_out(logfile):
@@ -1307,25 +1313,35 @@ def testORCA_ORCA3_0_dvb_gopt_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["package_version"] == "3.0.1"
+
 
 def testORCA_ORCA3_0_polar_rhf_cg_out(logfile):
     """Alternative CP-SCF solver for the polarizability wasn't being detected."""
     assert hasattr(logfile.data, 'polarizabilities')
+
+    assert logfile.data.metadata["package_version"] == "3.0.3"
 
 
 def testORCA_ORCA3_0_polar_rhf_diis_out(logfile):
     """Alternative CP-SCF solver for the polarizability wasn't being detected."""
     assert hasattr(logfile.data, 'polarizabilities')
 
+    assert logfile.data.metadata["package_version"] == "3.0.3"
+
 
 def testORCA_ORCA3_0_stopiter_orca_scf_compact_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 1
 
+    assert logfile.data.metadata["package_version"] == "3.0.1"
+
 
 def testORCA_ORCA3_0_stopiter_orca_scf_large_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 9
+
+    assert logfile.data.metadata["package_version"] == "2.9.1"
 
 
 def testORCA_ORCA4_0_1_ttt_td_out(logfile):
@@ -1336,6 +1352,8 @@ def testORCA_ORCA4_0_1_ttt_td_out(logfile):
     assert numpy.isnan(logfile.data.etsecs[0][0][2])
     assert len(logfile.data.etrotats) == 24
     assert logfile.data.etrotats[13] == -0.03974
+
+    assert logfile.data.metadata["package_version"] == "4.0.0"
 
 
 def testORCA_ORCA4_0_hydrogen_fluoride_numfreq_out(logfile):
@@ -1362,6 +1380,8 @@ def testORCA_ORCA4_0_invalid_literal_for_float_out(logfile):
     assert logfile.data.mocoeffs[0][106][378] == 241.536860
     assert logfile.data.mocoeffs[0][107][378] == -92.159399
 
+    assert logfile.data.metadata["package_version"] == "4.0.1.2"
+
 
 def testORCA_ORCA4_0_IrCl6_sp_out(logfile):
     """Tests ECP and weird SCF printing."""
@@ -1377,6 +1397,9 @@ def testORCA_ORCA4_0_comment_or_blank_line_out(logfile):
     assert hasattr(logfile.data,"atomcoords")
     assert logfile.data.atomcoords.shape == (1, 8, 3)
 
+    assert logfile.data.metadata["package_version"] == "4.0.0.2"
+
+
 def testORCA_ORCA4_1_725_out(logfile):
     """This file uses embedding potentials, which requires `>` after atom names in
     the input file and that confuses different parts of the parser.
@@ -1387,6 +1410,8 @@ def testORCA_ORCA4_1_725_out(logfile):
     numpy.testing.assert_equal(logfile.data.atomnos, numpy.array([20, 17, 17, 17, 17, 17, 17], dtype=int))
     assert len(logfile.data.atomcharges["mulliken"]) == 7
     assert len(logfile.data.atomcharges["lowdin"]) == 7
+
+    assert logfile.data.metadata["package_version"] == "4.1dev+13440"
 
 
 def testORCA_ORCA4_1_orca_from_issue_736_out(logfile):

--- a/test/regression.py
+++ b/test/regression.py
@@ -1492,6 +1492,7 @@ def testPsi4_Psi4_1_2_ch4_hf_opt_freq_out(logfile):
     assert hasattr(logfile.data, 'vibdisps')
     assert hasattr(logfile.data, 'vibfreqs')
 
+
 # Q-Chem #
 
 
@@ -2213,10 +2214,13 @@ def testQChem_QChem5_1_old_final_print_1_out(logfile):
 
 
 def testTurbomole_Turbomole7_2_dvb_gopt_b3_lyp_Gaussian__(logfile):
+    assert logfile.data.metadata["package_version"] == "7.2"
     assert logfile.data.natom == 20
+
 
 # These regression tests are for logfiles that are not to be parsed
 # for some reason, and the function should start with 'testnoparse'.
+
 
 def testnoparseADF_ADF2004_01_mo_sp_adfout(filename):
     """This is an ADF file that has a different number of AO functions

--- a/test/regression.py
+++ b/test/regression.py
@@ -101,6 +101,7 @@ def testADF_ADF2004_01_Fe_ox3_final_out(logfile):
     """Make sure HOMOS are correct."""
     assert logfile.data.homos[0] == 59 and logfile.data.homos[1] == 54
 
+    assert logfile.data.metadata["legacy_package_version"] == "2004.01"
     assert logfile.data.metadata["package_version"] == "2004.01+200410211341"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -111,6 +112,7 @@ def testADF_ADF2013_01_dvb_gopt_b_unconverged_adfout(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "2013.01"
     assert logfile.data.metadata["package_version"] == "2013.01+201309012319"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -192,6 +194,7 @@ def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
     isotropic_ref = 51.3359
     assert abs(isotropic_calc - isotropic_ref) < 1.0e-4
 
+    assert logfile.data.metadata["legacy_package_version"] == "2014"
     assert logfile.data.metadata["package_version"] == "2014dev42059"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -202,6 +205,7 @@ def testADF_ADF2014_01_DMO_ORD_orig_out(logfile):
 
 def testADF_ADF2016_166_tddft_0_31_new_out(logfile):
     """This file led to StopIteration (#430)."""
+    assert logfile.data.metadata["legacy_package_version"] == "2016"
     assert logfile.data.metadata["package_version"] == "2016dev53619"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -215,6 +219,7 @@ def testADF_ADF2016_fa2_adf_out(logfile):
     assert hasattr(logfile.data, "atombasis")
     assert [b for ab in logfile.data.atombasis for b in ab] == list(range(logfile.data.nbasis))
 
+    assert logfile.data.metadata["legacy_package_version"] == "2016"
     assert logfile.data.metadata["package_version"] == "2016dev50467"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -268,6 +273,7 @@ def testDALTON_DALTON_2013_dvb_td_normalprint_out(logfile):
     assert hasattr(logfile.data, "etsyms")
     assert hasattr(logfile.data, "etoscs")
 
+    assert logfile.data.metadata["legacy_package_version"] == "2013.4"
     assert logfile.data.metadata["package_version"] == "2013.4+7abef2ada27562fe5e02849d6caeaa67c961732f"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -282,6 +288,7 @@ def testDALTON_DALTON_2015_dalton_atombasis_out(logfile):
     assert logfile.data.nbasis == 37
     assert hasattr(logfile.data, "atombasis")
 
+    assert logfile.data.metadata["legacy_package_version"] == "2015.0"
     assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -333,6 +340,7 @@ def testDALTON_DALTON_2016_huge_neg_polar_freq_out(logfile):
     assert len(logfile.data.polarizabilities) == 3
     assert abs(logfile.data.polarizabilities[2][0, 0] - 183.6308) < 1.0e-5
 
+    assert logfile.data.metadata["legacy_package_version"] == "2016.2"
     assert logfile.data.metadata["package_version"] == "2016.2+7db4647eac203e51aae7da3cbc289f55146b30e9"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -370,6 +378,7 @@ def testDALTON_DALTON_2018_dft_properties_nosym_H2O_cc_pVDZ_out(logfile):
     This file is in DALTON-2018, rather than DALTON-2019, because 2018.0 was
     just released.
     """
+    assert logfile.data.metadata["legacy_package_version"] == "2019.alpha"
     assert logfile.data.metadata["package_version"] == "2019.alpha"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -385,6 +394,7 @@ def testDALTON_DALTON_2018_tdhf_2000_out(logfile):
         assert len(getattr(logfile.data, attr)) == 9
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), -0.9733558768]
 
+    assert logfile.data.metadata["legacy_package_version"] == "2019.alpha"
     assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -482,6 +492,7 @@ def testGAMESS_Firefly8_0_dvb_gopt_a_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.0.1"
     assert logfile.data.metadata["package_version"] == "8.0.1+8540"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -492,6 +503,7 @@ def testGAMESS_Firefly8_0_h2o_log(logfile):
     """Check that molecular orbitals are parsed correctly (cclib/cclib#208)."""
     assert logfile.data.mocoeffs[0][0][0] == -0.994216
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.0.0"
     assert logfile.data.metadata["package_version"] == "8.0.0+7651"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -509,6 +521,7 @@ def testGAMESS_Firefly8_1_benzene_am1_log(logfile):
     """Molecular orbitals were not parsed (cclib/cclib#228)."""
     assert hasattr(logfile.data, 'mocoeffs')
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.1.0"
     assert logfile.data.metadata["package_version"] == "8.1.0+9035"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -519,6 +532,7 @@ def testGAMESS_Firefly8_1_naphtalene_t_0_out(logfile):
     """Molecular orbitals were not parsed (cclib/cclib#228)."""
     assert hasattr(logfile.data, 'mocoeffs')
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.1.1"
     assert logfile.data.metadata["package_version"] == "8.1.1+9295"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -541,6 +555,7 @@ def testGAMESS_GAMESS_US2008_N2_UMP2_out(logfile):
     assert len(logfile.data.mpenergies) == 1
     assert abs(logfile.data.mpenergies[0] + 2975.97) < 0.01
 
+    assert logfile.data.metadata["legacy_package_version"] == "2008R1"
     assert logfile.data.metadata["package_version"] == "2008.r1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -562,6 +577,7 @@ def testGAMESS_GAMESS_US2009_open_shell_ccsd_test_log(logfile):
     assert len(logfile.data.ccenergies) == 1
     assert abs(logfile.data.ccenergies[0] + 3501.50) < 0.01
 
+    assert logfile.data.metadata["legacy_package_version"] == "2009R3"
     assert logfile.data.metadata["package_version"] == "2009.r3"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -581,6 +597,7 @@ def testGAMESS_GAMESS_US2012_dvb_gopt_a_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "2012R2"
     assert logfile.data.metadata["package_version"] == "2012.r2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -598,6 +615,7 @@ def testGAMESS_GAMESS_US2013_N_UHF_out(logfile):
     """An UHF job that has an LZ value analysis between the alpha and beta orbitals."""
     assert len(logfile.data.moenergies) == 2
 
+    assert logfile.data.metadata["legacy_package_version"] == "2013R1"
     assert logfile.data.metadata["package_version"] == "2013.r1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -611,6 +629,7 @@ def testGAMESS_GAMESS_US2014_CdtetraM1B3LYP_log(logfile):
     assert numpy.count_nonzero(logfile.data.mocoeffs[0][80-1: 0:]) == 0
     assert logfile.data.mocoeffs[0].all() == logfile.data.mocoeffs[1].all()
 
+    assert logfile.data.metadata["legacy_package_version"] == "2014R1"
     assert logfile.data.metadata["package_version"] == "2014.r1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -621,6 +640,7 @@ def testGAMESS_GAMESS_US2018_exam45_log(logfile):
     """This logfile has EOM-CC electronic transitions (not currently supported)."""
     assert not hasattr(logfile.data, 'etenergies')
 
+    assert logfile.data.metadata["legacy_package_version"] == "2018R2"
     assert logfile.data.metadata["package_version"] == "2018.r2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -642,6 +662,7 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     assert abs(max(logfile.data.etoscs) - 0.0) < 0.01
     assert len(logfile.data.etsecs) == number
 
+    assert logfile.data.metadata["legacy_package_version"] == "2007R1"
     assert logfile.data.metadata["package_version"] == "2007.r1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -654,6 +675,7 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
 def testGAMESS_UK_GAMESS_UK8_0_dvb_gopt_hf_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.0"
     assert logfile.data.metadata["package_version"] == "8.0+6248"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -702,6 +724,7 @@ def testGaussian_Gaussian16_naturalspinorbitals_parsing_log(logfile):
     assert logfile.data.aonames[41] == 'O2_9D 0'
     assert logfile.data.atombasis[1][0] == 23
 
+    assert logfile.data.metadata["legacy_package_version"] == "16revisionA.03"
     assert logfile.data.metadata["package_version"] == "2016+A.03"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -718,6 +741,7 @@ def testGaussian_Gaussian98_C_bigmult_log(logfile):
     assert logfile.data.homos[0] == 8
     assert logfile.data.homos[1] == -1 # No occupied beta orbitals
 
+    assert logfile.data.metadata["legacy_package_version"] == "98revisionA.11.3"
     assert logfile.data.metadata["package_version"] == "1998+A.11.3"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -735,6 +759,7 @@ def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
     # we expect only the last MP2 energy to be extracted.
     assert len(logfile.data.mpenergies) == 1
 
+    assert logfile.data.metadata["legacy_package_version"] == "98revisionA.7"
     assert logfile.data.metadata["package_version"] == "1998+A.7"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -754,6 +779,7 @@ def testGaussian_Gaussian98_test_Cu2_log(logfile):
     """An example of the number of basis set function changing."""
     assert logfile.data.nbasis == 38
 
+    assert logfile.data.metadata["legacy_package_version"] == "98revisionA.11.4"
     assert logfile.data.metadata["package_version"] == "1998+A.11.4"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -788,6 +814,7 @@ def testGaussian_Gaussian03_AM1_SP_out(logfile):
     """Previously, caused scfvalue parsing to fail."""
     assert len(logfile.data.scfvalues[0]) == 13
 
+    assert logfile.data.metadata["legacy_package_version"] == "03revisionE.01"
     assert logfile.data.metadata["package_version"] == "2003+E.01"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -798,6 +825,7 @@ def testGaussian_Gaussian03_anthracene_log(logfile):
     """This file exposed a bug in extracting the vibsyms."""
     assert len(logfile.data.vibsyms) == len(logfile.data.vibfreqs)
 
+    assert logfile.data.metadata["legacy_package_version"] == "03revisionC.02"
     assert logfile.data.metadata["package_version"] == "2003+C.02"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -819,6 +847,7 @@ def testGaussian_Gaussian03_chn1_log(logfile):
     """
     assert not hasattr(logfile.data, "mocoeffs")
 
+    assert logfile.data.metadata["legacy_package_version"] == "03revisionB.04"
     assert logfile.data.metadata["package_version"] == "2003+B.04"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -845,6 +874,7 @@ def testGaussian_Gaussian03_DCV4T_C60_log(logfile):
     assert len(logfile.data.coreelectrons) == 102
     assert logfile.data.coreelectrons[101] == 2
 
+    assert logfile.data.metadata["legacy_package_version"] == "03revisionD.02"
     assert logfile.data.metadata["package_version"] == "2003+D.02"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -859,6 +889,7 @@ def testGaussian_Gaussian03_dvb_gopt_symmfollow_log(logfile):
     """
     assert len(logfile.data.atomcoords) == len(logfile.data.geovalues)
 
+    assert logfile.data.metadata["legacy_package_version"] == "03revisionC.01"
     assert logfile.data.metadata["package_version"] == "2003+C.01"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -904,6 +935,7 @@ def testGaussian_Gaussian09_100_g09(logfile):
     assert logfile.data.natom == 54
     assert logfile.data.homos == [104]
 
+    assert logfile.data.metadata["legacy_package_version"] == "09revisionB.01"
     assert logfile.data.metadata["package_version"] == "2009+B.01"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -926,6 +958,7 @@ def testGaussian_Gaussian09_2D_PES_all_converged_log(logfile):
     """Check that optstatus has no UNCOVERGED values."""
     assert ccData.OPT_UNCONVERGED not in logfile.data.optstatus
 
+    assert logfile.data.metadata["legacy_package_version"] == "09revisionD.01"
     assert logfile.data.metadata["package_version"] == "2009+D.01"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -944,6 +977,7 @@ def testGaussian_Gaussian09_534_out(logfile):
     assert logfile.data.etsyms[0] == "Singlet-?Sym"
     assert abs(logfile.data.etenergies[0] - 20920.55328) < 1.0
 
+    assert logfile.data.metadata["legacy_package_version"] == "09revisionA.02"
     assert logfile.data.metadata["package_version"] == "2009+A.02"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1130,6 +1164,7 @@ def testJaguar_Jaguar8_3_stopiter_jaguar_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 4
 
+    assert logfile.data.metadata["legacy_package_version"] == "8.3"
     assert logfile.data.metadata["package_version"] == "8.3+13"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1151,6 +1186,7 @@ def testMolcas_Molcas18_test_standard_000_out(logfile):
     assert not hasattr(logfile.data, "moenergies")
     assert not hasattr(logfile.data, "mocoeffs")
 
+    assert logfile.data.metadata["legacy_package_version"] == "18.09"
     assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1228,6 +1264,7 @@ def testMolpro_Molpro2008_ch2o_molpro_casscf_out(logfile):
     assert len(logfile.data.nooccnos) == logfile.data.nmo
     assert logfile.data.nooccnos[27] == 1.95640
 
+    assert logfile.data.metadata["legacy_package_version"] == "2012.1"
     assert logfile.data.metadata["package_version"] == "2012.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1245,6 +1282,7 @@ def testMolpro_Molpro2012_CHONHSH_HF_STO_3G_out(logfile):
     assert len(logfile.data.gbasis[5]) == 1 # H
     assert len(logfile.data.gbasis[6]) == 1 # H
 
+    assert logfile.data.metadata["legacy_package_version"] == "2012.1"
     assert logfile.data.metadata["package_version"] == "2012.1.23+f8cfea266908527a8826bdcd5983aaf62e47d3bf"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1255,6 +1293,7 @@ def testMolpro_Molpro2012_dvb_gopt_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "2012.1"
     assert logfile.data.metadata["package_version"] == "2012.1.12+e112a8ab93d81616c1987a1f1ef3707d874b6803"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1265,6 +1304,7 @@ def testMolpro_Molpro2012_stopiter_molpro_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 6
 
+    assert logfile.data.metadata["legacy_package_version"] == "2012.1"
     assert logfile.data.metadata["package_version"] == "2012.1+c18f7d37f9f045f75d4f3096db241dde02ddca0a"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1285,6 +1325,7 @@ def testMOPAC_MOPAC2016_9S3_uuu_Cs_cation_freq_PM7_out(logfile):
     """There was a syntax error in the frequency parsing."""
     assert hasattr(logfile.data, 'vibfreqs')
 
+    assert logfile.data.metadata["legacy_package_version"] == "2016"
     assert logfile.data.metadata["package_version"] == "16.175"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1298,6 +1339,7 @@ def testNWChem_NWChem6_0_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "6.0"
     assert logfile.data.metadata["package_version"] == "6.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1367,6 +1409,7 @@ def testNWChem_NWChem6_5_stopiter_nwchem_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 3
 
+    assert logfile.data.metadata["legacy_package_version"] == "6.5"
     assert logfile.data.metadata["package_version"] == "6.5+26243"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1387,6 +1430,7 @@ def testNWChem_NWChem6_8_526_out(logfile):
     assert not hasattr(logfile.data, "scftargets")
     assert not hasattr(logfile.data, "scfvalues")
 
+    assert logfile.data.metadata["legacy_package_version"] == "6.8.1"
     assert logfile.data.metadata["package_version"] == "6.8.1+g08bf49b"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1411,6 +1455,7 @@ def testORCA_ORCA2_8_co_cosmo_out(logfile):
     """
     assert hasattr(logfile.data, "scfenergies") and len(logfile.data.scfenergies) == 4
 
+    assert logfile.data.metadata["legacy_package_version"] == "2.8"
     assert logfile.data.metadata["package_version"] == "2.8+2287"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1425,6 +1470,7 @@ def testORCA_ORCA2_9_job_out(logfile):
     """
     assert all([abs(sum(v)-1.0) < 0.0001 for k, v in logfile.data.atomspins.items()])
 
+    assert logfile.data.metadata["legacy_package_version"] == "2.9.0"
     assert logfile.data.metadata["package_version"] == "2.9.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1437,6 +1483,7 @@ def testORCA_ORCA2_9_qmspeedtest_hf_out(logfile):
     expected = -17542.5188694
     assert abs(energy - expected) < 10**-6
 
+    assert logfile.data.metadata["legacy_package_version"] == "2.9.1"
     assert logfile.data.metadata["package_version"] == "2.9.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1456,6 +1503,7 @@ def testORCA_ORCA3_0_dvb_gopt_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["legacy_package_version"] == "3.0.1"
     assert logfile.data.metadata["package_version"] == "3.0.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1466,6 +1514,7 @@ def testORCA_ORCA3_0_polar_rhf_cg_out(logfile):
     """Alternative CP-SCF solver for the polarizability wasn't being detected."""
     assert hasattr(logfile.data, 'polarizabilities')
 
+    assert logfile.data.metadata["legacy_package_version"] == "3.0.3"
     assert logfile.data.metadata["package_version"] == "3.0.3"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1502,6 +1551,7 @@ def testORCA_ORCA4_0_1_ttt_td_out(logfile):
     assert len(logfile.data.etrotats) == 24
     assert logfile.data.etrotats[13] == -0.03974
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.0.0"
     assert logfile.data.metadata["package_version"] == "4.0.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1532,6 +1582,7 @@ def testORCA_ORCA4_0_invalid_literal_for_float_out(logfile):
     assert logfile.data.mocoeffs[0][106][378] == 241.536860
     assert logfile.data.mocoeffs[0][107][378] == -92.159399
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.0.1.2"
     assert logfile.data.metadata["package_version"] == "4.0.1.2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1552,7 +1603,8 @@ def testORCA_ORCA4_0_comment_or_blank_line_out(logfile):
     assert hasattr(logfile.data,"atomcoords")
     assert logfile.data.atomcoords.shape == (1, 8, 3)
 
-    assert logfile.data.metadata["package_version"] == "4.0.0.2"
+    assert logfile.data.metadata["legacy_package_version"] == "4.0.1.2"
+    assert logfile.data.metadata["package_version"] == "4.0.1.2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
     )
@@ -1569,6 +1621,7 @@ def testORCA_ORCA4_1_725_out(logfile):
     assert len(logfile.data.atomcharges["mulliken"]) == 7
     assert len(logfile.data.atomcharges["lowdin"]) == 7
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.1.x"
     assert logfile.data.metadata["package_version"] == "4.1dev+13440"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1601,6 +1654,7 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
     assert logfile.data.nbasis == 25
     assert [len(ab) for ab in logfile.data.atombasis] == [15, 5, 5]
 
+    assert logfile.data.metadata["legacy_package_version"] == "3.4"
     assert logfile.data.metadata["package_version"] == "3.4alpha"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1612,6 +1666,7 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
 
 def testPsi4_Psi4_beta5_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
+    assert logfile.data.metadata["legacy_package_version"] == "beta5"
     assert logfile.data.metadata["package_version"] == "0!0.beta5"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1621,6 +1676,7 @@ def testPsi4_Psi4_beta5_dvb_gopt_hf_unconverged_out(logfile):
 
 def testPsi4_Psi4_beta5_sample_cc54_0_01_0_1_0_1_out(logfile):
     """TODO"""
+    assert logfile.data.metadata["legacy_package_version"] == "beta2+"
     assert logfile.data.metadata["package_version"] == "0!0.beta2.dev+fa5960b375b8ca2a5e4000a48cb95e7f218c579a"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1643,7 +1699,7 @@ def testPsi4_Psi4_beta5_stopiter_psi_hf_out(logfile):
 
 
 def testPsi4_Psi4_0_5_sample_scf5_out(logfile):
-    """TODO"""
+    assert logfile.data.metadata["legacy_package_version"] == "0.5"
     assert logfile.data.metadata["package_version"] == "1!0.5.dev+master-dbe9080"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1652,6 +1708,7 @@ def testPsi4_Psi4_0_5_sample_scf5_out(logfile):
 
 def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
     """Ensure that finite difference gradients are parsed."""
+    assert logfile.data.metadata["legacy_package_version"] == "1.2a1.dev429"
     assert logfile.data.metadata["package_version"] == "1!1.2a1.dev429+fixsym-7838fc1-dirty"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1666,6 +1723,7 @@ def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
 
 def testPsi4_Psi4_1_2_ch4_hf_opt_freq_out(logfile):
     """Ensure that molecular orbitals and normal modes are parsed in Psi4 1.2"""
+    assert logfile.data.metadata["legacy_package_version"] == "1.2.1"
     assert logfile.data.metadata["package_version"] == "1!1.2.1.dev+HEAD-406f4de"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1688,6 +1746,7 @@ def testQChem_QChem4_2_CH3___Na__RS_out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.2.2"
     assert logfile.data.metadata["package_version"] == "4.2.2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1722,6 +1781,7 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
     This is to ensure only the supersystem is printed.
     """
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.1.0.1"
     assert logfile.data.metadata["package_version"] == "4.1.0.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1754,6 +1814,7 @@ def testQChem_QChem4_2_CH4___Na__out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.2.0"
     assert logfile.data.metadata["package_version"] == "4.2.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -1786,6 +1847,7 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
     This is to ensure only the supersystem is parsed.
     """
 
+    assert logfile.data.metadata["legacy_package_version"] == "4.3.0"
     assert logfile.data.metadata["package_version"] == "4.3.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2208,6 +2270,7 @@ def testQChem_QChem4_2_read_molecule_out(logfile):
 
 def testQChem_QChem4_2_stopiter_qchem_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
+    assert logfile.data.metadata["legacy_package_version"] == "4.0.0.1"
     assert logfile.data.metadata["package_version"] == "4.0.0.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2336,6 +2399,7 @@ def testQChem_QChem4_4_full_2_out(logfile):
     """The polarizability section may not be parsed due to something
     appearing just beforehand from a frequency-type calculation.
     """
+    assert logfile.data.metadata["legacy_package_version"] == "4.4.2"
     assert logfile.data.metadata["package_version"] == "4.4.2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2347,6 +2411,7 @@ def testQChem_QChem4_4_srtlg_out(logfile):
     """Some lines in the MO coefficients require fixed-width parsing. See
     #349 and #381.
     """
+    assert logfile.data.metadata["legacy_package_version"] == "4.4.0"
     assert logfile.data.metadata["package_version"] == "4.4.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2390,6 +2455,7 @@ def testQChem_QChem5_0_438_out(logfile):
     """This job has an ECP on Pt, replacing 60 of 78 electrons, and was
     showing the charge as 60.
     """
+    assert logfile.data.metadata["legacy_package_version"] == "5.0.0"
     assert logfile.data.metadata["package_version"] == "5.0.0"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2402,6 +2468,7 @@ def testQChem_QChem5_0_argon_out(logfile):
     """This job has unit specifications at the end of 'Total energy for
     state' lines.
     """
+    assert logfile.data.metadata["legacy_package_version"] == "5.0.1"
     assert logfile.data.metadata["package_version"] == "5.0.1"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2416,6 +2483,7 @@ def testQChem_QChem5_0_argon_out(logfile):
 
 def testQChem_QChem5_1_old_final_print_1_out(logfile):
     """This job has was run from a development version."""
+    assert logfile.data.metadata["legacy_package_version"] == "5.1.0"
     assert logfile.data.metadata["package_version"] == "5.1.0dev+branches_libresponse-27553"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
@@ -2426,6 +2494,7 @@ def testQChem_QChem5_1_old_final_print_1_out(logfile):
 
 
 def testTurbomole_Turbomole7_2_dvb_gopt_b3_lyp_Gaussian__(logfile):
+    assert logfile.data.metadata["legacy_package_version"] == "7.2"
     assert logfile.data.metadata["package_version"] == "7.2"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version

--- a/test/regression.py
+++ b/test/regression.py
@@ -1182,21 +1182,35 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
 
 def testPsi4_Psi4_beta5_dvb_gopt_hf_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
+    assert logfile.data.metadata["package_version"] == "0!0.beta5"
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+
+def testPsi4_Psi4_beta5_sample_cc54_0_01_0_1_0_1_out(logfile):
+    """TODO"""
+    assert logfile.data.metadata["package_version"] == "0!0.beta2.dev+fa5960b375b8ca2a5e4000a48cb95e7f218c579a"
 
 
 def testPsi4_Psi4_beta5_stopiter_psi_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
+    assert logfile.data.metadata["package_version"] == "0!0.beta5"
     assert len(logfile.data.scfvalues[0]) == 7
 
 
 def testPsi4_Psi4_beta5_stopiter_psi_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
+    assert logfile.data.metadata["package_version"] == "0!0.beta5"
     assert len(logfile.data.scfvalues[0]) == 6
+
+
+def testPsi4_Psi4_0_5_sample_scf5_out(logfile):
+    """TODO"""
+    assert logfile.data.metadata["package_version"] == "1!0.5.dev+master-dbe9080"
 
 
 def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
     """Ensure that finite difference gradients are parsed."""
+    assert logfile.data.metadata["package_version"] == "1!1.2a1.dev429+fixsym-7838fc1-dirty"
     assert hasattr(logfile.data, 'grads')
     assert logfile.data.grads.shape == (1, 3, 3)
     assert abs(logfile.data.grads[0, 0, 2] - 0.05498126903657) < 1.0e-12
@@ -1207,6 +1221,7 @@ def testPsi4_Psi4_0_5_water_fdgrad_out(logfile):
 
 def testPsi4_Psi4_1_2_ch4_hf_opt_freq_out(logfile):
     """Ensure that molecular orbitals and normal modes are parsed in Psi4 1.2"""
+    assert logfile.data.metadata["package_version"] == "1!1.2.1.dev+HEAD-406f4de"
     assert hasattr(logfile.data, 'mocoeffs')
     assert hasattr(logfile.data, 'vibdisps')
     assert hasattr(logfile.data, 'vibfreqs')

--- a/test/regression.py
+++ b/test/regression.py
@@ -933,6 +933,8 @@ def testMolcas_Molcas18_test_standard_000_out(logfile):
     assert not hasattr(logfile.data, "moenergies")
     assert not hasattr(logfile.data, "mocoeffs")
 
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+
 
 def testMolcas_Molcas18_test_standard_001_out(logfile):
     """This logfile has two calculations, and we currently only want to parse the first."""
@@ -942,15 +944,21 @@ def testMolcas_Molcas18_test_standard_001_out(logfile):
     assert logfile.data.nbasis == 30
     assert logfile.data.nmo == 30
 
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+
 
 def testMolcas_Molcas18_test_standard_003_out(logfile):
     """This logfile has extra charged monopoles (not part of the molecule)."""
     assert logfile.data.charge == 0
 
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+
 
 def testMolcas_Molcas18_test_standard_005_out(logfile):
     """Final geometry in optimization has fewer atoms due to symmetry, and so is ignored."""
     assert len(logfile.data.atomcoords) == 2
+
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
 
 
 def testMolcas_Molcas18_test_stevenv_001_out(logfile):
@@ -958,11 +966,16 @@ def testMolcas_Molcas18_test_stevenv_001_out(logfile):
     assert not hasattr(logfile.data, "moenergies")
     assert not hasattr(logfile.data, "mocoeffs")
 
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+
 
 def testMolcas_Molcas18_test_stevenv_desym_out(logfile):
     """This logfile has iterations interrupted by a Fermi aufbau procedure."""
     assert len(logfile.data.scfvalues) == 1
     assert len(logfile.data.scfvalues[0]) == 26
+
+    assert logfile.data.metadata["package_version"] == "18.09+52-ge15dc38.81d3fb3dc6a5c5df6b3791ef1ef3790f"
+
 
 # Molpro #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -523,6 +523,8 @@ def testGaussian_Gaussian16_naturalspinorbitals_parsing_log(logfile):
     assert logfile.data.aonames[41] == 'O2_9D 0'
     assert logfile.data.atombasis[1][0] == 23
 
+    assert logfile.data.metadata["package_version"] == "2016+A.03"
+
 
 def testGaussian_Gaussian98_C_bigmult_log(logfile):
     """
@@ -533,6 +535,8 @@ def testGaussian_Gaussian98_C_bigmult_log(logfile):
     assert logfile.data.mult == 10
     assert logfile.data.homos[0] == 8
     assert logfile.data.homos[1] == -1 # No occupied beta orbitals
+
+    assert logfile.data.metadata["package_version"] == "1998+A.11.3"
 
 
 def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
@@ -546,6 +550,8 @@ def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m21b0_out(logfile):
     # we expect only the last MP2 energy to be extracted.
     assert len(logfile.data.mpenergies) == 1
 
+    assert logfile.data.metadata["package_version"] == "1998+A.7"
+
 
 def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m23b6_out(logfile):
     """A job that was killed before it ended, should have several basic attributes parsed."""
@@ -553,10 +559,14 @@ def testGaussian_Gaussian98_NIST_CCCBDB_1himidaz_m23b6_out(logfile):
     assert hasattr(logfile.data, 'metadata')
     assert hasattr(logfile.data, 'mult')
 
+    assert logfile.data.metadata["package_version"] == "1998+A.7"
+
 
 def testGaussian_Gaussian98_test_Cu2_log(logfile):
     """An example of the number of basis set function changing."""
     assert logfile.data.nbasis == 38
+
+    assert logfile.data.metadata["package_version"] == "1998+A.11.4"
 
 
 def testGaussian_Gaussian98_test_H2_log(logfile):
@@ -566,6 +576,8 @@ def testGaussian_Gaussian98_test_H2_log(logfile):
     """
     assert logfile.data.atomcharges['natural'][0] == 0.0
     assert logfile.data.atomcharges['natural'][1] == 0.0
+
+    assert logfile.data.metadata["package_version"] == "1998+A.11.4"
 
 
 def testGaussian_Gaussian98_water_zmatrix_nosym_log(logfile):
@@ -578,21 +590,29 @@ def testGaussian_Gaussian98_water_zmatrix_nosym_log(logfile):
     assert len(logfile.data.atomcoords) == 1
     assert logfile.data.natom == 3
 
+    assert logfile.data.metadata["package_version"] == "1998+A.11.3"
+
 
 def testGaussian_Gaussian03_AM1_SP_out(logfile):
     """Previously, caused scfvalue parsing to fail."""
     assert len(logfile.data.scfvalues[0]) == 13
+
+    assert logfile.data.metadata["package_version"] == "2003+E.01"
 
 
 def testGaussian_Gaussian03_anthracene_log(logfile):
     """This file exposed a bug in extracting the vibsyms."""
     assert len(logfile.data.vibsyms) == len(logfile.data.vibfreqs)
 
+    assert logfile.data.metadata["package_version"] == "2003+C.02"
+
 
 def testGaussian_Gaussian03_borane_opt_log(logfile):
     """An example of changing molecular orbital count."""
     assert logfile.data.optstatus[-1] == logfile.data.OPT_DONE
     assert logfile.data.nmo == 609
+
+    assert logfile.data.metadata["package_version"] == "2003+E.01"
 
 
 def testGaussian_Gaussian03_chn1_log(logfile):
@@ -602,6 +622,8 @@ def testGaussian_Gaussian03_chn1_log(logfile):
     """
     assert not hasattr(logfile.data, "mocoeffs")
 
+    assert logfile.data.metadata["package_version"] == "2003+B.04"
+
 
 def testGaussian_Gaussian03_cyclopropenyl_rhf_g03_cut_log(logfile):
     """
@@ -610,6 +632,8 @@ def testGaussian_Gaussian03_cyclopropenyl_rhf_g03_cut_log(logfile):
     which up till now stored the last coordinates.
     """
     assert len(logfile.data.atomcoords) == len(logfile.data.geovalues)
+
+    assert logfile.data.metadata["package_version"] == "2003+C.02"
 
 
 def testGaussian_Gaussian03_DCV4T_C60_log(logfile):
@@ -621,6 +645,8 @@ def testGaussian_Gaussian03_DCV4T_C60_log(logfile):
     assert len(logfile.data.coreelectrons) == 102
     assert logfile.data.coreelectrons[101] == 2
 
+    assert logfile.data.metadata["package_version"] == "2003+D.02"
+
 
 def testGaussian_Gaussian03_dvb_gopt_symmfollow_log(logfile):
     """Non-standard treatment of symmetry.
@@ -629,6 +655,8 @@ def testGaussian_Gaussian03_dvb_gopt_symmfollow_log(logfile):
     which caused only the first coordinates to be read previously.
     """
     assert len(logfile.data.atomcoords) == len(logfile.data.geovalues)
+
+    assert logfile.data.metadata["package_version"] == "2003+C.01"
 
 
 def testGaussian_Gaussian03_mendes_out(logfile):
@@ -640,6 +668,8 @@ def testGaussian_Gaussian03_mendes_out(logfile):
         else:
             assert x == 0
 
+    assert logfile.data.metadata["package_version"] == "2003+C.02"
+
 
 def testGaussian_Gaussian03_Mo4OSibdt2_opt_log(logfile):
     """
@@ -648,6 +678,8 @@ def testGaussian_Gaussian03_Mo4OSibdt2_opt_log(logfile):
     """
     assert logfile.data.optstatus[-1] == logfile.data.OPT_DONE
     assert hasattr(logfile.data, "atomcoords")
+
+    assert logfile.data.metadata["package_version"] == "2003+C.02"
 
 
 def testGaussian_Gaussian03_orbgs_log(logfile):
@@ -658,11 +690,15 @@ def testGaussian_Gaussian03_orbgs_log(logfile):
     assert logfile.data.coreelectrons[20] == 10
     assert logfile.data.coreelectrons[23] == 10
 
+    assert logfile.data.metadata["package_version"] == "2003+C.02"
+
 
 def testGaussian_Gaussian09_100_g09(logfile):
     """Check that the final system is the one parsed (cclib/cclib#243)."""
     assert logfile.data.natom == 54
     assert logfile.data.homos == [104]
+
+    assert logfile.data.metadata["package_version"] == "2009+B.01"
 
 
 def testGaussian_Gaussian09_25DMF_HRANH_log(logfile):
@@ -674,21 +710,29 @@ def testGaussian_Gaussian09_25DMF_HRANH_log(logfile):
     assert abs(anharms[0][0] + 43.341) < 0.01
     assert abs(anharms[N-1][N-1] + 36.481) < 0.01
 
+    assert logfile.data.metadata["package_version"] == "2009+B.01"
+
 
 def testGaussian_Gaussian09_2D_PES_all_converged_log(logfile):
     """Check that optstatus has no UNCOVERGED values."""
     assert ccData.OPT_UNCONVERGED not in logfile.data.optstatus
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
 def testGaussian_Gaussian09_2D_PES_one_unconverged_log(logfile):
     """Check that optstatus contains UNCOVERGED values."""
     assert ccData.OPT_UNCONVERGED in logfile.data.optstatus
 
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
+
 
 def testGaussian_Gaussian09_534_out(logfile):
     """Previously, caused etenergies parsing to fail."""
     assert logfile.data.etsyms[0] == "Singlet-?Sym"
     assert abs(logfile.data.etenergies[0] - 20920.55328) < 1.0
+
+    assert logfile.data.metadata["package_version"] == "2009+A.02"
 
 
 def testGaussian_Gaussian09_BSL_opt_freq_DFT_out(logfile):
@@ -701,11 +745,15 @@ def testGaussian_Gaussian09_BSL_opt_freq_DFT_out(logfile):
     # hexadecapole ZZZZ
     assert logfile.data.moments[4][-1] == -77.9600
 
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
+
 
 def testGaussian_Gaussian09_dvb_gopt_unconverged_log(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
     assert logfile.data.optstatus[-1] == logfile.data.OPT_UNCONVERGED
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
 def testGaussian_Gaussian09_dvb_lowdin_log(logfile):
@@ -713,17 +761,23 @@ def testGaussian_Gaussian09_dvb_lowdin_log(logfile):
     assert "mulliken" in logfile.data.atomcharges
     assert "lowdin" in logfile.data.atomcharges
 
+    assert logfile.data.metadata["package_version"] == "2009+A.02"
+
 
 def testGaussian_Gaussian09_Dahlgren_TS_log(logfile):
     """Failed to parse ccenergies for a variety of reasons"""
     assert hasattr(logfile.data, "ccenergies")
     assert abs(logfile.data.ccenergies[0] - (-11819.96506609)) < 0.001
 
+    assert logfile.data.metadata["package_version"] == "2009+A.02"
+
 
 def testGaussian_Gaussian09_irc_point_log(logfile):
     """Failed to parse vibfreqs except for 10, 11"""
     assert hasattr(logfile.data, "vibfreqs")
     assert len(logfile.data.vibfreqs) == 11
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
 def testGaussian_Gaussian09_issue_460_log(logfile):
@@ -749,11 +803,15 @@ def testGaussian_Gaussian09_issue_460_log(logfile):
     assert logfile.data.scfvalues[0][0, 0] == 3.37e-03
     assert numpy.isnan(logfile.data.scfvalues[0][0, 2])
 
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
+
 
 def testGaussian_Gaussian09_OPT_td_g09_out(logfile):
     """Couldn't find etrotats as G09 has different output than G03."""
     assert len(logfile.data.etrotats) == 10
     assert logfile.data.etrotats[0] == -0.4568
+
+    assert logfile.data.metadata["package_version"] == "2009+A.02"
 
 
 def testGaussian_Gaussian09_OPT_td_out(logfile):
@@ -761,9 +819,13 @@ def testGaussian_Gaussian09_OPT_td_out(logfile):
     assert len(logfile.data.etrotats) == 10
     assert logfile.data.etrotats[0] == -0.4568
 
+    assert logfile.data.metadata["package_version"] == "2003+B.05"
+
 
 def testGaussian_Gaussian09_OPT_oniom_log(logfile):
     """AO basis extraction broke with ONIOM"""
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
 def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
@@ -771,20 +833,28 @@ def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
     assert hasattr(logfile.data, 'vibirs')
     assert len(logfile.data.vibirs) == 216
 
+    assert logfile.data.metadata["package_version"] == "2009+C.01"
+
 
 def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):
     """Here atomnos wans't added to the gaussian parser before."""
     assert len(logfile.data.atomnos) == 69
+
+    assert logfile.data.metadata["package_version"] == "2009+A.02"
 
 
 def testGaussian_Gaussian09_benzene_HPfreq_log(logfile):
     """Check that higher precision vib displacements obtained with freq=hpmodes) are parsed correctly."""
     assert abs(logfile.data.vibdisps[0,0,2] - (-0.04497)) < 0.00001
 
+    assert logfile.data.metadata["package_version"] == "2009+C.01"
+
 
 def testGaussian_Gaussian09_benzene_freq_log(logfile):
     """Check that default precision vib displacements are parsed correctly."""
     assert abs(logfile.data.vibdisps[0,0,2] - (-0.04)) < 0.00001
+
+    assert logfile.data.metadata["package_version"] == "2009+C.01"
 
 
 def testGaussian_Gaussian09_relaxed_PES_testH2_log(logfile):
@@ -794,6 +864,8 @@ def testGaussian_Gaussian09_relaxed_PES_testH2_log(logfile):
     assert len(optstatus) == len(atomcoords)
 
     assert all(s == ccData.OPT_DONE + ccData.OPT_NEW for s in optstatus)
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
 def testGaussian_Gaussian09_relaxed_PES_testCO2_log(logfile):
@@ -821,10 +893,15 @@ def testGaussian_Gaussian09_relaxed_PES_testCO2_log(logfile):
     # to have converged in a single step.
     assert all(s == ccData.OPT_DONE + ccData.OPT_NEW for s in optstatus[new_points[3]:])
 
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
+
 
 def testGaussian_Gaussian09_stopiter_gaussian_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 4
+
+    assert logfile.data.metadata["package_version"] == "2009+D.01"
+
 
 # Jaguar #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1010,6 +1010,7 @@ def testNWChem_NWChem6_5_stopiter_nwchem_dft_out(logfile):
 
 def testNWChem_NWChem6_5_stopiter_nwchem_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
+    assert logfile.data.metadata["package_version"] == "6.5+26243"
     assert len(logfile.data.scfvalues[0]) == 2
 
 
@@ -1017,6 +1018,7 @@ def testNWChem_NWChem6_8_526_out(logfile):
     """If `print low` is present in the input, SCF iterations are not
     printed.
     """
+    assert logfile.data.metadata["package_version"] == "6.8.1+g08bf49b"
     assert not hasattr(logfile.data, "scftargets")
     assert not hasattr(logfile.data, "scfvalues")
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -251,6 +251,8 @@ def testDALTON_DALTON_2013_dvb_td_normalprint_out(logfile):
     assert hasattr(logfile.data, "etsyms")
     assert hasattr(logfile.data, "etoscs")
 
+    assert logfile.data.metadata["package_version"] == "2013.4+7abef2ada27562fe5e02849d6caeaa67c961732f"
+
 
 def testDALTON_DALTON_2015_dalton_atombasis_out(logfile):
     """This logfile didn't parse due to the absence of a line in the basis
@@ -260,6 +262,8 @@ def testDALTON_DALTON_2015_dalton_atombasis_out(logfile):
     assert logfile.data.nbasis == 37
     assert hasattr(logfile.data, "atombasis")
 
+    assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
+
 
 def testDALTON_DALTON_2015_dalton_intgrl_out(logfile):
     """This logfile didn't parse due to the absence of a line in the basis
@@ -268,6 +272,8 @@ def testDALTON_DALTON_2015_dalton_intgrl_out(logfile):
     assert hasattr(logfile.data, "nbasis")
     assert logfile.data.nbasis == 4
     assert hasattr(logfile.data, "atombasis")
+
+    assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
 
 
 def testDALTON_DALTON_2015_dvb_td_normalprint_out(logfile):
@@ -279,15 +285,21 @@ def testDALTON_DALTON_2015_dvb_td_normalprint_out(logfile):
     assert hasattr(logfile.data, "etsyms")
     assert hasattr(logfile.data, "etoscs")
 
+    assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
+
 
 def testDALTON_DALTON_2015_stopiter_dalton_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 8
 
+    assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
+
 
 def testDALTON_DALTON_2015_stopiter_dalton_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 5
+
+    assert logfile.data.metadata["package_version"] == "2015.0+d34efb170c481236ad60c789dea90a4c857c6bab"
 
 
 def testDALTON_DALTON_2016_huge_neg_polar_freq_out(logfile):
@@ -298,6 +310,8 @@ def testDALTON_DALTON_2016_huge_neg_polar_freq_out(logfile):
     assert len(logfile.data.polarizabilities) == 3
     assert abs(logfile.data.polarizabilities[2][0, 0] - 183.6308) < 1.0e-5
 
+    assert logfile.data.metadata["package_version"] == "2016.2+7db4647eac203e51aae7da3cbc289f55146b30e9"
+
 
 def testDALTON_DALTON_2016_huge_neg_polar_stat_out(logfile):
     """This logfile didn't parse due to lack of spacing between
@@ -306,6 +320,8 @@ def testDALTON_DALTON_2016_huge_neg_polar_stat_out(logfile):
     assert hasattr(logfile.data, "polarizabilities")
     assert len(logfile.data.polarizabilities) == 1
     assert abs(logfile.data.polarizabilities[0][1, 1] + 7220.150408) < 1.0e-7
+
+    assert logfile.data.metadata["package_version"] == "2016.2+7db4647eac203e51aae7da3cbc289f55146b30e9"
 
 
 def testDALTON_DALTON_2016_Trp_polar_response_diplnx_out(logfile):
@@ -318,6 +334,8 @@ def testDALTON_DALTON_2016_Trp_polar_response_diplnx_out(logfile):
     assert abs(logfile.data.polarizabilities[0][0, 0] - 95.11540019) < 1.0e-8
     assert numpy.count_nonzero(numpy.isnan(logfile.data.polarizabilities)) == 8
 
+    assert logfile.data.metadata["package_version"] == "2016.2+7db4647eac203e51aae7da3cbc289f55146b30e9"
+
 
 def testDALTON_DALTON_2018_dft_properties_nosym_H2O_cc_pVDZ_out(logfile):
     """The "simple" version string in newer development versions of DALTON wasn't
@@ -326,7 +344,6 @@ def testDALTON_DALTON_2018_dft_properties_nosym_H2O_cc_pVDZ_out(logfile):
     This file is in DALTON-2018, rather than DALTON-2019, because 2018.0 was
     just released.
     """
-    assert "package_version" in logfile.data.metadata
     assert logfile.data.metadata["package_version"] == "2019.alpha"
 
 
@@ -339,6 +356,8 @@ def testDALTON_DALTON_2018_tdhf_2000_out(logfile):
         assert len(getattr(logfile.data, attr)) == 9
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), -0.9733558768]
 
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
+
 
 def testDALTON_DALTON_2018_tdhf_2000_sym_out(logfile):
     """Ensure etsecs are being parsed from a TDHF calculation with symmetry and a
@@ -348,6 +367,8 @@ def testDALTON_DALTON_2018_tdhf_2000_sym_out(logfile):
     for attr in ("etenergies", "etsecs", "etsyms", "etoscs"):
         assert len(getattr(logfile.data, attr)) == 3
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9733562358]
+
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
 
 
 def testDALTON_DALTON_2018_tdhf_normal_out(logfile):
@@ -359,6 +380,8 @@ def testDALTON_DALTON_2018_tdhf_normal_out(logfile):
         assert len(getattr(logfile.data, attr)) == 9
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), -0.9733558768]
 
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
+
 
 def testDALTON_DALTON_2018_tdhf_normal_sym_out(logfile):
     """Ensure etsecs are being parsed from a TDHF calculation with symmetry and a
@@ -368,6 +391,8 @@ def testDALTON_DALTON_2018_tdhf_normal_sym_out(logfile):
     for attr in ("etenergies", "etsecs", "etsyms", "etoscs"):
         assert len(getattr(logfile.data, attr)) == 3
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9733562358]
+
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
 
 
 def testDALTON_DALTON_2018_tdpbe_2000_out(logfile):
@@ -379,6 +404,8 @@ def testDALTON_DALTON_2018_tdpbe_2000_out(logfile):
         assert len(getattr(logfile.data, attr)) == 9
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9992665559]
 
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
+
 
 def testDALTON_DALTON_2018_tdpbe_2000_sym_out(logfile):
     """Ensure etsecs are being parsed from a TDDFT calculation with symmetry and a
@@ -388,6 +415,8 @@ def testDALTON_DALTON_2018_tdpbe_2000_sym_out(logfile):
     for attr in ("etenergies", "etsecs", "etsyms", "etoscs"):
         assert len(getattr(logfile.data, attr)) == 3
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9992672154]
+
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
 
 
 def testDALTON_DALTON_2018_tdpbe_normal_out(logfile):
@@ -399,6 +428,8 @@ def testDALTON_DALTON_2018_tdpbe_normal_out(logfile):
         assert len(getattr(logfile.data, attr)) == 9
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9992665559]
 
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
+
 
 def testDALTON_DALTON_2018_tdpbe_normal_sym_out(logfile):
     """Ensure etsecs are being parsed from a TDDFT calculation with symmetry and a
@@ -408,6 +439,8 @@ def testDALTON_DALTON_2018_tdpbe_normal_sym_out(logfile):
     for attr in ("etenergies", "etsecs", "etsyms", "etoscs"):
         assert len(getattr(logfile.data, attr)) == 3
     assert logfile.data.etsecs[0][0] == [(1, 0), (2, 0), 0.9992672154]
+
+    assert logfile.data.metadata["package_version"] == "2019.alpha+25947a3d842ee2ebb42bff87a4dd64adbbd3ec5b"
 
 
 # Firefly #

--- a/test/regression.py
+++ b/test/regression.py
@@ -1440,6 +1440,8 @@ def testPsi3_Psi3_4_water_psi3_log(logfile):
     assert logfile.data.nbasis == 25
     assert [len(ab) for ab in logfile.data.atombasis] == [15, 5, 5]
 
+    assert logfile.data.metadata["package_version"] == "3.4alpha"
+
 
 # PSI 4 #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -2495,7 +2495,7 @@ def testQChem_QChem5_1_old_final_print_1_out(logfile):
 
 def testTurbomole_Turbomole7_2_dvb_gopt_b3_lyp_Gaussian__(logfile):
     assert logfile.data.metadata["legacy_package_version"] == "7.2"
-    assert logfile.data.metadata["package_version"] == "7.2"
+    assert logfile.data.metadata["package_version"] == "7.2.r21471"
     assert isinstance(
         parse_version(logfile.data.metadata["package_version"]), Version
     )

--- a/test/regression.py
+++ b/test/regression.py
@@ -1925,7 +1925,7 @@ def testQChem_QChem5_0_argon_out(logfile):
 
 def testQChem_QChem5_1_old_final_print_1_out(logfile):
     """This job has was run from a development version."""
-    assert logfile.data.metadata["package_version"] == "5.1.0dev27553+branches_libresponse"
+    assert logfile.data.metadata["package_version"] == "5.1.0dev+branches_libresponse-27553"
 
 
 # Turbomole

--- a/test/regression.py
+++ b/test/regression.py
@@ -915,10 +915,15 @@ def testJaguar_Jaguar8_3_stopiter_jaguar_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 4
 
+    assert logfile.data.metadata["package_version"] == "8.3+13"
+
 
 def testJaguar_Jaguar8_3_stopiter_jaguar_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 3
+
+    assert logfile.data.metadata["package_version"] == "8.3+13"
+
 
 # Molcas #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1163,6 +1163,9 @@ def testMOPAC_MOPAC2016_9S3_uuu_Cs_cation_freq_PM7_out(logfile):
     """There was a syntax error in the frequency parsing."""
     assert hasattr(logfile.data, 'vibfreqs')
 
+    assert logfile.data.metadata["package_version"] == "16.175"
+
+
 # NWChem #
 
 def testNWChem_NWChem6_0_dvb_gopt_hf_unconverged_out(logfile):

--- a/test/regression.py
+++ b/test/regression.py
@@ -1118,6 +1118,8 @@ def testMolpro_Molpro2008_ch2o_molpro_casscf_out(logfile):
     assert len(logfile.data.nooccnos) == logfile.data.nmo
     assert logfile.data.nooccnos[27] == 1.95640
 
+    assert logfile.data.metadata["package_version"] == "2012.1"
+
 
 def testMolpro_Molpro2012_CHONHSH_HF_STO_3G_out(logfile):
     """Formatting of the basis function is slightly different than expected."""
@@ -1130,19 +1132,29 @@ def testMolpro_Molpro2012_CHONHSH_HF_STO_3G_out(logfile):
     assert len(logfile.data.gbasis[5]) == 1 # H
     assert len(logfile.data.gbasis[6]) == 1 # H
 
+    assert logfile.data.metadata["package_version"] == "2012.1.23+f8cfea266908527a8826bdcd5983aaf62e47d3bf"
+
+
 def testMolpro_Molpro2012_dvb_gopt_unconverged_out(logfile):
     """An unconverged geometry optimization to test for empty optdone (see #103 for details)."""
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
+
+    assert logfile.data.metadata["package_version"] == "2012.1.12+e112a8ab93d81616c1987a1f1ef3707d874b6803"
 
 
 def testMolpro_Molpro2012_stopiter_molpro_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 6
 
+    assert logfile.data.metadata["package_version"] == "2012.1+c18f7d37f9f045f75d4f3096db241dde02ddca0a"
+
 
 def testMolpro_Molpro2012_stopiter_molpro_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 6
+
+    assert logfile.data.metadata["package_version"] == "2012.1+c18f7d37f9f045f75d4f3096db241dde02ddca0a"
+
 
 # MOPAC #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -580,21 +580,31 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     assert abs(max(logfile.data.etoscs) - 0.0) < 0.01
     assert len(logfile.data.etsecs) == number
 
+    assert logfile.data.metadata["package_version"] == "2007.r1"
+
+
 # GAMESS-UK #
 
 
 def testGAMESS_UK_GAMESS_UK8_0_dvb_gopt_hf_unconverged_out(logfile):
     assert hasattr(logfile.data, 'optdone') and not logfile.data.optdone
 
+    assert logfile.data.metadata["package_version"] == "8.0+6248"
+
 
 def testGAMESS_UK_GAMESS_UK8_0_stopiter_gamessuk_dft_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 7
 
+    assert logfile.data.metadata["package_version"] == "8.0+6248"
+
 
 def testGAMESS_UK_GAMESS_UK8_0_stopiter_gamessuk_hf_out(logfile):
     """Check to ensure that an incomplete SCF is handled correctly."""
     assert len(logfile.data.scfvalues[0]) == 5
+
+    assert logfile.data.metadata["package_version"] == "8.0+6248"
+
 
 # Gaussian #
 


### PR DESCRIPTION
Closes #533.

Needs tests to make sure that parsing the version doesn't produce a `LegacyVersion`, which is something that would violate PEP 440.