### PR TITLE
ORCA: fix ROCIS parsing that changed from 4.0 to 4.1

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -909,7 +909,8 @@ States    Energy  Wavelength   fosc         T2         TX        TY        TZ
                     state, state2, energy, wavelength, intensity, t2, tx, ty, tz = line.split()
                     return energy, intensity
 
-            elif line[:79] == 'ROCIS COMBINED ELECTRIC DIPOLE + MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM':
+            elif line[:79] == 'ROCIS COMBINED ELECTRIC DIPOLE + MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM' \
+                 or line[:87] == 'SOC CORRECTED COMBINED ELECTRIC DIPOLE + MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM':
                 def energy_intensity(line):
                     """ ROCIS with DoQuad = True and SOC = True (also does origin adjusted)
 ------------------------------------------------------------------------------------------------------

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -960,9 +960,9 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
 
                 line = next(inputfile)
 
-            self.etenergies = numpy.array(etenergies)
-            self.etoscs = numpy.array(etoscs)
-            self.transprop[name] = (self.etenergies, self.etoscs)
+            self.set_attribute('etenergies', etenergies)
+            self.set_attribute('etoscs', etoscs)
+            self.transprop[name] = (numpy.asarray(etenergies), numpy.asarray(etoscs))
 
         if line.strip() == "CD SPECTRUM":
             # -------------------------------------------------------------------

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -160,11 +160,7 @@ class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
     expected_l_max = 2316970.8
-    # In ORCA 4.0, an additional spectrum ("COMBINED ELECTRIC DIPOLE +
-    # MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM (Origin Independent,
-    # Length Representation)") was present that is not in ORCA 4.1. This
-    # accounts for the difference in a version-independent way.
-    n_spectra = (8, 9)
+    n_spectra = 8
 
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""
@@ -173,7 +169,7 @@ class OrcaROCISTest(GenericTDTest):
 
     def testTransprop(self):
         """Check the number of spectra parsed"""
-        self.assertTrue(len(self.data.transprop) in self.n_spectra)
+        self.assertEqual(len(self.data.transprop), self.n_spectra)
         tddft_length = 'ABSORPTION SPECTRUM VIA TRANSITION ELECTRIC DIPOLE MOMENTS'
         self.assertIn(tddft_length, self.data.transprop)
 
@@ -194,7 +190,15 @@ class OrcaROCISTest(GenericTDTest):
         pass
 
 
-if __name__=="__main__":
+class OrcaROCIS40Test(OrcaROCISTest):
+    """Customized test for ROCIS"""
+    # In ORCA 4.0, an additional spectrum ("COMBINED ELECTRIC DIPOLE +
+    # MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM (Origin Independent,
+    # Length Representation)") was present that is not in ORCA 4.1.
+    n_spectra = 9
+
+
+if __name__ =="__main__":
 
     import sys
     sys.path.insert(1, os.path.join(__filedir__, ".."))

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -160,6 +160,10 @@ class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
     expected_l_max = 2316970.8
+    # In ORCA 4.0, an additional spectrum ("COMBINED ELECTRIC DIPOLE +
+    # MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM (Origin Independent,
+    # Length Representation)") was present that is not in ORCA 4.1. This
+    # accounts for the difference in a version-independent way.
     n_spectra = (8, 9)
 
     def testoscs(self):

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -160,7 +160,7 @@ class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
     expected_l_max = 2316970.8
-    n_spectra = 9
+    n_spectra = (8, 9)
 
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""
@@ -169,7 +169,7 @@ class OrcaROCISTest(GenericTDTest):
 
     def testTransprop(self):
         """Check the number of spectra parsed"""
-        self.assertEqual(len(self.data.transprop), self.n_spectra)
+        self.assertTrue(len(self.data.transprop) in self.n_spectra)
         tddft_length = 'ABSORPTION SPECTRUM VIA TRANSITION ELECTRIC DIPOLE MOMENTS'
         self.assertIn(tddft_length, self.data.transprop)
 

--- a/test/testdata
+++ b/test/testdata
@@ -287,7 +287,7 @@ TD        Gaussian    GaussianTDDFTTest     basicGaussian16       dvb_td.out
 TD        Jaguar      JaguarTDDFTTest       basicJaguar8.3        dvb_td.out
 TD        ORCA        OrcaTDDFTTest         basicORCA4.0          dvb_td.out
 TD        ORCA        OrcaTDDFTTest         basicORCA4.1          dvb_td.out
-TD        ORCA        OrcaROCISTest         basicORCA4.0          dvb_rocis.out
+TD        ORCA        OrcaROCIS40Test       basicORCA4.0          dvb_rocis.out
 TD        ORCA        OrcaROCISTest         basicORCA4.1          dvb_rocis.out
 TD        QChem       QChemTDDFTTest        basicQChem4.2         dvb_td.out
 TD        QChem       QChemTDDFTTest        basicQChem5.1         dvb_td.out


### PR DESCRIPTION
Fixes for the ORCA ROCIS issues exposed by https://github.com/cclib/cclib/pull/743. The fix for the second problem (there is a missing excitation section) is not ideal.