### PR TITLE
Pin biopython to 1.76, because they dropped Python2 support in 1.77

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy
 periodictable
 
 # bridges
-biopython
+biopython==1.76
 openbabel==2.4.1
 # For some reason PyQuante can't be installed from PyPI.
 https://sourceforge.net/projects/pyquante/files/PyQuante-1.6/PyQuante-1.6.5/PyQuante-1.6.5.tar.gz  ; python_version <= '2.7'


### PR DESCRIPTION
This is needed quite urgently to get Travis green again so we can evaluate PRs.

See BioPython changelog at https://raw.githubusercontent.com/biopython/biopython/master/NEWS.rst

We've decided to wait until a version 2.x to get rid of Python2. If we don't release a version 2.x this year, we should think about accelerating that process. See #518 for a discussion.