### PR TITLE
Adding Unittest for #790

### DIFF
--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -103,6 +103,21 @@ class NuclearTest(unittest.TestCase):
         np.testing.assert_allclose(np.abs(axes), np.abs(ref_axes), rtol=0, atol=1.0e-4)
 
     @unittest.skipIf(sys.version_info < (3, 0), "The periodictable package doesn't work in Python2.")
+    def test_principal_moments_of_inertia_2(self):
+        """Testing principal moments of inertia and the principal axes for one
+        logfile where it is printed.
+
+        This test was added as a follow-up to PR #790.
+        """        
+        data, _ = getdatafile(Gaussian, "basicGaussian16", ["dvb_ir.out"])
+        nuclear = Nuclear(data)
+        nuclear.logger.setLevel(logging.ERROR)
+
+        ref_pmoi = [390.07633792, 2635.01850639, 3025.09484431]
+        pmoi, _ = nuclear.principal_moments_of_inertia("amu_bohr_2")
+        np.testing.assert_allclose(pmoi, ref_pmoi, rtol=0, atol=1.0e-4)
+
+    @unittest.skipIf(sys.version_info < (3, 0), "The periodictable package doesn't work in Python2.")
     def test_rotational_constants(self):
         """Testing rotational constants for two logfiles where they are
         printed.


### PR DESCRIPTION
This PR adds a single unit test to accompany #790. 

@berquist Let me know if this is what you had in mind. It's a little bit different than the other unit test for the principal moments of inertia from a DALTON output. I forgot when I posted #790, I had "prettified" the Gaussian16 output to make things clearer. The actual snippet from the log looks like this:

```
 Principal axes and moments of inertia in atomic units:
                           1         2         3
     Eigenvalues --   390.076312635.018523025.09483
           X            0.02413   0.99971   0.00000
           Y            0.99971  -0.02413   0.00000
           Z           -0.00000  -0.00000   1.00000
```

Making it a bit weird to parse. As a result, I skipped the parsing and compared the principal moments of inertial to their know values.

Let me know what you think.