### PR TITLE
[ORCA] Fix shape of ccenergies

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -445,8 +445,8 @@ class ORCA(logfileparser.Logfile):
             assert line[:7] == 'E(CORR)'
             while 'E(TOT)' not in line:
                 line = next(inputfile)
-            self.append_attribute('ccenergies', [])
-            self.ccenergies[-1].append(
+            self.append_attribute(
+                'ccenergies',
                 utils.convertor(utils.float(line.split()[-1]), 'hartree', 'eV')
             )
 


### PR DESCRIPTION
This is a post-fix after #832 - I'm not sure why it didn't trip up Travis there, perhaps it's due to the period where Travis stopped working for us. In any case, this should fix it.