### PR TITLE
Make makecclib the inverse of makeopenbabel

### DIFF
--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -43,6 +43,7 @@ def makecclib(mol):
         attributes['atomcoords'].append([atom.GetX(), atom.GetY(), atom.GetZ()])
         attributes['atommasses'].append(atom.GetAtomicMass())
         attributes['atomnos'].append(atom.GetAtomicNum())
+    attributes['atomcoords'] = [attributes['atomcoords']]
     return ccData(attributes)
 
 

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -31,6 +31,23 @@ class OpenbabelTest(unittest.TestCase):
         formatok = obconversion.SetOutFormat("inchi")
         assert obconversion.WriteString(obmol).strip() == "InChI=1S/H2O/h1H2"
 
+    def test_makeopenbabel_and_makecclib(self):
+        """Ensure that makeopenbabel and makecclib are inverse of each other"""
+        atomnos = numpy.array([1, 8, 1], "i")
+        atomcoords = numpy.array([[[-1., 1., 0.], [0., 0., 0.], [1., 1., 0.]]])
+
+        # makecclib(makeopenbabel(...))
+        obmol = cclib2openbabel.makeopenbabel(atomcoords, atomnos)
+        data = cclib2openbabel.makecclib(obmol)
+        numpy.testing.assert_allclose(data.atomcoords, atomcoords)
+        numpy.testing.assert_allclose(data.atomnos, atomnos)
+
+        # makeopenbabel(makecclib(...))
+        obmol = cclib2openbabel.makeopenbabel(data.atomcoords, data.atomnos)
+        data = cclib2openbabel.makecclib(obmol)  # this line is just to make the test easier
+        numpy.testing.assert_allclose(data.atomcoords, atomcoords)
+        numpy.testing.assert_allclose(data.atomnos, atomnos)
+
     def test_readfile(self):
         """Try to load an XYZ file with uracyl through Openbabel"""
         data = cclib2openbabel.readfile(self.path + "/uracil.xyz", "XYZ")


### PR DESCRIPTION
(This substitutes and implements the same changes as #759. All suggestions have been included here.)

It's currently impossible to call `makecclib` from the result of `makeopenbabel` since `makeopenbabel` demands the dimension of `atomcoords` to be three. In contrast, the return object of `makecclib` is always two dimensional.

This PR ensures `np.asarray(atomcoords).ndim == 3` for the return object of ` cclib.bridge.cclib2openbabel.makecclib`.