### PR TITLE
Print all citations to the cclib paper in rst file

### DIFF
--- a/doc/sphinx/citations.py
+++ b/doc/sphinx/citations.py
@@ -1,0 +1,13 @@
+import scholarly
+
+# Retrieve the author's data and fill-in
+search_query = scholarly.search_author('Karol M. Langner')
+author = next(search_query).fill()
+
+# Take a closer look at the cclib paper
+for i in range(len(author.publications)):
+    if author.publications[i] == "Cclib: a library for package‐independent computational chemistry algorithms":
+        pub = author.publications[i].fill()
+
+# Which papers cited that publication?
+print([citation.bib['title'] for citation in pub.get_citedby()])


### PR DESCRIPTION
The above api called scholarly can be used to retreive the list of citations from google scholar. This code may partially resolve #610 
However, it requires the installation of the arrow, Beautiful Soup, bibtexparser, and requests[security] libraries, which may not all be dependancies of cclib.
This has to be implemented into the rst file of the overview section in the docs