### PR TITLE
Implement per-attribute data unit tests parameterized with decorators

### DIFF
--- a/test/data/common.py
+++ b/test/data/common.py
@@ -5,7 +5,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
-"""Functions used across multiple data tests."""
+"""Helpers used across multiple data tests."""
 
 import itertools
 

--- a/test/data/paths.py
+++ b/test/data/paths.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+UNIT_TEST_PATHS = {
+    'BOMD': {
+        'Gaussian': {
+            'basicGaussian09': ('dvb_bomd.out', ),
+        },
+        'NWChem': {
+            'basicNWChem6.6': ('dvb_bomd_ks.out',),
+        },
+        'QChem': {
+            'basicQChem4.2': ('dvb_bomd.out',),
+            'basicQChem5.1': ('dvb_bomd.out',),
+        },
+    },
+}

--- a/test/data/testBOMD.py
+++ b/test/data/testBOMD.py
@@ -23,32 +23,6 @@ class GenericBOMDTest(unittest.TestCase):
     nsteps = 35
     nenergies = 36
 
-    def testdimscfenergies(self):
-        """Are the number of parsed energies consistent with the number of MD
-        steps?
-        """
-        self.assertEqual(self.data.scfenergies.shape, (self.nenergies, ))
-
-    def testdimatomcoords(self):
-        """Are the number of parsed geometries consistent with the number of
-        MD steps?
-        """
-        self.assertEqual(self.data.atomcoords.shape, (self.nenergies, 20, 3))
-
-    def testdimtime(self):
-        """Are the number of time points consistent with the number of MD
-        steps?
-        """
-        self.assertEqual(self.data.time.shape, (self.nsteps, ))
-
-
-class GaussianBOMDTest(GenericBOMDTest):
-    """Customized Born-Oppenheimer molecular dynamics unittest"""
-
-    # This may have something to do with our corrections for
-    # extrapolation step rejection.
-    nenergies = 35
-
 
 if __name__=="__main__":
 

