### PR TITLE
ORCA parser fails for long (1,000+ lines) inputs

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -183,7 +183,7 @@ class ORCA(logfileparser.Logfile):
                                 continue
                             if line[0] == '#' or line.strip(' ') == '\n':
                                 continue
-                            if '*' in line or line.strip() == "end":
+                            if line.strip()[0] == '*' or line.strip() == "end":
                                 break
                             # Strip basis specification that can appear after coordinates
                             line = line.split('newGTO')[0].strip()

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -183,7 +183,7 @@ class ORCA(logfileparser.Logfile):
                                 continue
                             if line[0] == '#' or line.strip(' ') == '\n':
                                 continue
-                            if line[0] == '*' or line.strip() == "end":
+                            if '*' in line or line.strip() == "end":
                                 break
                             # Strip basis specification that can appear after coordinates
                             line = line.split('newGTO')[0].strip()

--- a/test/regression.py
+++ b/test/regression.py
@@ -1652,6 +1652,12 @@ def testORCA_ORCA4_2_MP2_gradient_out(logfile):
     idx = (0, 1, 1)
     assert logfile.data.grads[idx] == -0.00040549
 
+def testORCA_ORCA4_2_long_input_out(logfile):
+    """Long ORCA input file (#804)."""
+    assert logfile.data.metadata["package_version"] == "4.2.0"
+    assert hasattr(logfile.data, 'atomcoords')
+    assert logfile.data.atomcoords.shape == (100, 12, 3)
+
 
 # PSI 3 #
 


### PR DESCRIPTION
One of the ways the ORCA parser terminates parsing input coordinates is with
```python
if line[0] == '*' or line.strip() == "end":
    break
```
However, when the input file is longer than 1,000 lines (multiple jobs in one ORCA input file), cclib will have `' *'` instead of `'*'`. By changing orcaparser to have
```python
if '*' in line or line.strip() == "end":
    break
```
we capture all circumstances.

Here is the output file from ORCA 4.2.0 that originally caused this error:
[out-CD-2MeOH-300K-1.txt](https://github.com/cclib/cclib/files/4308555/out-CD-2MeOH-300K-1.txt)


