### PR TITLE
Update context for github links in documentation

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -243,9 +243,9 @@ texinfo_documents = [
 
 # Update template context with project information.
 context = {
-    'conf_py_path': '/sphinx/',
+    'conf_py_path': '/docs/sphinx/',
     'github_user': 'cclib',
-    'github_repo': 'cclib.github.io',
+    'github_repo': 'cclib',
     'github_version': 'master',
     'display_github': True,
     'source_suffix': source_suffix,


### PR DESCRIPTION
We should be pointing to the cclib repo ever since we moved the documentation sources there from the cclib/cclib.github.io repository.

Here's a screenshot below. The link that's not working is in the upper right corner:
![screencapture-cclib-github-io-data-html-1581217926904](https://user-images.githubusercontent.com/743698/74095543-48d2f480-4aa7-11ea-93aa-2fcd17f954a6.png)