--- a/test/data/test_atomcoords.py
+++ b/test/data/test_atomcoords.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Unit tests for the scfenergies attribute."""
+
+import inspect
+import os
+import unittest
+
+import cclib
+
+import utils
+
+
+class AtomCoordsTest(utils.DataTestCase):
+
+    @utils.for_job_type('BOMD', nenergies=36, natoms=20)
+    @utils.for_program(
+        'Gaussian', nenergies=35,
+        msg='This may have something to do with our corrections for extrapolation step rejections.')
+    def test_shape(self, data, nenergies, natoms):
+        self.assertEqual(data.atomcoords.shape, (nenergies, natoms, 3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/data/test_scfenergies.py
+++ b/test/data/test_scfenergies.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Unit tests for the scfenergies attribute."""
+
+import inspect
+import os
+import unittest
+
+import cclib
+
+import utils
+
+
+class ScfEnergiesTest(utils.DataTestCase):
+
+    @utils.for_job_type('BOMD', nenergies=36)
+    @utils.for_program(
+        'Gaussian', nenergies=35,
+        msg='This may have something to do with our corrections for extrapolation step rejections.')
+    def test_shape(self, data, nenergies):
+        self.assertEqual(data.scfenergies.shape, (nenergies, ))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/data/test_time.py
+++ b/test/data/test_time.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Unit tests for the time attribute."""
+
+import inspect
+import os
+import unittest
+
+import cclib
+
+import utils
+
+
+class TimeTest(utils.DataTestCase):
+
+    @utils.for_job_type('BOMD', nsteps=35)
+    def test_shape(self, data, nsteps):
+        self.assertEqual(data.time.shape, (nsteps, ))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/data/utils.py
+++ b/test/data/utils.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Helpers used for data tests."""
+
+import inspect
+import os
+import unittest
+
+import cclib
+
+from paths import UNIT_TEST_PATHS
+
+
+class DataTestCase(unittest.TestCase):
+    """A test case class the support parameterizing with job types.
+    
+    The purpose of this class is to make it easier to write compact tests
+    for cclib data unit tests. There are two basic features on top of the
+    base TestCase class:
+      1. The ability to parameterize test methods with job types such as
+         SP, GOpt, which generates a test method for each program version
+         that has a logfile in the UNIT_TEST_PATHS dictionary. Additional
+         parameters may be passed to the test method as well.
+      2. The ability to override a test parameter for specific programs.
+    
+    Below is an example test case with two methods. The first test method
+    applies to two different job types, and all programs for which we have
+    log files for those job types. The second one uses a different expected
+    value for one program.
+    
+    class NAtomsTestCase(DataTestCase):
+
+        @for_job_type("SP", "GOpt", expected_natoms=5)
+        test_value(self, data, expected_natoms):
+            self.assertEqual(data.natoms, expected_natoms)
+
+        @for_job_type("vib", expected_natoms=5)
+        @for_program("Psi", expected_natoms=6, msg="Some mix up in the input file")
+        test_value(self, data, expected_natoms):
+            self.assertEqual(data.natoms, expected_natoms)
+
+    Note that the for_job_type decorator needs to always be on opt (last).
+    """
+
+    # This is a class member, which means any unit tests inheriting from
+    # it will access and write to the same cache. And this is desirable,
+    # since we only want to parse each logfile once regardless of the
+    # scope of the test run.
+    _logfile_data_cache = {}
+
+    def setUp(self):
+        self.current_program = None
+
+    def _get_data_for_logfile_path(self, path):
+        if path not in self._logfile_data_cache:
+            data = cclib.io.ccread(path)
+            if not data:
+                raise IOError("Could not parse: %s" % path)
+            self._logfile_data_cache[path] = data
+        return self._logfile_data_cache[path]
+
+
+def for_job_type(*job_types, **kwargs):
+    """Returns a decorator for parameterizing a DataTestCase method with one or more job types."""
+    def wrapper(wrapped_func):
+        new_methods = {}
+        for jtype, program, version, file_name in _flattened_unit_test_paths(job_types):
+            path = os.path.join('data', program, version, file_name)
+            original_name = wrapped_func.__name__.lstrip('_')
+            new_func = _standalone_job_type_func(path, wrapped_func, program, original_name, **kwargs)
+            new_func.__test__ = True
+            new_name = '_'.join((original_name, jtype, version))
+            new_methods[new_name] = new_func
+
+        stack = inspect.stack()
+        frame = stack[1]
+        frame_locals = frame[0].f_locals
+        for new_name, new_func in new_methods.items():
+            frame_locals[new_name] = new_func
+
+        wrapped_func.__test__ = False
+
+    return wrapper
+
+
+def for_program(program_type, msg=None, **kwargs):
+    """Returns a decorator for modifying a DataTestCase method with one or more program-specific changes."""
+    def decorator(wrapped_func):
+        if not wrapped_func:
+            raise TypeError('The for_job_type decorator needs to be applied last.')
+
+        new_func = _standalone_program_func(wrapped_func, program_type, **kwargs)
+        new_func.__test__ = True
+        new_name = '_' + wrapped_func.__name__
+        new_func.__name__ = new_name
+
+        stack = inspect.stack()
+        frame = stack[1]
+        frame_locals = frame[0].f_locals
+        frame_locals[new_name] = new_func
+
+        wrapped_func.__test__ = False
+        return new_func
+    return decorator
+
+
+def _standalone_job_type_func(path, wrapped_func, program, original_name, **kwargs):
+  """Returns a new function that wraps a job-specific test method."""
+  def standalone_func(self):
+    if not isinstance(self, DataTestCase):
+        raise TypeError("This method assumes it will be bound to a cclib DataTestCase.")
+    data = self._get_data_for_logfile_path(path)
+    self.current_program = program
+    wrapped_func(self, data, **kwargs)
+  return standalone_func
+
+
+def _standalone_program_func(wrapped_func, program_type, **wrapped_kwargs):
+  """Returns a new function that wraps a program-specific test method."""
+  def standalone_func(self, *args, **kwargs):
+    if not isinstance(self, DataTestCase):
+        raise TypeError('This method assumes it will be bound to a cclib DataTestCase.')
+    new_kwargs = kwargs
+    if not self.current_program:
+        raise ValueError('No program set. Use for_job_type decorator before for_program.')
+    if self.current_program == program_type:
+        new_kwargs = _merge_two_dicts(kwargs, wrapped_kwargs)
+    wrapped_func(self, *args, **new_kwargs)
+  return standalone_func
+
+
+def _flattened_unit_test_paths(job_types):
+  """Generates flattened tuples from the unit test path dictionary of selected job types."""
+  for jtype in job_types:
+      for program, program_files in UNIT_TEST_PATHS[jtype].items():
+          for version, version_files in program_files.items():
+              for file_name in version_files:
+                  yield jtype, program, version, file_name
+
+
+def _merge_two_dicts(x, y):
+    z = x.copy()
+    z.update(y)
+    return z

