### PR TITLE
Bump travis python version so biopython can install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 2.7
-  - 3.4
+  - 3.5
   - 3.7
 addons:
     apt:

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -105,7 +105,10 @@ class LogfileTest(unittest.TestCase):
 
         parser.etenergies = [1, -1]
         parser.parse()
-        parser.logger.error.assert_called_once()
+        try:
+            parser.logger.error.assert_called_once()
+        except AttributeError: # assert_called_once is not availible until python 3.6
+            self.assertEqual(parser.logger.error.call_count, 1, "Expected mock to have been called once. Called {} times.".format(parser.logger.error.call_count))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Travis was failing on 3.4 because biopython needs 3.5 or later. 