### PR TITLE
Add point group detection, take 2: DALTON

### DIFF
--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -46,7 +46,8 @@ class DALTON(logfileparser.Logfile):
         # would like to use as triggers.
         self.section = None
 
-        # If there is no symmetry (point group is C1), assume this.
+        # If there is no symmetry (point group is C1), set default 
+        # symlabel to A (the only representation in C1)
         self.symlabels = ['A']
 
         # Is the basis set from a single library file? This is true

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -46,10 +46,6 @@ class DALTON(logfileparser.Logfile):
         # would like to use as triggers.
         self.section = None
 
-        # If there is no symmetry (point group is C1), set default 
-        # symlabel to A (the only representation in C1)
-        self.symlabels = ['A']
-
         # Is the basis set from a single library file? This is true
         # when the first line is BASIS, false for INTGRL/ATOMBASIS.
         self.basislibrary = True
@@ -786,7 +782,7 @@ class DALTON(logfileparser.Logfile):
                 # energies per line, though, so we can deduce if we have the labels or
                 # not just the index. In the latter case, we depend on the labels
                 # being read earlier into the list `symlabels`. Finally, if no symlabels
-                # were read that implies there is only one symmetry, namely Ag.
+                # were read that implies there is only one symmetry, namely A.
                 if 'A' in cols[1] or 'B' in cols[1]:
                     sym = self.normalisesym(cols[1])
                     energies = [float(t) for t in cols[2:]]
@@ -795,7 +791,7 @@ class DALTON(logfileparser.Logfile):
                         sym = self.normalisesym(self.symlabels[int(cols[0]) - 1])
                     else:
                         assert cols[0] == '1'
-                        sym = "Ag"
+                        sym = "A"
                     energies = [float(t) for t in cols[1:]]
 
                 while len(energies) > 0:

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -47,7 +47,7 @@ class DALTON(logfileparser.Logfile):
         self.section = None
 
         # If there is no symmetry (point group is C1), assume this.
-        self.symlabels = ['Ag']
+        self.symlabels = ['A']
 
         # Is the basis set from a single library file? This is true
         # when the first line is BASIS, false for INTGRL/ATOMBASIS.

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -327,6 +327,8 @@ A dictionary containing metadata_ (data about data) for the calculation. Current
 * ``methods``: A list of strings containing each method used in order. Currently, the list may contain ``HF``, ``DFT``, ``LMP2``/``DF-MP2``/``MP2``, ``MP3``, ``MP4``, ``CCSD``, and/or ``CCSD(T)``/``CCSD-T``.
 * ``package``: A string with the name of the quantum chemistry program used.
 * ``package_version``: A string representation of the package version. It is formatted to allow comparison using relational operators.
+* ``symmetry_detected``: A string representing the full or largest point group detected by the program.
+* ``symmetry_used``: A string representing the point group used by the program for the calculation. This may be different from ``symmetry_detected`` if the full point group is non-abelian and the program can only take advantage of abelian groups. For example, when performing a calculation on benzene with symmetry turned on, ``symmetry_detected`` may be ``d6h``, but ``symmetry_used`` is most likely ``d2h``, since D2h is the largest abelian subgroup of D6h.
 * ``success``: A boolean for whether or not the calculation completed properly.
 * ``unrestricted``: A boolean for whether or not the calculation was performed with a unrestricted wavefunction.
 * ``wall_time``: A list of datetime.timedeltas containing the wall time of each calculation in the output.  

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -346,7 +346,6 @@ class GenericSPTest(unittest.TestCase):
         )
 
     @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
