### PR TITLE
Fix Typo (numpy version in doc)

### DIFF
--- a/doc/sphinx/how_to_install.rst
+++ b/doc/sphinx/how_to_install.rst
@@ -8,7 +8,7 @@ Requirements
 
 Before you install cclib, you need to make sure that you have the following:
  * Python (at least version 3.4 is recommended, although 2.7 is still tested)
- * NumPy (at least version 1.5 is recommended)
+ * NumPy (at least version 1.15 is recommended)
 
 Python is an open-source programming language available from https://www.python.org. It is available for Windows as well as being included in most Linux distributions. In Debian/Ubuntu it is installed as follows (as root):
 


### PR DESCRIPTION
It looks like there is a tiny typo in the numpy version listed in the doc on line 11. Judging from line 41 and the fact that latest version of numpy being 1.19, it seems reasonable that the intended version was 1.15.
