### PR TITLE
[Gaussian] Revert 'Elmar Neumann' exception for which there is no regression

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1595,8 +1595,7 @@ class Gaussian(logfileparser.Logfile):
                     line = next(inputfile)
                     # Just do this the first time 'round.
                     if base == 0:
-                        # Changed below from :12 to :11 to deal with Elmar Neumann's example.
-                        parts = line[:11].split()
+                        parts = line[:12].split()
                         # New atom.
                         if len(parts) > 1:
                             if i > 0:


### PR DESCRIPTION
So this little change fixes #756 as pointed out there. Since we don't have any regression as far as I can tell from Elmar Neumann - or at least this change doesn't break anything we have - I think it's fair to ignore the old warning. If something comes up that we can debug, we can look for a better fix.