### PR TITLE
Fixes issue with dealing with reduced list of atoms

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -272,8 +272,9 @@ class Gaussian(logfileparser.Logfile):
 
             # Necessary for `if line.strip().split()[0:3] == ["Atom", "AN", "X"]:` block
             if not hasattr(self, 'nqmf'):
-                nqmf = int(re.search('NQMF=\s*(\d+)', line).group(1))
-                self.set_attribute('nqmf', nqmf)
+                match = re.search('NQMF=\s*(\d+)', line)
+                if match is not None:
+                    self.set_attribute('nqmf', int(match.group(1)))
 
         # Basis set name
         if line[1:15] == "Standard basis":

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -270,6 +270,11 @@ class Gaussian(logfileparser.Logfile):
             natom = int(re.search(r'NAtoms=\s*(\d+)', line).group(1))
             self.set_attribute('natom', natom)
 
+            # Necessary for `if line.strip().split()[0:3] == ["Atom", "AN", "X"]:` block
+            if not hasattr(self, 'nqmf'):
+                nqmf = int(re.search('NQMF=\s*(\d+)', line).group(1))
+                self.set_attribute('nqmf', nqmf)
+
         # Basis set name
         if line[1:15] == "Standard basis":
             self.metadata["basis_set"] = line.split()[2]
@@ -1206,7 +1211,7 @@ class Gaussian(logfileparser.Logfile):
                     if not hasattr(self, 'vibdisps'):
                         self.vibdisps = []
                     disps = []
-                    for n in range(self.natom):
+                    for n in range(self.nqmf):
                         line = next(inputfile)
                         numbers = [float(s) for s in line[10:].split()]
                         N = len(numbers) // 3

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1211,6 +1211,8 @@ class Gaussian(logfileparser.Logfile):
                     if not hasattr(self, 'vibdisps'):
                         self.vibdisps = []
                     disps = []
+                    if not hasattr(self, 'nqmf'):
+                        self.set_attribute('nqmf', self.natom)
                     for n in range(self.nqmf):
                         line = next(inputfile)
                         numbers = [float(s) for s in line[10:].split()]


### PR DESCRIPTION
## Issue

When working with an atom selection in Gaussian of the form

```
 AtmSel:  Line="noatoms atoms=X-Y"
```

the block of code

```
if line.strip().split()[0:3] == ["Atom", "AN", "X"]:
```

from `gaussianparser.py` will run for `self.natom` iterations.
However, since the number of atoms has been reduced, the block of code will read too many lines and cause an error:

```
ValueError: could not convert string to float: 'A'
```

## Fix

To fix this, the parameter `NQMF` is directly read from the .out file and stored as an instance attribute.
This parameter corresponds to the number of reduced atoms.
This is then used when iterating in a 

```
if line.strip().split()[0:3] == ["Atom", "AN", "X"]:
```

block of code, allowing for the correct number of lines to be read.