### PR TITLE
Fix duplicate method name in testutils.py, fixes #773

### DIFF
--- a/test/parser/testutils.py
+++ b/test/parser/testutils.py
@@ -51,7 +51,7 @@ class PeriodicTableTest(unittest.TestCase):
         self.assertEqual(self.pt.element[6], 'C')
         self.assertEqual(self.pt.element[44], 'Ru')
 
-    def test_elements(self):
+    def test_numbers(self):
         """Does the periodic table give correct atom numbers?"""
         self.assertEqual(self.pt.number['C'], 6)
         self.assertEqual(self.pt.number['Au'], 79)


### PR DESCRIPTION
Rename duplicate test method `test_elements` to `test_numbers`, because it tests atomic numbers in PeriodicTable.

Fixes #773