### PR TITLE
Make Logfile base class abstract

### DIFF
--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -17,6 +17,8 @@ import os
 import random
 import sys
 import zipfile
+from abc import ABCMeta, abstractmethod
+from six import add_metaclass
 
 if sys.version_info.major == 2:
     getargspec = inspect.getargspec
@@ -182,6 +184,7 @@ def openlogfile(filename, object=None):
         return fileobject
 
 
+@add_metaclass(ABCMeta)
 class Logfile(object):
     """Abstract class for logfile objects.
 
@@ -398,14 +401,9 @@ class Logfile(object):
                 self.progress.update(newstep, msg)
                 self.progress.step = newstep
 
+    @abstractmethod
     def normalisesym(self, symlabel):
-        """Standardise the symmetry labels between parsers.
-
-        This method should be overwritten by individual parsers, and should
-        contain appropriate doctests. If is not overwritten, this is detected
-        as an error by unit tests.
-        """
-        raise NotImplementedError("normalisesym(self, symlabel) must be overriden by the parser.")
+        """Standardise the symmetry labels between parsers."""
 
     def float(self, number):
         """Convert a string to a float.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -405,7 +405,8 @@ class Logfile(object):
     def normalisesym(self, symlabel):
         """Standardise the symmetry labels between parsers."""
 
-    def float(self, number):
+    @staticmethod
+    def float(number):
         """Convert a string to a float.
 
         This method should perform certain checks that are specific to cclib,

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -35,8 +35,12 @@ class Molcas(logfileparser.Logfile):
         return 'Molcas("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """TODO Does Molcas require symmetry label normalization?"""
-        return label
+        """Normalise the symmetries used by Molcas.
+
+        The labels are standardized except for the first character being
+        lowercase.
+        """
+        return label[0].upper() + label[1:]
 
     def after_parsing(self):
         for element, ncore in self.core_array:

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -34,9 +34,9 @@ class Molcas(logfileparser.Logfile):
         """Return a representation of the object."""
         return 'Molcas("%s")' % (self.filename)
 
-    #These are yet to be implemented.
     def normalisesym(self, label):
-        """Does Molcas require symmetry label normalization?"""
+        """TODO Does Molcas require symmetry label normalization?"""
+        return label
 
     def after_parsing(self):
         for element, ncore in self.core_array:

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -37,8 +37,7 @@ class Molcas(logfileparser.Logfile):
     def normalisesym(self, label):
         """Normalise the symmetries used by Molcas.
 
-        The labels are standardized except for the first character being
-        lowercase.
+        The labels are standardized except for the first character being lowercase.
         """
         return label[0].upper() + label[1:]
 

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -50,9 +50,11 @@ class Psi4(logfileparser.Logfile):
                 self.set_attribute('natom', len(self.atomnos))
 
     def normalisesym(self, label):
-        """Psi4 does not require normalizing symmetry labels.
+        """Use standard symmetry labels instead of Psi4 labels.
 
-        Only the Cs group (A prime and A double prime) need modification.
+        To normalise:
+        (1) `App` -> `A"`
+        (2) `Ap` -> `A'`
         """
         return label.replace("pp", '"').replace("p", "'")
 

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -50,8 +50,11 @@ class Psi4(logfileparser.Logfile):
                 self.set_attribute('natom', len(self.atomnos))
 
     def normalisesym(self, label):
-        """Psi4 does not require normalizing symmetry labels."""
-        return label
+        """Psi4 does not require normalizing symmetry labels.
+
+        Only the Cs group (A prime and A double prime) need modification.
+        """
+        return label.replace("pp", '"').replace("p", "'")
 
     # Match the number of skipped lines required based on the type of
     # gradient present (determined from the header), as otherwise the

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -62,8 +62,7 @@ class Turbomole(logfileparser.Logfile):
     def normalisesym(self, label):
         """Normalise the symmetries used by Turbomole.
 
-        The labels are standardized except for the first character being
-        lowercase.
+        The labels are standardized except for the first character being lowercase.
         """
         # TODO more work could be required, but we don't have any logfiles
         # with non-C1 symmetry.

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -60,8 +60,14 @@ class Turbomole(logfileparser.Logfile):
         return 'Turbomole("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """TODO Normalise the symmetries used by Turbomole."""
