### PR TITLE
Fixing bug where Mulliken charges weren't getting parsed in Gaus…

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1702,7 +1702,8 @@ class Gaussian(logfileparser.Logfile):
         # ...
         #
         if line[1:25] == "Mulliken atomic charges:" or line[1:18] == "Mulliken charges:" or \
-           line[1:23] == "Lowdin Atomic Charges:" or line[1:16] == "Lowdin charges:":
+           line[1:23] == "Lowdin Atomic Charges:" or line[1:16] == "Lowdin charges:" or \
+           line[1:37] == "Mulliken charges and spin densities:":
 
             if not hasattr(self, "atomcharges"):
                 self.atomcharges = {}

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -183,8 +183,15 @@ class GaussianSPunTest(GenericSPunTest):
         """Does atomnos have the right dimension (20)?"""
         size = len(self.data.atomnos)
         self.assertEqual(size, 20)
+    
+    def testatomcharges(self):
+        """Are atomcharges (at least Mulliken) consistent with natom and sum to one?"""
+        for type in set(['mulliken'] + list(self.data.atomcharges.keys())):
+            charges = self.data.atomcharges[type]
+            self.assertEqual(len(charges), self.data.natom)
+            self.assertAlmostEqual(sum(charges), 1.0, delta=0.001)
 
-
+            
 class JaguarSPunTest(GenericSPunTest):
     """Customized unrestricted single point unittest"""
 


### PR DESCRIPTION
Hello!

I was using CCLIB to parse Gaussian16 files and I was having some trouble parsing the Mulliken charges. When I looked at the `cclib/parser/gaussianparser.py` I found the none of the string fragments that triggered the parsing of Mulliken data matched what I saw in my log files. 

More explicitly the string that indicates the start of Mulliken output in my log files is "Mulliken charges and spin densities:". Given the notes, in the current, version of `gaussianparser.py` i.e.:

https://github.com/cclib/cclib/blob/24f508625468a338cfcbf5eb26f0e0e4bd617b21/cclib/parser/gaussianparser.py#L1689

It seems like this change is the header isn't unexpected. So I've updated the `if` statement that triggers the parsing of Mulliken data to include this new header. Please let me know if there are other things I should do for this PR!

Best,
James