### PR TITLE
Update adding apt resource in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - $HOME/miniconda
 
 before_install:
-  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu cosmic universe"
+  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu eoan universe"
   - sudo apt update
   - sudo apt install libopenbabel-dev
 


### PR DESCRIPTION
We needed to install a newer version of OpenBabel than was available in the apt resources of the default python Travis image. This required us to add the apt resource for Ubuntu Cosmic Cuttlefish, which is now EOL. Updating this to Eoan Ermine should fix this. It can be removed once the default python Travis image updates to the Focal LTS.