### PR TITLE
Ensure ccframe consistently overwrites existing data files

### DIFF
--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -63,7 +63,12 @@ def main():
                         help=('name of sheet which will contain DataFrame, if '
                               'writing to an Excel file, or identifier for '
                               'the group in HDFStore, if writing a HDF file'))
+    parser.add_argument('-f', '--force', action='store_true',
+                        help=('overwrite output file in case it already exists'))
     args = parser.parse_args()
+    if args.output is not None and not args.force and os.path.exists(args.output):
+        parser.exit(1, 'failure: exiting to avoid overwriting existing file "{}"\n'.format(args.output))
+
     process_logfiles(args.compchemlogfiles, args.output, args.identifier)
 
 

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -31,15 +31,15 @@ def process_logfiles(filenames, output, identifier):
             )
 
         if outputtype in {'csv'}:
-            df.to_csv(output)
+            df.to_csv(output, mode='w')
         elif outputtype in {'h5', 'hdf', 'hdf5'}:
-            df.to_hdf(output, key=identifier)
+            df.to_hdf(output, mode='w', key=identifier)
         elif outputtype in {'json'}:
             df.to_json(output)
         elif outputtype in {'pickle', 'pkl'}:
             df.to_pickle(output)
         elif outputtype in {'xlsx'}:
-            writer = pd.ExcelWriter(output)
+            writer = pd.ExcelWriter(output, mode='w')
             # This overwrites previous sheets
             # (see https://stackoverflow.com/a/42375263/4039050)
             df.to_excel(writer, sheet_name=identifier)

--- a/doc/sphinx/how_to_parse.rst
+++ b/doc/sphinx/how_to_parse.rst
@@ -232,8 +232,9 @@ Since the pandas library is not a dependency of cclib, `it must be installed <ht
 
 A complete data table can be parsed from many output files by following this format::
 
-    ccframe -O <OutputDest> <CompChemLogFile> [<CompChemLogFile>...]
+    ccframe [--force|-f] -O <OutputDest> <CompChemLogFile> [<CompChemLogFile>...]
 
 The argument for ``-O`` indicates the data file to be written and its extension specifies the filetype (e.g. csv, h5/hdf/hdf5, json, pickle/pkl, xlsx).
+An error will be thrown if ``<OutputDest>`` already exists, but you can force overwriting by using the ``--force`` (or ``-f``) flag.
 Since higher-dimensional attributes (e.g. ``atomcoords``) are handled as plain text in some file formats (such as Excel XLSX or CSV), we recommend storing JSON or HDF5 files.
 Observe that the output data file is overwritten if it exits already.

--- a/doc/sphinx/how_to_parse.rst
+++ b/doc/sphinx/how_to_parse.rst
@@ -236,3 +236,4 @@ A complete data table can be parsed from many output files by following this for
 
 The argument for ``-O`` indicates the data file to be written and its extension specifies the filetype (e.g. csv, h5/hdf/hdf5, json, pickle/pkl, xlsx).
 Since higher-dimensional attributes (e.g. ``atomcoords``) are handled as plain text in some file formats (such as Excel XLSX or CSV), we recommend storing JSON or HDF5 files.
+Observe that the output data file is overwritten if it exits already.


### PR DESCRIPTION
`ccframe` had an unexpected behaviour when writing `hdf5` files (when compared to other file types).
When the output data file already existed, it didn't overwrite, but *appended* the data (because [that's panda's default](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html)).

The problem is that, as this might get unnoticed, files keep growing, making the posterior reading process potentially slower.

This is fixed with this PR, making all output file types behave the same with regard to overwriting policy:

```bash
% rm data.h5 
% ccframe -O data.h5 opt/**/*out
% du -h data.h5 
23M	data.h5
% ccframe -O data.h5 opt/**/*out
% du -h data.h5 
23M	data.h5
```

This fixes #797.