-        return label
+        """Normalise the symmetries used by Turbomole.
+
+        The labels are standardized except for the first character being
+        lowercase.
+        """
+        # TODO more work could be required, but we don't have any logfiles
+        # with non-C1 symmetry.
+        return label[0].upper() + label[1:]
 
     def before_parsing(self):
         self.geoopt = False # Is this a GeoOpt? Needed for SCF targets/values.

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -60,8 +60,8 @@ class Turbomole(logfileparser.Logfile):
         return 'Turbomole("%s")' % (self.filename)
 
     def normalisesym(self, label):
-        """Normalise the symmetries used by Turbomole."""
-        raise NotImplementedError('Now yet implemented for Turbomole.')
+        """TODO Normalise the symmetries used by Turbomole."""
+        return label
 
     def before_parsing(self):
         self.geoopt = False # Is this a GeoOpt? Needed for SCF targets/values.

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -400,7 +400,7 @@ The symmetry labels are normalised and cclib reports standard symmetry names:
 Developers:
 
 * The tests for these functions live in ``test/parser/testspecficparser.py``.
-* The character tables `here <http://www.mpip-mainz.mpg.de/~gelessus/group.html>`_ may be useful in determining the correspondence between the labels used by the comp chem package and the commonly-used symbols.
+* The character tables `here <http://symmetry.jacobs-university.de/>`_ may be useful in determining the correspondence between the labels used by the comp chem package and the commonly-used symbols.
 
 .. index::
     single: energy; mpenergies (attribute)

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -399,7 +399,7 @@ The symmetry labels are normalised and cclib reports standard symmetry names:
 
 Developers:
 
-* The use of a function with doctests for each of these cases is recommended, to make sure that the conversion is robust. There is a prototype called normalisesym() in logfileparser.py which should be overwritten in the subclasses if necessary (there is a unittest to make sure that this has been done).
+* The tests for these functions live in ``test/parser/testspecficparser.py``.
 * The character tables `here <http://www.mpip-mainz.mpg.de/~gelessus/group.html>`_ may be useful in determining the correspondence between the labels used by the comp chem package and the commonly-used symbols.
 
 .. index::

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -392,9 +392,9 @@ The symmetry labels are normalised and cclib reports standard symmetry names:
     sigma.g Sigma.g                     SGG
     ======= ======= ======= ==========  ==================          ======
 
