### PR TITLE
cElementTree has been deprecated since Python 3.3 and removed in Python 3.9

### DIFF
--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -7,7 +7,7 @@
 
 """A writer for chemical markup language (CML) files."""
 
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 from cclib.io import filewriter
 from cclib.parser.utils import find_package


### PR DESCRIPTION
Fixes #824 