--- a/test/data/utils_test.py
+++ b/test/data/utils_test.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Tests for data test utilities."""
+
+import mock
+import os
+import unittest
+
+import cclib
+
+import utils
+
+
+def load_and_run(test_case_class):
+    """Loads and runs test methods from a TestCase class."""
+    loader = unittest.loader.TestLoader()
+    test_suite = loader.loadTestsFromTestCase(test_case_class)
+    results = unittest.TestResult()
+    test_suite.run(results)
+    return test_suite, results
+
+
+def get_fake_ccread(filename_to_attribute_dict):
+    """Generates a function that fakes the behavior or ccread.
+    
+    This is for use by tests that want to simulate the behavior of ccread
+    and return ccData object with specific attributes set.
+    """
+    def fake_ccread(path):
+        data = cclib.parser.ccData()
+        for filename, attribute_dict in filename_to_attribute_dict.items():
+            if os.path.basename(path) == filename:
+                for key, value in attribute_dict.items():
+                    setattr(data, key, value)
+                return data
+        return data
+    return fake_ccread
+
+
+class DataTestCaseTest(unittest.TestCase):        
+    """Test case class used by cclib for testing logfile parsing for multiple programs."""
+
+    def setUp(self):
+      self.addCleanup(mock.patch.stopall)
+
+      # We don't actually want to parse anything in this test.
+      self.mock_cclib = mock.patch.object(utils, 'cclib').start()
+      
+      # This mock will let us set unit test path data for specific job
+      # types and programs in test methods. Note that overriding the
+      # unit_test_paths dictionary will break tests, because it needs to
+      # be the same object that the mock references. The default dict
+      # below is useful for test that don't realy on the data.
+      self.mock_unit_test_paths = mock.patch.object(utils, 'UNIT_TEST_PATHS').start()
+      self.unit_test_paths = {
+            'some_job_type': {
+                'some_program': {
+                    'some_version': ('some_file',)
+                }
+            }
+        }
+      self.mock_unit_test_paths.__getitem__.side_effect = self.unit_test_paths.__getitem__
+
+    def test_for_job_type(self):
+        self.unit_test_paths['some_job_type'] = {
+            'some_program': {
+                'some_version1': ('some_file1',),
+                'some_version2': ('some_file2',),
+            },
+        }
+        class FakeTestCase(utils.DataTestCase):
+            @utils.for_job_type('some_job_type')
+            def test_pass(self, data): pass
+        self.assertIn('test_pass_some_job_type_some_version1', dir(FakeTestCase))
+        self.assertIn('test_pass_some_job_type_some_version2', dir(FakeTestCase))
+
+        # Only the job-specific methods get loaded, because the original
+        # test_pass method is set to None since the for_job_type decorator
+        # doesn't return a callable object.
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(test_suite.countTestCases(), 2)
+        self.assertEqual(results.testsRun, 2)
+        self.assertEqual(len(results.errors), 0)
+        self.assertEqual(len(results.failures), 0)
+
+    def test_for_job_type_with_parameter(self):
+        self.unit_test_paths['some_job_type'] = {
+            'some_program': {
+                'some_version1': ('some_file1',),
+                'some_version2': ('some_file2',),
+            },
+        }
+        class FakeTestCase(utils.DataTestCase):
+            @utils.for_job_type('some_job_type', some_param=5)
+            def test_param(self, data, some_param):
+                self.assertEqual(some_param, 5)
+
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(results.testsRun, 2)
+        self.assertEqual(len(results.errors), 0)
+        self.assertEqual(len(results.failures), 0)
+
+    def test_for_job_type_with_parameter_and_program_override(self):
+        self.unit_test_paths['some_job_type'] = {
+            'some_program': {
+                'some_version': ('some_file',),
+            },
+            'other_program': {
+                'other_version': ('other_file',),
+            },
+        }
+        self.mock_cclib.io.ccread = get_fake_ccread({
+            'some_file': {'some_param': 5},
+            'other_file': {'some_param': 6},
+        })
+        class FakeTestCase(utils.DataTestCase):
+            @utils.for_job_type('some_job_type', some_param=5)
+            @utils.for_program('other_program', some_param=6)
+            def test_param(self, data, some_param):
+                self.assertEqual(some_param, data.some_param)
+
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(results.testsRun, 2)
+        self.assertEqual(len(results.errors), 0)
+        self.assertEqual(len(results.failures), 0)
+
+    def test_for_job_type_with_multiple_job_types(self):
+        self.unit_test_paths['some_job_type'] = {
+            'some_program': {
+                'some_version1': ('some_file1',),
+                'some_version2': ('some_file2',),
+            },
+        }
+        self.unit_test_paths['other_job_type'] = {
+            'some_program': {
+                'some_version3': ('some_file3',),
+                'some_version4': ('some_file4',),
+            },
+        }
+        class FakeTestCase(utils.DataTestCase):
+            @utils.for_job_type('some_job_type', 'other_job_type')
+            def test_pass(self, data): pass
+
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(results.testsRun, 4)
+        self.assertEqual(len(results.errors), 0)
+        self.assertEqual(len(results.failures), 0)
+
+    def test_for_job_type_with_multiple_test_methods(self):
+        self.unit_test_paths['some_job_type'] = {
+            'some_program': {
+                'some_version1': ('some_file1',),
+                'some_version2': ('some_file2',),
+            },
+        }
+        self.unit_test_paths['other_job_type'] = {
+            'some_program': {
+                'some_version2': ('some_file2',),
+                'some_version3': ('some_file3',),
+                'some_version4': ('some_file4',),
+            },
+        }
+        class FakeTestCase(utils.DataTestCase):
+            @utils.for_job_type('some_job_type')
+            def test_pass1(self, data): pass
+            @utils.for_job_type('some_job_type', 'other_job_type')
+            def test_pass2(self, data): pass
+
+        # We need to start "parsing" from scratch in order to make
+        # meaningful assertions about it below.
+        FakeTestCase._logfile_data_cache.clear()
+
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(results.testsRun, 7)
+        self.assertEqual(len(results.errors), 0)
+        self.assertEqual(len(results.failures), 0)
+
+        # There are five job-program-filename combinations in the paths
+        # dictionary, but the cache should eliminate one call to ccread,
+        # because only program-filename combos have different data.
+        self.assertEqual(self.mock_cclib.io.ccread.call_count, 4)
+
+    def test_for_program_without_for_job_type(self):
+        class FakeTestCase(utils.DataTestCase):
+            def runTest(self): pass
+            @utils.for_program('some_program')
+            def test_pass(self): pass
+        self.assertIn('_test_pass', dir(FakeTestCase))
+
+        # The test_pass method is wrapped and set, but it will error because
+        # there are no program-specific test methods and the for_program decorator
+        # only makes sense in that context.
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(test_suite.countTestCases(), 1)
+        self.assertEqual(results.testsRun, 1)
+        self.assertEqual(len(results.errors), 1)
+        self.assertIn('Use for_job_type decorator before for_program',
+                      results.errors[0][1])
+
+    def test_for_job_type_before_for_program(self):
+        with self.assertRaises(TypeError):
+            class FakeTestCase(utils.DataTestCase):
+                def runTest(self): pass
+                @utils.for_program('some_program')
+                @utils.for_job_type('some_job_type')
+                def test_pass(self): pass
+
+    def test_for_job_type_with_different_class(self):
+        class FakeTestCase(unittest.TestCase):
+            @utils.for_job_type('some_job_type')
+            def test_pass(self): pass
+
+        test_suite, results = load_and_run(FakeTestCase)
+        self.assertEqual(results.testsRun, 1)
+        self.assertEqual(len(results.errors), 1)
+        self.assertIn('method assumes it will be bound to a cclib DataTestCase',
+                      results.errors[0][1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_data_new.py
+++ b/test/test_data_new.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Run data tests for cclib."""
+
+import unittest
+
+from data.test_atomcoords import *
+from data.test_scfenergies import *
+from data.test_time import *
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/testdata
+++ b/test/testdata
@@ -56,11 +56,6 @@ Basis     Psi4        Psi4BigBasisTest      basicPsi4-1.0         C_bigbasis.out
 Basis     QChem       QChemBigBasisTest     basicQChem4.2         C_bigbasis.out
 Basis     QChem       QChemBigBasisTest     basicQChem5.1         C_bigbasis.out
 
