### PR TITLE
Fixing problem with units on moment of inertia tensor

### DIFF
--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -66,7 +66,7 @@ class Nuclear(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
-        self.required_attrs = ("natom", "atomcoords", "atomnos", "charge")
+        self.required_attrs = ('natom','atomcoords','atomnos','charge')
 
         super(Nuclear, self).__init__(data, progress, loglevel, logname)
 
@@ -86,16 +86,16 @@ class Nuclear(Method):
 
         formula = ""
         elcount = lambda el, c: "%s%i" % (el, c) if c > 1 else el
-        if "C" in elements:
-            formula += elcount("C", counts["C"])
-            counts.pop("C")
-            if "H" in elements:
-                formula += elcount("H", counts["H"])
-                counts.pop("H")
+        if 'C' in elements:
+            formula += elcount('C', counts['C'])
+            counts.pop('C')
+            if 'H' in elements:
+              formula += elcount('H', counts['H'])
+              counts.pop('H')
         for el, c in sorted(counts.items()):
             formula += elcount(el, c)
 
-        if getattr(self.data, "charge", 0):
+        if getattr(self.data, 'charge', 0):
             magnitude = abs(self.data.charge)
             sign = "+" if self.data.charge > 0 else "-"
             formula += "(%s%i)" % (sign, magnitude)
@@ -107,11 +107,11 @@ class Nuclear(Method):
         for i in range(self.data.natom):
             ri = self.data.atomcoords[atomcoords_index][i]
             zi = self.data.atomnos[i]
-            for j in range(i + 1, self.data.natom):
+            for j in range(i+1, self.data.natom):
                 rj = self.data.atomcoords[0][j]
                 zj = self.data.atomnos[j]
-                d = np.linalg.norm(ri - rj)
-                nre += zi * zj / d
+                d = np.linalg.norm(ri-rj)
+                nre += zi*zj/d
         return nre
 
     def center_of_mass(self, atomcoords_index=-1):
@@ -134,9 +134,9 @@ class Nuclear(Method):
 
         moi_tensor = np.empty((3, 3))
 
-        moi_tensor[0][0] = np.sum(masses * (coords[:, 1] ** 2 + coords[:, 2] ** 2))
-        moi_tensor[1][1] = np.sum(masses * (coords[:, 0] ** 2 + coords[:, 2] ** 2))
-        moi_tensor[2][2] = np.sum(masses * (coords[:, 0] ** 2 + coords[:, 1] ** 2))
+        moi_tensor[0][0] = np.sum(masses * (coords[:, 1]**2 + coords[:, 2]**2))
+        moi_tensor[1][1] = np.sum(masses * (coords[:, 0]**2 + coords[:, 2]**2))
+        moi_tensor[2][2] = np.sum(masses * (coords[:, 0]**2 + coords[:, 1]**2))
 
         moi_tensor[0][1] = np.sum(masses * coords[:, 0] * coords[:, 1])
         moi_tensor[0][2] = np.sum(masses * coords[:, 0] * coords[:, 2])
@@ -148,46 +148,46 @@ class Nuclear(Method):
 
         return moi_tensor
 
-    def principal_moments_of_inertia(self, units="amu_bohr_2"):
+    def principal_moments_of_inertia(self, units='amu_bohr_2'):
         """Return the principal moments of inertia in 3 kinds of units:
         1. [amu][bohr]^2
         2. [amu][angstrom]^2
         3. [g][cm]^2
         and the principal axes.
         """
-        choices = ("amu_bohr_2", "amu_angstrom_2", "g_cm_2")
+        choices = ('amu_bohr_2', 'amu_angstrom_2', 'g_cm_2')
         units = units.lower()
         if units not in choices:
             raise ValueError("Invalid units, pick one of {}".format(choices))
         moi_tensor = self.moment_of_inertia_tensor()
         principal_moments, principal_axes = np.linalg.eigh(moi_tensor)
-        if units == "amu_bohr_2":
-            _check_scipy(_found_scipy)
-            bohr2ang = spc.value("atomic unit of length") / spc.angstrom
-            conv = 1 / bohr2ang ** 2
-        if units == "amu_angstrom_2":
+        if units == 'amu_bohr_2':
             conv = 1
-        if units == "g_cm_2":
+        if units == 'amu_angstrom_2':
             _check_scipy(_found_scipy)
-            amu2g = spc.value("unified atomic mass unit") * spc.kilo
-            conv = amu2g * (spc.angstrom / spc.centi) ** 2
+            bohr2ang = spc.value('atomic unit of length') / spc.angstrom
+            conv = bohr2ang ** 2
+        if units == 'g_cm_2':
+            _check_scipy(_found_scipy)
+            amu2g = spc.value('unified atomic mass unit') * spc.kilo
+            conv = amu2g * (spc.value('atomic unit of length') * spc.centi) ** 2
         return conv * principal_moments, principal_axes
 
-    def rotational_constants(self, units="ghz"):
+    def rotational_constants(self, units='ghz'):
         """Compute the rotational constants in 1/cm or GHz."""
-        choices = ("invcm", "ghz")
+        choices = ('invcm', 'ghz')
         units = units.lower()
         if units not in choices:
             raise ValueError("Invalid units, pick one of {}".format(choices))
         principal_moments = self.principal_moments_of_inertia()[0]
         _check_scipy(_found_scipy)
-        bohr2ang = spc.value("atomic unit of length") / spc.angstrom
-        xfamu = 1 / spc.value("electron mass in u")
-        xthz = spc.value("hartree-hertz relationship")
+        bohr2ang = spc.value('atomic unit of length') / spc.angstrom
+        xfamu = 1 / spc.value('electron mass in u')
+        xthz = spc.value('hartree-hertz relationship')
         rotghz = xthz * (bohr2ang ** 2) / (2 * xfamu * spc.giga)
-        if units == "ghz":
+        if units == 'ghz':
             conv = rotghz
-        if units == "invcm":
+        if units == 'invcm':
             ghz2invcm = spc.giga * spc.centi / spc.c
             conv = rotghz * ghz2invcm
         return conv / principal_moments

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -161,16 +161,16 @@ class Nuclear(Method):
             raise ValueError("Invalid units, pick one of {}".format(choices))
         moi_tensor = self.moment_of_inertia_tensor()
         principal_moments, principal_axes = np.linalg.eigh(moi_tensor)
-        if units == 'amu_bohr_2':
+        if units == "amu_bohr_2":
+            _check_scipy(_found_scipy)
+            bohr2ang = spc.value("atomic unit of length") / spc.angstrom
+            conv = 1 / bohr2ang ** 2
+        if units == "amu_angstrom_2":
             conv = 1
-        if units == 'amu_angstrom_2':
+        if units == "g_cm_2":
             _check_scipy(_found_scipy)
-            bohr2ang = spc.value('atomic unit of length') / spc.angstrom
-            conv = bohr2ang ** 2
-        if units == 'g_cm_2':
-            _check_scipy(_found_scipy)
-            amu2g = spc.value('unified atomic mass unit') * spc.kilo
-            conv = amu2g * (spc.value('atomic unit of length') * spc.centi) ** 2
+            amu2g = spc.value("unified atomic mass unit") * spc.kilo
+            conv = amu2g * (spc.angstrom / spc.centi) ** 2
         return conv * principal_moments, principal_axes
 
     def rotational_constants(self, units='ghz'):
@@ -179,7 +179,7 @@ class Nuclear(Method):
         units = units.lower()
         if units not in choices:
             raise ValueError("Invalid units, pick one of {}".format(choices))
-        principal_moments = self.principal_moments_of_inertia()[0]
+        principal_moments = self.principal_moments_of_inertia("amu_angstrom_2")[0]
         _check_scipy(_found_scipy)
         bohr2ang = spc.value('atomic unit of length') / spc.angstrom
         xfamu = 1 / spc.value('electron mass in u')

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -66,7 +66,7 @@ class Nuclear(Method):
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
 
-        self.required_attrs = ('natom','atomcoords','atomnos','charge')
+        self.required_attrs = ("natom", "atomcoords", "atomnos", "charge")
 
         super(Nuclear, self).__init__(data, progress, loglevel, logname)
 
@@ -86,16 +86,16 @@ class Nuclear(Method):
 
         formula = ""
         elcount = lambda el, c: "%s%i" % (el, c) if c > 1 else el
-        if 'C' in elements:
-            formula += elcount('C', counts['C'])
-            counts.pop('C')
-            if 'H' in elements:
-              formula += elcount('H', counts['H'])
-              counts.pop('H')
+        if "C" in elements:
+            formula += elcount("C", counts["C"])
+            counts.pop("C")
+            if "H" in elements:
+                formula += elcount("H", counts["H"])
+                counts.pop("H")
         for el, c in sorted(counts.items()):
             formula += elcount(el, c)
 
-        if getattr(self.data, 'charge', 0):
+        if getattr(self.data, "charge", 0):
             magnitude = abs(self.data.charge)
             sign = "+" if self.data.charge > 0 else "-"
             formula += "(%s%i)" % (sign, magnitude)
@@ -107,11 +107,11 @@ class Nuclear(Method):
         for i in range(self.data.natom):
             ri = self.data.atomcoords[atomcoords_index][i]
             zi = self.data.atomnos[i]
-            for j in range(i+1, self.data.natom):
+            for j in range(i + 1, self.data.natom):
                 rj = self.data.atomcoords[0][j]
                 zj = self.data.atomnos[j]
-                d = np.linalg.norm(ri-rj)
-                nre += zi*zj/d
+                d = np.linalg.norm(ri - rj)
+                nre += zi * zj / d
         return nre
 
     def center_of_mass(self, atomcoords_index=-1):
@@ -134,9 +134,9 @@ class Nuclear(Method):
 
         moi_tensor = np.empty((3, 3))
 
-        moi_tensor[0][0] = np.sum(masses * (coords[:, 1]**2 + coords[:, 2]**2))
-        moi_tensor[1][1] = np.sum(masses * (coords[:, 0]**2 + coords[:, 2]**2))
-        moi_tensor[2][2] = np.sum(masses * (coords[:, 0]**2 + coords[:, 1]**2))
+        moi_tensor[0][0] = np.sum(masses * (coords[:, 1] ** 2 + coords[:, 2] ** 2))
+        moi_tensor[1][1] = np.sum(masses * (coords[:, 0] ** 2 + coords[:, 2] ** 2))
+        moi_tensor[2][2] = np.sum(masses * (coords[:, 0] ** 2 + coords[:, 1] ** 2))
 
         moi_tensor[0][1] = np.sum(masses * coords[:, 0] * coords[:, 1])
         moi_tensor[0][2] = np.sum(masses * coords[:, 0] * coords[:, 2])
@@ -148,46 +148,46 @@ class Nuclear(Method):
 
         return moi_tensor
 
-    def principal_moments_of_inertia(self, units='amu_bohr_2'):
+    def principal_moments_of_inertia(self, units="amu_bohr_2"):
         """Return the principal moments of inertia in 3 kinds of units:
         1. [amu][bohr]^2
         2. [amu][angstrom]^2
         3. [g][cm]^2
         and the principal axes.
         """
-        choices = ('amu_bohr_2', 'amu_angstrom_2', 'g_cm_2')
+        choices = ("amu_bohr_2", "amu_angstrom_2", "g_cm_2")
         units = units.lower()
         if units not in choices:
             raise ValueError("Invalid units, pick one of {}".format(choices))
         moi_tensor = self.moment_of_inertia_tensor()
         principal_moments, principal_axes = np.linalg.eigh(moi_tensor)
-        if units == 'amu_bohr_2':
+        if units == "amu_bohr_2":
+            _check_scipy(_found_scipy)
+            bohr2ang = spc.value("atomic unit of length") / spc.angstrom
+            conv = 1 / bohr2ang ** 2
+        if units == "amu_angstrom_2":
             conv = 1
-        if units == 'amu_angstrom_2':
+        if units == "g_cm_2":
             _check_scipy(_found_scipy)
-            bohr2ang = spc.value('atomic unit of length') / spc.angstrom
-            conv = bohr2ang ** 2
-        if units == 'g_cm_2':
-            _check_scipy(_found_scipy)
-            amu2g = spc.value('unified atomic mass unit') * spc.kilo
-            conv = amu2g * (spc.value('atomic unit of length') * spc.centi) ** 2
+            amu2g = spc.value("unified atomic mass unit") * spc.kilo
+            conv = amu2g * (spc.angstrom / spc.centi) ** 2
         return conv * principal_moments, principal_axes
 
-    def rotational_constants(self, units='ghz'):
+    def rotational_constants(self, units="ghz"):
         """Compute the rotational constants in 1/cm or GHz."""
-        choices = ('invcm', 'ghz')
+        choices = ("invcm", "ghz")
         units = units.lower()
         if units not in choices:
             raise ValueError("Invalid units, pick one of {}".format(choices))
         principal_moments = self.principal_moments_of_inertia()[0]
         _check_scipy(_found_scipy)
-        bohr2ang = spc.value('atomic unit of length') / spc.angstrom
-        xfamu = 1 / spc.value('electron mass in u')
-        xthz = spc.value('hartree-hertz relationship')
+        bohr2ang = spc.value("atomic unit of length") / spc.angstrom
+        xfamu = 1 / spc.value("electron mass in u")
+        xthz = spc.value("hartree-hertz relationship")
         rotghz = xthz * (bohr2ang ** 2) / (2 * xfamu * spc.giga)
-        if units == 'ghz':
+        if units == "ghz":
             conv = rotghz
-        if units == 'invcm':
+        if units == "invcm":
             ghz2invcm = spc.giga * spc.centi / spc.c
             conv = rotghz * ghz2invcm
         return conv / principal_moments

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -165,9 +165,9 @@ class Nuclear(Method):
             _check_scipy(_found_scipy)
             bohr2ang = spc.value("atomic unit of length") / spc.angstrom
             conv = 1 / bohr2ang ** 2
-        if units == "amu_angstrom_2":
+        elif units == "amu_angstrom_2":
             conv = 1
-        if units == "g_cm_2":
+        elif units == "g_cm_2":
             _check_scipy(_found_scipy)
             amu2g = spc.value("unified atomic mass unit") * spc.kilo
             conv = amu2g * (spc.angstrom / spc.centi) ** 2

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -762,7 +762,7 @@ class ORCA(logfileparser.Logfile):
             self.entropy = float(next(inputfile).split()[4])
 
             line = next(inputfile)
-            while line[:25] != 'Final Gibbs free enthalpy':
+            while (line[:25] != 'Final Gibbs free enthalpy') and (line[:23] != 'Final Gibbs free energy'):
                 line = next(inputfile)
             self.freeenergy = float(line.split()[5])
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -762,7 +762,7 @@ class ORCA(logfileparser.Logfile):
             self.entropy = float(next(inputfile).split()[4])
 
             line = next(inputfile)
-            while (line[:25] != 'Final Gibbs free enthalpy') and (line[:23] != 'Final Gibbs free energy'):
+            while line[:25] != 'Final Gibbs free enthalpy':
                 line = next(inputfile)
             self.freeenergy = float(line.split()[5])
 

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -96,7 +96,7 @@ class NuclearTest(unittest.TestCase):
                         tokens = [float(x) for x in next(f).split()[1:]]
                         ref_pmoi.append(tokens[0])
                         ref_axes.append(tokens[1:])
-        pmoi, axes = nuclear.principal_moments_of_inertia()
+        pmoi, axes = nuclear.principal_moments_of_inertia("amu_angstrom_2")
         np.testing.assert_allclose(pmoi, ref_pmoi, rtol=0, atol=1.0e-4)
         # The phases of the eigenvectors may be different, but they
         # are still orthonormal within each set.


### PR DESCRIPTION
Hi all, I ran across an issue with the function `Nuclear.principal_moments_of_inertia()`. I found that the units for this function were not correct.

Here is a script which demonstrates the original problem:
```python
import cclib
from cclib.method import Nuclear

file_path = (
    "/home/james/apps/pull_requests/cclib/data/Gaussian/basicGaussian16/dvb_ir.out"
)
data = cclib.io.ccread(file_path)
nuc = Nuclear(data)
print(nuc.principal_moments_of_inertia()[0])
```

Output:
```
[109.23249971 737.88033329 847.112833  ]
```

Comparing these to the Gaussian16 output moments (shown below) I believe the moments from cclib are incorrect.
```
 Principal axes and moments of inertia in atomic units:
                           1         2         3
     Eigenvalues --   390.07631 2635.01852 3025.09483
           X            0.02413   0.99971   0.00000
           Y            0.99971  -0.02413   0.00000
           Z           -0.00000  -0.00000   1.00000
```

Since `Nuclear.moment_of_inertia_tensor()` is used elsewhere (e.g. `Nuclear.rotational_constants()`) and behaves correctly, I think that the problem is isolated in the unit conversions in `Nuclear.principal_moments_of_inertia()`. After correcting these I get the following output from my script above:
```
[ 390.07633792 2635.01850639 3025.09484431]
````

I've run the unit tests and found that it breaks the `NuclearTest.test_principal_moments_of_inertia` unit test. Let me know how you'd like me to address these testing issues.