### PR TITLE
Implement parsing T1 diagnostic

### DIFF
--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -854,6 +854,9 @@ class DALTON(logfileparser.Logfile):
                     "ccenergies", utils.convertor(ccenergies[-1], "hartree", "eV")
                 )
 
+        if "Tau1 diagnostic" in line:
+            self.metadata["t1_diagnostic"] = float(line.split()[-1])
+
         # The molecular geometry requires the use of .RUN PROPERTIES in the input.
         # Note that the second column is not the nuclear charge, but the atom type
         # index used internally by DALTON.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -283,6 +283,9 @@ class GAMESS(logfileparser.Logfile):
                     ccenergy = float(line.split()[2])
             self.ccenergies.append(utils.convertor(ccenergy, "hartree", "eV"))
 
+        if "T1 DIAGNOSTIC" in line:
+            self.metadata["t1_diagnostic"] = float(line.split()[3])
+
         # Also collect MP2 energies, which are always calculated before CC
         if line[8:23] == "MBPT(2) ENERGY:":
             if not hasattr(self, "mpenergies"):

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -857,6 +857,8 @@ class Gaussian(logfileparser.Logfile):
         if line[1:10] == "DE(Corr)=" and line[27:35] == "E(CORR)=":
             self.metadata["methods"].append("CCSD")
             self.ccenergy = utils.float(line.split()[3])
+        if line[1:14] == "T1 Diagnostic":
+            self.metadata["t1_diagnostic"] = utils.float(line.split()[-1])
         if line[1:10] == "T5(CCSD)=":
             line = next(inputfile)
             if line[1:9] == "CCSD(T)=":

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -548,6 +548,8 @@ class Molpro(logfileparser.Logfile):
             if not hasattr(self, "ccenergies"):
                 self.ccenergies = []
             while line[1:20] != "Program statistics:":
+                if line[71:84] == "T1 diagnostic":
+                    self.metadata["t1_diagnostic"] = float(line.split()[-1])
                 # The last energy (most exact) will be read last and thus saved.
                 if line[1:5] == "!CCD" or line[1:6] == "!CCSD" or line[1:9] == "!CCSD(T)":
                     ccenergy = float(line.split()[-1])

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -449,6 +449,10 @@ class ORCA(logfileparser.Logfile):
                 'ccenergies',
                 utils.convertor(utils.float(line.split()[-1]), 'hartree', 'eV')
             )
+            line = next(inputfile)
+            assert line[:23] == 'Singles Norm <S|S>**1/2'
+            line = next(inputfile)
+            self.metadata["t1_diagnostic"] = utils.float(line.split()[-1])
 
         # ------------------
         # CARTESIAN GRADIENT

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -1040,6 +1040,20 @@ class Psi4(logfileparser.Logfile):
         if line.strip().startswith('Using finite-differences of gradients'):
             self.set_attribute('finite_difference', True)
 
+        # This is the result of calling `print_variables()` and contains all
+        # current inner variables known to Psi4.
+        if line.strip() == "Variable Map:":
+            self.skip_line(inputfile, "d")
+            line = next(inputfile)
+            while line.strip():
+                tokens = line.split()
+                # Remove double quotation marks
+                name = " ".join(tokens[:-2])[1:-1]
+                value = float(tokens[-1])
+                if name == "CC T1 DIAGNOSTIC":
+                    self.metadata["t1_diagnostic"] = value
+                line = next(inputfile)
+
         if line[:54] == '*** Psi4 exiting successfully. Buy a developer a beer!'\
                 or line[:54] == '*** PSI4 exiting successfully. Buy a developer a beer!':
             self.metadata['success'] = True

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
+import math
 import re
 
 import numpy
@@ -979,6 +980,11 @@ cannot be determined. Rerun without `$molecule read`."""
                 if not has_triples:
                     ccsdenergy = utils.convertor(ccsdenergy, 'hartree', 'eV')
                     self.ccenergies.append(ccsdenergy)
+
+            if line[:11] == " CCSD  T1^2":
+                t1_squared = float(line.split()[3])
+                t1_norm = math.sqrt(t1_squared)
+                self.metadata["t1_diagnostic"] = t1_norm / math.sqrt(2 * (self.nalpha + self.nbeta))
 
             # Electronic transitions. Works for both CIS and TDDFT.
             if 'Excitation Energies' in line:


### PR DESCRIPTION
Closes #807

For these programs, can parse directly:
- [x] DALTON (needs `.PRINT\n3` or greater under `**CC INPUT`)
- [x] GAMESS
- [x] Gaussian (needs `ccsd(t1diag)`)
- [x] Molpro
- [x] ORCA
- [x] Psi4 (needs `print_variables()`)

For these programs, parse T1 norm and calculate:
- [x] Q-Chem

For these programs, parse all T1 amplitudes and calculate:

For these programs, not possible:
- ADF (cannot do coupled cluster)
- GAMESS-UK (no coupled cluster logfiles)
- Jaguar (no coupled cluster logfiles)
- Molcas (doesn't print, maybe all T1 amplitudes?)
- NWChem (It can print it, but only for >= CCSDT? I can't get this working)
- Turbomole (by default, logfiles only print D1, we'd need to run `T1Diag` but don't have access to Turbomole anymore)