-BOMD      Gaussian    GaussianBOMDTest      basicGaussian09       dvb_bomd.out
-BOMD      NWChem      GenericBOMDTest       basicNWChem6.6        dvb_bomd_ks.out
-BOMD      QChem       GenericBOMDTest       basicQChem4.2         dvb_bomd.out
-BOMD      QChem       GenericBOMDTest       basicQChem5.1         dvb_bomd.out
-
 CC        DALTON      GenericCCTest         basicDALTON-2013      water_ccsdt.out
 CC        DALTON      GenericCCTest         basicDALTON-2015      water_ccsdt.out
 CC        GAMESS      GenericCCTest         basicGAMESS-US2014    water_ccd.out


### PR DESCRIPTION
**(This is a proposal, please don't submit)**

So I had a go at #602 , at it wasn't too hard to implement. The result is kind of similar to what we have now in `test/test_data.py` just in decorators and encapsulated in a test case class. I like the idea of decorator syntax and relying more on the standard test framework.

Beyond the framework, I migrated the `BOMD` unit tests here, because it's only 4 files and 3 test method right now. This translates into three new test files, which can coexist with the current test system. Which means the migration could be incremental. Travis is currently failing due to relative imports I used.

Some cons I now observe:
- The logic in the decorator implementation is brittle, so it might be harder to maintain.
- Organizing tests by attributes seemed natural, until I actually tried it. There are certain bits that tie together the test methods in our current test modules. For `BOMD`, this is the number of energies/steps. Organizing by attribute disperses this across files for all the attributes being tested.
- This organization doesn't play well with our regression suite... which are all job-type focused.

The second and third points are most important IMO. I wonder if there is some middle ground where we could get the best of both worlds. Perhaps something that leverages attribute classes like we thought about for 2.x. Or maybe we should leave the current organization and just migrate to a decorator-based framework if you think it's an improvement.

Thoughts? I have some more ideas about how to change this, but want to first get your guys' general input.