-* ADF - the full list can be found [http://www.scm.com/Doc/Doc2005.01/ADF/ADFUsersGuide/page339.html here].
-* GAMESS-UK - to get the list, 'grep "data yr" input.m' if you have access to the source. Note that for E, it's split into "e1+" and "e1-" for instance.
-* Jaguar - to get the list, look at the examples in schrodinger/jaguar-whatever/samples if you have access to Jaguar. Note that for E, it's written as E1pp/Ap, for instance.
+* ADF - the full list can be found `here http://www.scm.com/Doc/Doc2005.01/ADF/ADFUsersGuide/page339.html`_.
+* GAMESS-UK - to get the list, ``grep "data yr" input.m`` if you have access to the source. Note that for E, it's split into "e1+" and "e1-" for instance.
+* Jaguar - to get the list, look at the examples in ``schrodinger/jaguar-whatever/samples`` if you have access to Jaguar. Note that for E, it's written as E1pp/Ap, for instance.
 * NWChem - if molecular symmetry is turned off or set to C1, symmetry adaption for orbitals is also deactivated, and can be explicitly turned on with `adapt on` in the SCF block
 
 Developers:

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -128,13 +128,6 @@ class GenericSPTest(unittest.TestCase):
         numpy.testing.assert_array_equal(self.data.coreelectrons, ans)
 
     @skipForParser('Molcas','The parser is still being developed so we skip this test')
-    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
-    def testnormalisesym(self):
-        """Did this subclass overwrite normalisesym?"""
-        # https://stackoverflow.com/a/8747890
-        self.logfile.normalisesym("A")
-
-    @skipForParser('Molcas','The parser is still being developed so we skip this test')
     @skipForParser('Molpro', '?')
     @skipForParser('ORCA', 'ORCA has no support for symmetry yet')
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -93,27 +93,22 @@ class LogfileTest(unittest.TestCase):
 
     def test_float_basic(self):
         """Are floats converted from strings correctly?"""
-        float = cclib.parser.logfileparser.Logfile('').float
+        float = cclib.parser.logfileparser.Logfile.float
         self.assertEqual(float("0.0"), 0.0)
         self.assertEqual(float("1.0"), 1.0)
         self.assertEqual(float("-1.0"), -1.0)
 
     def test_float_numeric_format(self):
         """Does numeric formatting get converted correctly?"""
-        float = cclib.parser.logfileparser.Logfile('').float
+        float = cclib.parser.logfileparser.Logfile.float
         self.assertEqual(float("1.2345E+02"), 123.45)
         self.assertEqual(float("1.2345D+02"), 123.45)
 
     def test_float_stars(self):
         """Does the function return nan for stars?"""
-        float = cclib.parser.logfileparser.Logfile('').float
+        float = cclib.parser.logfileparser.Logfile.float
         self.assertTrue(numpy.isnan(float("*")))
         self.assertTrue(numpy.isnan(float("*****")))
-
-    def test_normalisesym_base_class_error(self):
-        """Does this method raise an error in the base class?"""
-        normalisesym = cclib.parser.logfileparser.Logfile('').normalisesym
-        self.assertRaises(NotImplementedError, normalisesym, 'Ag')
 
     def test_parse_check_values(self):
         """Are custom checks performed after parsing finishes?
@@ -123,7 +118,9 @@ class LogfileTest(unittest.TestCase):
         for the data class should have comprehensive coverage.
         """
         _, path = tempfile.mkstemp()
-        parser = cclib.parser.logfileparser.Logfile(path)
+        logfileclass = cclib.parser.logfileparser.Logfile
+        logfileclass.__abstractmethods__ = set()
+        parser = logfileclass(path)
         parser.extract = lambda self, inputfile, line: None
         parser.logger = mock.Mock()
 

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -56,6 +56,13 @@ class NormalisesymTest(unittest.TestCase):
         ref = ["A'", "A''"]
         self.assertEqual(list(map(sym, labels)), ref)
 
+    def test_normalisesym_turbomole(self):
+        from cclib.parser.turbomoleparser import Turbomole
+        sym = Turbomole("dummyfile").normalisesym
+        labels = ["a", "a1", "ag"]
+        ref = ["A", "A1", "Ag"]
+        self.assertEqual(list(map(sym, labels)), ref)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -49,6 +49,13 @@ class NormalisesymTest(unittest.TestCase):
         ref = ['A', 'A1', 'Ag', "A'", 'A"', "A1'", 'A1"', 'E1"']
         self.assertEqual(list(map(sym, labels)), ref)
 
+    def test_normalisesym_molcas(self):
+        from cclib.parser.molcasparser import Molcas
+        sym = Molcas("dummyfile").normalisesym
+        labels = ["a", "a1", "ag"]
+        ref = ["A", "A1", "Ag"]
+        self.assertEqual(list(map(sym, labels)), ref)
+
     def test_normalisesym_molpro(self):
         from cclib.parser.molproparser import Molpro
         sym = Molpro("dummyfile").normalisesym

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -12,7 +12,7 @@ import unittest
 
 class NormalisesymTest(unittest.TestCase):
 
-    # Not needed: DALTON, MOPAC, NWChem, ORCA, Psi, QChem
+    # Not needed: DALTON, MOPAC, NWChem, ORCA, QChem
 
     def test_normalisesym_adf(self):
         from cclib.parser.adfparser import ADF
@@ -63,13 +63,19 @@ class NormalisesymTest(unittest.TestCase):
         ref = ["A'", "A''"]
         self.assertEqual(list(map(sym, labels)), ref)
 
+    def test_normalisesym_psi4(self):
+        from cclib.parser.psi4parser import Psi4
+        sym = Psi4("dummyfile").normalisesym
+        labels = ["Ap", "App"]
+        ref = ["A'", 'A"']
+        self.assertEqual(list(map(sym, labels)), ref)
+
     def test_normalisesym_turbomole(self):
         from cclib.parser.turbomoleparser import Turbomole
         sym = Turbomole("dummyfile").normalisesym
         labels = ["a", "a1", "ag"]
         ref = ["A", "A1", "Ag"]
         self.assertEqual(list(map(sym, labels)), ref)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The cleanest way of enforcing that `normalisesym` is implemented for each parser is to make it an abstract method on `Logfile`. It also removes the need for testing to make sure it's implemented.

- We are no longer using doctests, so all references to using them were removed.
- Implements `normalisesym` for Molcas, Psi4, and Turbomole.