-    @skipForParser('DALTON', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
     @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')
@@ -365,7 +364,6 @@ class GenericSPTest(unittest.TestCase):
         self.assertEqual(self.data.metadata["symmetry_detected"], "c2h")
 
     @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
-    @skipForParser('DALTON', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
     @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -344,6 +344,45 @@ class GenericSPTest(unittest.TestCase):
             packaging.version.parse(self.data.metadata["package_version"]),
             packaging.version.Version
         )
+
+    @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
+    @skipForParser('DALTON', 'reading point group symmetry and name is not implemented')
+    @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
+    @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Jaguar', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Molcas', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Molpro', 'reading point group symmetry and name is not implemented')
+    @skipForParser('MOPAC', 'reading point group symmetry and name is not implemented')
+    @skipForParser('NWChem', 'reading point group symmetry and name is not implemented')
+    @skipForParser('ORCA', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Psi3', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Psi4', 'reading point group symmetry and name is not implemented')
+    @skipForParser('QChem', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Turbomole', 'reading point group symmetry and name is not implemented')
+    def testmetadata_symmetry_detected(self):
+        """Does metadata have expected keys and values?"""
+        self.assertEqual(self.data.metadata["symmetry_detected"], "c2h")
+
+    @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
+    @skipForParser('DALTON', 'reading point group symmetry and name is not implemented')
+    @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
+    @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Jaguar', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Molcas', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Molpro', 'reading point group symmetry and name is not implemented')
+    @skipForParser('MOPAC', 'reading point group symmetry and name is not implemented')
+    @skipForParser('NWChem', 'reading point group symmetry and name is not implemented')
+    @skipForParser('ORCA', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Psi3', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Psi4', 'reading point group symmetry and name is not implemented')
+    @skipForParser('QChem', 'reading point group symmetry and name is not implemented')
+    @skipForParser('Turbomole', 'reading point group symmetry and name is not implemented')
+    def testmetadata_symmetry_used(self):
+        """Does metadata have expected keys and values?"""
+        self.assertEqual(self.data.metadata["symmetry_used"], "c2h")
+
     @skipForParser('ADF', 'reading cpu/wall time is not implemented for this parser')
     @skipForParser('DALTON', 'reading cpu/wall time is not implemented for this parser') 
     @skipForParser('FChk', 'reading cpu/wall time is not implemented for this parser') 

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -346,6 +346,7 @@ class GenericSPTest(unittest.TestCase):
         )
 
     @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
+    @skipForParser('FChk', 'point group symmetry cannot be printed')
     @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
     @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')
@@ -364,6 +365,7 @@ class GenericSPTest(unittest.TestCase):
         self.assertEqual(self.data.metadata["symmetry_detected"], "c2h")
 
     @skipForParser('ADF', 'reading point group symmetry and name is not implemented')
+    @skipForParser('FChk', 'point group symmetry cannot be printed')
     @skipForParser('GAMESS', 'reading point group symmetry and name is not implemented')
     @skipForParser('GAMESSUK', 'reading point group symmetry and name is not implemented')
     @skipForParser('Gaussian', 'reading point group symmetry and name is not implemented')

--- a/test/regression.py
+++ b/test/regression.py
@@ -2809,10 +2809,22 @@ class DALTONBigBasisTest_aug_cc_pCVQZ(GenericBigBasisTest):
     spherical = True
 
 
-class DALTONSPTest_nosyms_nolabels(GenericSPTest):
-    @unittest.skip('?')
+class DALTONSPTest_nosymmetry(GenericSPTest):
+
     def testsymlabels(self):
-        """Are all the symmetry labels either Ag/u or Bg/u?."""
+        """Are all the symmetry labels either Ag/u or Bg/u?"""
+        # A calculation without symmetry, meaning it belongs to the C1 point
+        # group, only has the `A` irreducible representation.
+        sumwronglabels = sum(x not in {'A'} for x in self.data.mosyms[0])
+        self.assertEqual(sumwronglabels, 0)
+
+    def testmetadata_symmetry_detected(self):
+        """Does metadata have expected keys and values?"""
+        self.assertEqual(self.data.metadata["symmetry_detected"], "c1")
+
+    def testmetadata_symmetry_used(self):
+        """Does metadata have expected keys and values?"""
+        self.assertEqual(self.data.metadata["symmetry_used"], "c1")
 
 
 class DALTONTDTest_noetsecs(DALTONTDTest):
@@ -3128,8 +3140,8 @@ old_unittests = {
     "ADF/ADF2014.01/dvb_gopt_b_fullscf.out":       ADFGeoOptTest,
 
     "DALTON/DALTON-2013/C_bigbasis.aug-cc-pCVQZ.out":       DALTONBigBasisTest_aug_cc_pCVQZ,
-    "DALTON/DALTON-2013/b3lyp_energy_dvb_sp_nosym.out":     DALTONSPTest_nosyms_nolabels,
-    "DALTON/DALTON-2013/dvb_sp_hf_nosym.out":               GenericSPTest,
+    "DALTON/DALTON-2013/b3lyp_energy_dvb_sp_nosym.out":     DALTONSPTest_nosymmetry,
+    "DALTON/DALTON-2013/dvb_sp_hf_nosym.out":               DALTONSPTest_nosymmetry,
     "DALTON/DALTON-2013/dvb_td_normalprint.out":            DALTONTDTest_noetsecs,
     "DALTON/DALTON-2013/sp_b3lyp_dvb.out":                  GenericSPTest,
     "DALTON/DALTON-2015/dvb_td_normalprint.out":            DALTONTDTest_noetsecs,


### PR DESCRIPTION
This does three things:
- Adds a test for detected (full) and used (most likely largest Abelian subgroup) point group
- Enables the test for DALTON, which has point group detection implemented.
- Updates the DALTON no symmetry regression test to look for C1 symmetry rather than C2h (the DVB point group). In doing this, I discovered that it used `Ag` as the no-symmetry irrep symbol when it should be `A`.