### PR TITLE
Fuzzy matching attribute arguments to ccget

### DIFF
--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -116,7 +116,7 @@ def ccget():
             fuzzy_attr = difflib.get_close_matches(arg, ccData._attrlist, n=1, cutoff=0.85)
             if len(fuzzy_attr) > 0:
                 fuzzy_attr = fuzzy_attr[0]
-                logging.warn("Attribute '{0}' not found, but attribute '{1}' is close. "
+                logging.warning("Attribute '{0}' not found, but attribute '{1}' is close. "
                     "Using '{1}' instead.".format(arg, fuzzy_attr))
                 arg = fuzzy_attr
         if arg in ccData._attrlist:

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -15,6 +15,7 @@ import glob
 import logging
 import os.path
 import sys
+from fuzzywuzzy import process
 from functools import partial
 from pprint import pprint
 
@@ -111,6 +112,12 @@ def ccget():
     attrnames = []
     filenames = []
     for arg in arglist:
+        if arg not in ccData._attrlist:
+            fuzzy_attr, confidence = process.extractOne(arg, ccData._attrlist)
+            if confidence > 85:
+                logging.warn("Attribute '{0}' not found, but attribute '{1}' is close. "
+                    "Using '{1}' instead.".format(arg, fuzzy_attr))
+                arg = fuzzy_attr
         if arg in ccData._attrlist:
             attrnames.append(arg)
         elif URL_PATTERN.match(arg) or os.path.isfile(arg):

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -15,7 +15,7 @@ import glob
 import logging
 import os.path
 import sys
-from fuzzywuzzy import process
+import difflib
 from functools import partial
 from pprint import pprint
 
@@ -113,8 +113,9 @@ def ccget():
     filenames = []
     for arg in arglist:
         if arg not in ccData._attrlist:
-            fuzzy_attr, confidence = process.extractOne(arg, ccData._attrlist)
-            if confidence > 85:
+            fuzzy_attr = difflib.get_close_matches(arg, ccData._attrlist, n=1, cutoff=0.85)
+            if len(fuzzy_attr) > 0:
+                fuzzy_attr = fuzzy_attr[0]
                 logging.warn("Attribute '{0}' not found, but attribute '{1}' is close. "
                     "Using '{1}' instead.".format(arg, fuzzy_attr))
                 arg = fuzzy_attr

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -15,7 +15,6 @@ import six
 from six import add_move, MovedModule
 add_move(MovedModule('mock', 'mock', 'unittest.mock'))
 from six.moves import mock
-import warnings
 import cclib
 
 

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -67,6 +67,9 @@ class ccgetTest(unittest.TestCase):
     def test_ccread_invocation_matching_args(self, mock_warn, mock_ccread):
         self.main()
         self.assertEqual(mock_warn.call_count, 1)
+        warn_call_args, warn_call_kwargs = mock_warn.call_args
+        warn_message = warn_call_args[0]
+        self.assertEqual(warn_message, "Attribute 'atomcoord' not found, but attribute 'atomcoords' is close. Using 'atomcoords' instead.")
         self.assertEqual(mock_ccread.call_count, 1)
         ccread_call_args, ccread_call_kwargs = mock_ccread.call_args
         self.assertEqual(ccread_call_args[0], INPUT_FILE)

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -15,7 +15,7 @@ import six
 from six import add_move, MovedModule
 add_move(MovedModule('mock', 'mock', 'unittest.mock'))
 from six.moves import mock
-
+import warnings
 import cclib
 
 
@@ -59,6 +59,17 @@ class ccgetTest(unittest.TestCase):
         ccread_call_args, ccread_call_kwargs = mock_ccread.call_args
         self.assertEqual(ccread_call_args[0], INPUT_FILE)
 
+    @mock.patch("logging.warning")
+    @mock.patch(
+        "cclib.scripts.ccget.sys.argv",
+        ["ccget", "atomcoord", INPUT_FILE]
+    )
+    def test_ccread_invocation_matching_args(self, mock_warn, mock_ccread):
+        self.main()
+        self.assertEqual(mock_warn.call_count, 1)
+        self.assertEqual(mock_ccread.call_count, 1)
+        ccread_call_args, ccread_call_kwargs = mock_ccread.call_args
+        self.assertEqual(ccread_call_args[0], INPUT_FILE)
 
 @mock.patch("cclib.scripts.ccwrite.ccwrite")
 class ccwriteTest(unittest.TestCase):


### PR DESCRIPTION
I always forget the attribute names, and I figured this would be helpful. The example below tries to parse `atomcoord` and `mo_coeff` from the log files instead of the correct `atomcoords` and `mocoeffs`. The `homos` is correct and included just to show it works.

A warning is logged that the argument is being fuzzy matched 

```
WARNING:root:Attribute 'atomcoord' not found, but attribute 'atomcoords' is close. Using 'atomcoords' instead.
WARNING:root:Attribute 'mo_coeff' not found, but attribute 'mocoeffs' is close. Using 'mocoeffs' instead.
Attempting to read data/Gaussian/basicGaussian16/dvb_un_sp.log
atomcoords
array([[[ 0.      ,  0.      ,  0.      ],
        [ 0.      ,  0.      ,  1.421154],
        [ 1.203695,  0.      ,  2.140325],
        [ 2.46209 ,  0.      ,  1.477152],
        [ 2.46209 ,  0.      ,  0.055998],
        [-0.952813,  0.      ,  1.966053],
        [ 1.180146,  0.      ,  3.238735],
        [ 3.414904,  0.      , -0.488901],
        [ 3.717531,  0.      ,  2.293665],
        [ 4.977755,  0.      ,  1.825807],
        [ 5.210853,  0.      ,  0.754892],
        [ 3.55288 ,  0.      ,  3.381684],
        [ 5.836811,  0.      ,  2.506791],
        [-1.255441,  0.      , -0.816513],
        [-1.09079 ,  0.      , -1.904532],
        [-2.515665,  0.      , -0.348656],
        [-2.748763,  0.      ,  0.72226 ],
        [-3.374721,  0.      , -1.02964 ],
        [ 1.258395,  0.      , -0.663174],
        [ 1.281944,  0.      , -1.761584]]])
mocoeffs
[array([[ 7.0027e-01,  3.1280e-02,  9.4000e-04, ..., -0.0000e+00, -2.2800e-03,  2.2000e-04],
       [ 7.0029e-01,  3.1080e-02,  7.1000e-04, ...,  0.0000e+00, -2.0300e-03,  1.1000e-04],
       [ 9.9400e-03, -7.6600e-03, -1.1100e-03, ..., -0.0000e+00,  2.6000e-03, -1.6700e-03],
       ...,
       [ 2.0410e-02, -1.4481e-01, -2.9322e-01, ...,  0.0000e+00,  1.4040e-01, -1.3490e-02],
       [ 5.4900e-03, -3.6130e-02, -2.9737e-01, ...,  0.0000e+00,  2.0780e-02,  1.1360e-02],
       [ 4.0360e-02, -3.0538e-01, -5.3642e-01, ...,  0.0000e+00,  6.1608e-01,  2.9064e-01]]),
 array([[ 7.0031e-01,  3.0970e-02,  9.2000e-04, ..., -0.0000e+00, -2.2500e-03,  2.3000e-04],
       [ 7.0033e-01,  3.0790e-02,  7.0000e-04, ...,  0.0000e+00, -2.0100e-03,  1.2000e-04],
       [ 1.0780e-02, -7.6200e-03, -1.1700e-03, ..., -0.0000e+00,  2.6000e-03, -1.7200e-03],
       ...,
       [ 2.1680e-02, -1.5309e-01, -2.9553e-01, ...,  0.0000e+00,  1.4542e-01, -1.1150e-02],
       [ 5.6800e-03, -3.7310e-02, -2.9524e-01, ..., -0.0000e+00,  2.2160e-02,  9.8600e-03],
       [ 4.1730e-02, -3.1344e-01, -5.3676e-01, ...,  0.0000e+00,  6.1443e-01,  2.8805e-01]])]
homos
array([34, 33], dtype=int32)
Attempting to read data/Gaussian/basicGaussian16/dvb_sp.out
atomcoords
array([[[ 0.269445,  1.410118,  0.      ],
        [-1.064785,  0.920662, -0.      ],
        [-1.325389, -0.457058, -0.      ],
        [-0.269445, -1.410118,  0.      ],
        [ 1.064785, -0.920662,  0.      ],
        [-1.90447 ,  1.627522, -0.      ],
        [-2.364759, -0.813041, -0.      ],
        [ 1.90447 , -1.627522,  0.      ],
        [-0.603688, -2.86996 , -0.      ],
        [ 0.269445, -3.89207 , -0.      ],
        [ 1.355175, -3.742314, -0.      ],
        [-1.681859, -3.090152, -0.      ],
        [-0.074247, -4.933029, -0.      ],
        [ 0.603688,  2.86996 , -0.      ],
        [ 1.681859,  3.090152, -0.      ],
        [-0.269445,  3.89207 , -0.      ],
        [-1.355175,  3.742314, -0.      ],
        [ 0.074247,  4.933029, -0.      ],
        [ 1.325389,  0.457058, -0.      ],
        [ 2.364759,  0.813041, -0.      ]]])
mocoeffs
[array([[ 6.9930e-01,  3.1570e-02, -5.0000e-05, ..., -2.7200e-03,  0.0000e+00,  3.3000e-04],
       [ 6.9929e-01,  3.1360e-02,  1.0000e-05, ..., -3.0800e-03,  0.0000e+00,  2.2000e-04],
       [-2.8020e-02,  4.1300e-03,  7.8000e-04, ..., -0.0000e+00,  0.0000e+00, -8.0000e-05],
       ...,
       [ 2.0710e-02, -1.4604e-01, -4.4799e-01, ...,  1.3245e-01,  0.0000e+00, -1.8140e-02],
       [-5.0000e-03,  3.3080e-02,  7.0026e-01, ..., -5.4166e-01,  0.0000e+00, -6.6700e-03],
       [ 4.4390e-02, -3.3032e-01,  1.8649e-01, ..., -2.2716e-01,  0.0000e+00,  2.6965e-01]])]
homos
array([34], dtype=int32)
```