### PR TITLE
Change PeriodicTable class to use periodictable library (#604)

### DIFF
--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -164,8 +164,9 @@ class PeriodicTable(object):
         self.number = {}
         
         for e in periodictable.elements:
-            self.element.append(e.symbol)
-            self.number[e.symbol] = e.number
+            if e.symbol != 'n':
+                self.element.append(e.symbol)
+                self.number[e.symbol] = e.number
 
 
 class WidthSplitter:

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -155,6 +155,7 @@ def convertor(value, fromunits, tounits):
 
     return _convertor["%s_to_%s" % (fromunits, tounits)](value)
 
+
 class PeriodicTable(object):
     """Allows conversion between element name and atomic no."""
 
@@ -165,6 +166,7 @@ class PeriodicTable(object):
         for e in periodictable.elements:
             self.element.append(e.symbol)
             self.number[e.symbol] = e.number
+
 
 class WidthSplitter:
     """Split a line based not on a character, but a given number of field

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -9,6 +9,7 @@
 
 import sys
 import numpy
+import periodictable
 
 
 # See https://github.com/kachayev/fn.py/commit/391824c43fb388e0eca94e568ff62cc35b543ecb
@@ -154,36 +155,16 @@ def convertor(value, fromunits, tounits):
 
     return _convertor["%s_to_%s" % (fromunits, tounits)](value)
 
-
 class PeriodicTable(object):
     """Allows conversion between element name and atomic no."""
 
     def __init__(self):
-        self.element = [
-            None,
-            'H', 'He',
-            'Li', 'Be',
-            'B', 'C', 'N', 'O', 'F', 'Ne',
-            'Na', 'Mg',
-            'Al', 'Si', 'P', 'S', 'Cl', 'Ar',
-            'K', 'Ca',
-            'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn',
-            'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr',
-            'Rb', 'Sr',
-            'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd',
-            'In', 'Sn', 'Sb', 'Te', 'I', 'Xe',
-            'Cs', 'Ba',
-            'La', 'Ce', 'Pr', 'Nd', 'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb',
-            'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg',
-            'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn',
-            'Fr', 'Ra',
-            'Ac', 'Th', 'Pa', 'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 'No',
-            'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 'Cn',
-            'Uut', 'Fl', 'Uup', 'Lv', 'Uus', 'Uuo']
+        self.element = [None]
         self.number = {}
-        for i in range(1, len(self.element)):
-            self.number[self.element[i]] = i
-
+        
+        for e in periodictable.elements:
+            self.element.append(e.symbol)
+            self.number[e.symbol] = e.number
 
 class WidthSplitter:
     """Split a line based not on a character, but a given number of field

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ def setup_cclib():
         install_requires=[
             "packaging>=19.0",
             "numpy",
+            "periodictable",
             "six",
         ],
 

--- a/test/parser/testutils.py
+++ b/test/parser/testutils.py
@@ -50,6 +50,7 @@ class PeriodicTableTest(unittest.TestCase):
         """Does the periodic table give correct elements?"""
         self.assertEqual(self.pt.element[6], 'C')
         self.assertEqual(self.pt.element[44], 'Ru')
+        self.assertIsNone(self.pt.element[0])
 
     def test_elements(self):
         """Does the periodic table give correct atom numbers?"""


### PR DESCRIPTION
Change parser.utils.PeriodicTable class to use periodictable library, as per #604. The interface for the class remains unchanged.