### PR TITLE
Revert "Run regression tests on Travis with --traceback flag"

### DIFF
--- a/travis/run_pytest.bash
+++ b/travis/run_pytest.bash
@@ -9,4 +9,4 @@ python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=html
 pushd data
 bash ./regression_download.sh
 popd
-python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=html --cov-append -k test_regression test/regression.py --traceback
+python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=html --cov-append -k test_regression test/regression.py


### PR DESCRIPTION
Reverts cclib/cclib#834

I don't this this change was working: https://travis-ci.org/github/langner/cclib

Additionally, the Travis CI icons are not showing up in our PRs, so it wasn't obvious this was breaking stuff.