### PR TITLE
adding parser for gaussian mulliken atom spins

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1762,19 +1762,29 @@ class Gaussian(logfileparser.Logfile):
            line[1:23] == "Lowdin Atomic Charges:" or line[1:16] == "Lowdin charges:" or \
            line[1:37] == "Mulliken charges and spin densities:":
 
+            has_spin = 'spin densities' in line 
+
             if not hasattr(self, "atomcharges"):
                 self.atomcharges = {}
+
+            if has_spin and not hasattr(self, "atomspins"):
+                self.atomspins = {}
 
             ones = next(inputfile)
 
             charges = []
+            spins = []
             nline = next(inputfile)
             while not "Sum of" in nline:
                 charges.append(float(nline.split()[2]))
+                if has_spin:
+                    spins.append(float(nline.split()[3]))
                 nline = next(inputfile)
 
             if "Mulliken" in line:
                 self.atomcharges["mulliken"] = charges
+                self.atomspins["mulliken"] = spins
+
             else:
                 self.atomcharges["lowdin"] = charges
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1783,7 +1783,8 @@ class Gaussian(logfileparser.Logfile):
 
             if "Mulliken" in line:
                 self.atomcharges["mulliken"] = charges
-                self.atomspins["mulliken"] = spins
+                if has_spin:
+                    self.atomspins["mulliken"] = spins
 
             else:
                 self.atomcharges["lowdin"] = charges

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1760,11 +1760,13 @@ class Gaussian(logfileparser.Logfile):
         #
         if line[1:25] == "Mulliken atomic charges:" or line[1:18] == "Mulliken charges:" or \
            line[1:23] == "Lowdin Atomic Charges:" or line[1:16] == "Lowdin charges:" or \
-           line[1:37] == "Mulliken charges and spin densities:":
+           line[1:37] == "Mulliken charges and spin densities:" or \
+           line[1:32] == "Mulliken atomic spin densities:":
 
             has_spin = 'spin densities' in line 
+            has_charges = 'charges' in line 
 
-            if not hasattr(self, "atomcharges"):
+            if has_charges and not hasattr(self, "atomcharges"):
                 self.atomcharges = {}
 
             if has_spin and not hasattr(self, "atomspins"):
@@ -1776,36 +1778,25 @@ class Gaussian(logfileparser.Logfile):
             spins = []
             nline = next(inputfile)
             while not "Sum of" in nline:
-                charges.append(float(nline.split()[2]))
-                if has_spin:
+                if has_charges:
+                    charges.append(float(nline.split()[2]))
+
+                if has_spin and has_charges:
                     spins.append(float(nline.split()[3]))
+
+                if has_spin and not has_charges:
+                    spins.append(float(nline.split()[2]))
+
                 nline = next(inputfile)
 
             if "Mulliken" in line:
-                self.atomcharges["mulliken"] = charges
+                if has_charges:
+                    self.atomcharges["mulliken"] = charges
                 if has_spin:
                     self.atomspins["mulliken"] = spins
 
-            else:
+            elif "Lowdin" in line:
                 self.atomcharges["lowdin"] = charges
-
-        #  Mulliken atomic spin densities:
-        #               1
-        #      1  C    0.213023
-        #      2  C    0.025415
-        #      3  C    0.019730
-        #      4  C    0.213023
-        if line[1:32] == "Mulliken atomic spin densities:":
-            if not hasattr(self, "atomspins"):
-                self.atomspins = {}
-
-            spins = []
-            nline = next(inputfile)
-            while not "Sum of" in nline:
-                spins.append(float(nline.split()[2]))
-                nline = next(inputfile)
-                    
-            self.atomspins["mulliken"] = spins
 
 
         if line.strip() == "Natural Population":

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1795,7 +1795,7 @@ class Gaussian(logfileparser.Logfile):
         #      2  C    0.025415
         #      3  C    0.019730
         #      4  C    0.213023
-        if "Mulliken atomic spin densities:" in line:
+        if line[1:32] == "Mulliken atomic spin densities:":
             if not hasattr(self, "atomspins"):
                 self.atomspins = {}
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1789,6 +1789,25 @@ class Gaussian(logfileparser.Logfile):
             else:
                 self.atomcharges["lowdin"] = charges
 
+        #  Mulliken atomic spin densities:
+        #               1
+        #      1  C    0.213023
+        #      2  C    0.025415
+        #      3  C    0.019730
+        #      4  C    0.213023
+        if "Mulliken atomic spin densities:" in line:
+            if not hasattr(self, "atomspins"):
+                self.atomspins = {}
+
+            spins = []
+            nline = next(inputfile)
+            while not "Sum of" in nline:
+                spins.append(float(nline.split()[2]))
+                nline = next(inputfile)
+                    
+            self.atomspins["mulliken"] = spins
+
+
         if line.strip() == "Natural Population":
             if not hasattr(self, 'atomcharges'):
                 self.atomcharges = {}

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -186,10 +186,15 @@ class GaussianSPunTest(GenericSPunTest):
     
     def testatomcharges(self):
         """Are atomcharges (at least Mulliken) consistent with natom and sum to one?"""
-        for type in set(['mulliken'] + list(self.data.atomcharges.keys())):
-            charges = self.data.atomcharges[type]
+        for type_ in set(['mulliken'] + list(self.data.atomcharges.keys())):
+            charges = self.data.atomcharges[type_]
             self.assertEqual(len(charges), self.data.natom)
             self.assertAlmostEqual(sum(charges), 1.0, delta=0.001)
+
+    def testatomspins(self):
+        spins = self.data.atomspins['mulliken']
+        self.assertEqual(len(spins), self.data.natom)
+        self.assertAlmostEqual(sum(spins), 1.0, delta=0.001)
 
             
 class JaguarSPunTest(GenericSPunTest):


### PR DESCRIPTION
Adds a couple lines to enable parsing of mulliken atom spins from a gaussian log file. These look like this
```
 Mulliken charges and spin densities:
               1          2
     1  C   -0.387596   1.060148
     2  C   -0.200858  -0.093393
     3  C   -0.336819   0.029550
     4  C    0.349212  -0.000550
     5  O   -0.322174   0.002229
     6  O   -0.410581  -0.000111
     7  H    0.163961  -0.038402
     8  H    0.163228  -0.036199
     9  H    0.151451   0.022440
    10  H    0.157424   0.058876
    11  H    0.166521  -0.001892
    12  H    0.171347  -0.003006
    13  H    0.334883   0.000311
 Sum of Mulliken charges =  -0.00000   1.00000
```