### PR TITLE
Adding a bridge module to Psi4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,33 @@ addons:
         - swig
 cache:
   pip: true
+  directories:
+    - $HOME/miniconda
 
 before_install:
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu cosmic universe"
   - sudo apt update
   - sudo apt install libopenbabel-dev
-  - pip install -r requirements.txt
+
+  - |
+    if [[ $(echo "$TRAVIS_PYTHON_VERSION >= 3.6" | bc -l) == 1 ]];
+    then
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda -u
+        export PATH="$HOME/miniconda/bin:$PATH"
+
+        hash -r
+        conda config --set always_yes yes --set changeps1 no
+        conda update -q conda
+        conda info -a
+        conda create -q -n p4env python=$TRAVIS_PYTHON_VERSION ci-psi4 psi4 numpy matplotlib jupyter scipy -c psi4/label/dev -c defaults -c conda-forge
+
+        source activate p4env
+        conda install pytest pytest-cov codecov -c conda-forge
+        pip install pytest-shutil
+        conda list
+    fi
+    pip install -r requirements.txt
 
 install:
   - pip install .
@@ -36,7 +57,7 @@ script:
 
 after_success:
   - |
-    if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_PULL_REQUEST}" == false && $TRAVIS_PYTHON_VERSION == 3.7 ]];
+    if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_PULL_REQUEST}" == false && $(echo "$TRAVIS_PYTHON_VERSION == 3.7" | bc -l) == 1 ]];
     then
         # Commits to master that are not pull requests, that is, only actual
         # addition of code to master, should deploy the documentation.

--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -18,5 +18,8 @@ if find_package("openbabel"):
 if find_package("PyQuante"):
     from cclib.bridge.cclib2pyquante import makepyquante
 
+if find_package("psi4"):
+    from cclib.bridge.cclib2psi4 import makepsi4
+
 
 del find_package

--- a/cclib/bridge/cclib2psi4.py
+++ b/cclib/bridge/cclib2psi4.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Bridge for using cclib data in Psi4 (http://www.psicode.org/)."""
+
+from cclib.parser.utils import find_package
+
+_found_psi4 = find_package("psi4")
+if _found_psi4:
+    from psi4.core import Molecule
+
+
+def _check_psi4(found_psi4):
+    if not found_psi4:
+        raise ImportError("You must install `psi4` to use this function")
+
+
+def makepsi4(atomcoords, atomnos, charge=0, mult=1):
+    """Create a Psi4 Molecule."""
+    _check_psi4(_found_psi4)
+    return Molecule.from_arrays(
+        name="notitle",
+        elez=atomnos,
+        geom=atomcoords,
+        units="Angstrom",
+        molecular_charge=charge,
+        molecular_multiplicity=mult,
+    )
+
+
+del find_package

--- a/test/bridge/testpsi4.py
+++ b/test/bridge/testpsi4.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+import unittest
+
+import numpy as np
+
+from cclib.bridge import cclib2psi4
+
+
+class Psi4Test(unittest.TestCase):
+    """Tests for the cclib2psi4 bridge in cclib."""
+
+    def test_makepsi4(self):
+        import psi4
+        from psi4 import energy
+
+        psi4.core.set_output_file("psi4_output.dat", False)
+
+        atomnos = np.array([1, 8, 1], "i")
+        a = np.array([[-1, 1, 0], [0, 0, 0], [1, 1, 0]], "f")
+        psi4mol = cclib2psi4.makepsi4(a, atomnos)
+        en = energy("scf/6-31G**", molecule=psi4mol)
+        ref = -75.82474605514503
+        assert abs(en - ref) < 1.0e-6
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -12,9 +12,13 @@ import unittest
 
 sys.path.insert(1, "bridge")
 
-if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
-    from .bridge.testbiopython import *
+if sys.version_info[0] == 3:
+    if sys.version_info[1] >= 6:
+        from .bridge.testpsi4 import *
+    if sys.version_info[1] >= 4:
+        from .bridge.testbiopython import *
 from .bridge.testopenbabel import *
+
 if sys.version_info[0] == 2:
     from .bridge.testpyquante import *
 


### PR DESCRIPTION
This adds a simple bridge to the Python API of [Psi4](http://psicode.org/) [[1]](http://www.psicode.org/psi4manual/1.2/psiapi.html) [[2]](https://github.com/psi4/psi4numpy). I tried to follow the [PyQuante bridge](https://github.com/cclib/cclib/blob/428b4cf07dfd91a6b28c49c63d93ddc0175b5cf2/cclib/bridge/cclib2pyquante.py) as closely as possible.

This allows one to do things like:

```python3
import psi4
from cclib import ccopen
from cclib.bridge import makepsi4

data = ccopen("acetic_acid.out").parse()
psi4mol = makepsi4(data.atomcoords[-1], data.atomnos, data.charge, data.mult)
energy = psi4.energy("mp2/cc-pvdz", molecule=psi4mol)
print(energy)  # -228.48044415212507
```