### PR TITLE
Add horton 2 --> cclib bridge, along with tests

### DIFF
--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -6,6 +6,7 @@
 # the terms of the BSD 3-Clause License.
 
 """Bridge for using cclib data in horton (http://theochem.github.io/horton)."""
+# Support for horton 2 will likely be dropped when Python 2 support is dropped from cclib.
 
 import numpy
 from cclib.parser.data import ccData
@@ -13,11 +14,13 @@ from cclib.parser.utils import find_package
 
 # First check horton version
 _old_horton = False
-_found_horton = find_package('horton')
-_found_iodata = find_package('iodata')
+_found_horton = find_package("horton")
+_found_iodata = find_package("iodata")
 
-if _found_horton: # Detect whether horton 2 is present or not
-    try: # Older horton packages do not have __version__, causing exceptions.
+# Detect whether horton 2 is present or not
+if _found_horton:
+    # Older horton packages do not have __version__, causing exceptions.
+    try:
         from horton import __version__
     except:
         _old_horton = True
@@ -25,43 +28,78 @@ if _found_horton: # Detect whether horton 2 is present or not
         if __version__[0] == "2":
             from horton.io.iodata import IOData
 
-if _found_iodata: # Detect whether iodata (part of horton 3) is present or not; Horton 3 is divided into smaller (sub)packages that each take different functionalities.
+# Detect whether iodata (part of horton 3) is present or not
+# Horton 3 is divided into smaller (sub)packages that each take different functionalities.
+if _found_iodata:
     from iodata import IOData
     from iodata.orbitals import MolecularOrbitals
-    
+
+
 def check_horton():
     if _old_horton:
         raise ImportError("You must have at least version 2 of `horton` to use this function.")
     elif not _found_horton and not _found_iodata:
         raise ImportError("You must install `horton` to use this function.")
-    if (_found_iodata):
+    if _found_iodata:
         return 3
-    elif (_found_horton):
+    elif _found_horton:
         return 2
+
 
 def makehorton(ccdat):
     """ Create horton IOData object from ccData object """
-    
+
     hortonver = check_horton()
     attributes = {}
-    
-    if (hortonver == 2):
-        pass # Populate with bridge for horton 2 in later PR
-    elif (hortonver == 3):
-        pass # Populate with bridge for horton 3 in later PR
-    
-    return IOData(**attributes) # Pass collected attributes into IOData constructor
-    
+
+    if hortonver == 2:
+        pass  # Populate with bridge for horton 2 in later PR
+    elif hortonver == 3:
+        pass  # Populate with bridge for horton 3 in later PR
+
+    return IOData(**attributes)  # Pass collected attributes into IOData constructor
+
+
 def makecclib(iodat):
     """ Create cclib ccData object from horton IOData object """
-    
+
     hortonver = check_horton()
     attributes = {}
-    
-    if(hortonver == 2):
+
+    if hortonver == 2:
+        # For a few attributes, a simple renaming suffices
+        renameAttrs = {
+            "numbers": "atomnos",
+            "ms2": "mult",
+            "polar": "polarizability",
+        }
+        inputattrs = iodat.__dict__
+
+        attributes = dict(
+            (renameAttrs[oldKey], val)
+            for (oldKey, val) in inputattrs.items()
+            if (oldKey in renameAttrs)
+        )
+
+        # Rest of attributes need some manipulation in data structure.
+        if hasattr(iodat, "coordinates"):
+            # cclib parses the whole history of coordinates in the list, horton keeps the last one.
+            attributes["atomcoords"] = [iodat.coordinates]
+        if hasattr(iodat, "orb_alpha"):
+            attributes["mocoeffs"] = [iodat.orb_alpha]
+        if hasattr(iodat, "orb_beta"):
+            attributes["mocoeffs"].append(iodat.orb_beta)
+        if hasattr(iodat, "pseudo_numbers"):
+            # cclib stores the number of excluded electrons,
+            # horton IOData stores the number of electrons that were considered after exclusion.
+            attributes["coreelectrons"] = iodat.numbers - iodat.pseudo_numbers
+        if hasattr(iodat, "mulliken_charges"):
+            attributes["atomcharges"] = {"mulliken": iodat.mulliken_charges}
+            if hasattr(iodat, "npa_charges"):
+                attributes["atomcharges"]["natural"] = iodat.npa_charges
+        elif hasattr(iodat, "npa_charges"):
+            attributes["atomcharges"] = {"natural": iodat.npa_charges}
+    elif hortonver == 3:
         pass
-    elif (hortonver == 3):
-        pass
-    
+
     return ccData(attributes)
-    

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+import unittest
+import os, sys
+import numpy
+
+from cclib.bridge import cclib2horton
+from ..test_data import getdatafile
+from cclib.parser.utils import find_package
+
+from numpy.testing import assert_array_almost_equal
+
+
+class HortonTest(unittest.TestCase):
+    """ Tests for the horton bridge in cclib """
+
+    # Both horton and cclib can read in fchk files. The test routine utilizes this fact and compares the attributes that were directly loaded from each package and the attributes that were converted.
+
+    def setUp(self):
+        super(HortonTest, self).setUp()
+
+        self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"])
+        datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "data"))
+        inputfile = os.path.join(datadir, "Gaussian", "basicGaussian16", "dvb_un_sp.fchk")
+
+        self._old_horton = False
+        self._found_horton = find_package("horton")
+        self._found_iodata = find_package("iodata")
+
+        if self._found_horton:
+            try:
+                from horton import __version__
+            except:
+                self._old_horton = (
+                    True  # Old horton versions do not have this __version__ attribute
+                )
+            else:
+                if __version__[0] == "2":
+                    from horton.io.iodata import IOData
+                    from horton import log
+
+                    log.set_level(
+                        0
+                    )  # This suppresses horton outputs so that they do not flood the test log.
+                    self._hortonver = 2
+                    self.iodat = IOData.from_file(inputfile)
+        if self._found_iodata:
+            # Add horton 3 import lines
+            pass
+
+    def test_makehorton(self):
+        pass
+
+    def test_makecclib(self):
+        """ Check that the bridge from horton to cclib works correctly """
+        # First use `makecclib` function to generate ccData object converted from horton IOData
+        cclibequiv = cclib2horton.makecclib(self.iodat)
+
+        # Identify attributes that should be verified
+        check = ["mult", "coreelectrons"]  # float or int
+        checkArr = ["atomcoords", "atomnos", "mocoeffs"]  # one dimensional arrays
+        checkArrArr = ["polarizability"]  # two dimensional arrays
+        checkChg = ["mulliken", "natural"]  # partial charges
+
+        for attr in check:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                self.assertAlmostEqual(
+                    getattr(self.data, attr), getattr(cclibequiv, attr), delta=1.0e-3
+                )
+
+        for attr in checkArr:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                assert_array_almost_equal(
+                    getattr(self.data, attr), getattr(cclibequiv, attr), decimal=3
+                )
+
+        for attr in checkArrArr:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                assert_array_almost_equal(
+                    getattr(self.data, attr)[0], getattr(cclibequiv, attr)[0], decimal=3
+                )
+
+        if hasattr(self.data, "atomcharges") and hasattr(cclibequiv, "atcomcharges"):
+            for chg in checkChg:
+                if chg in self.data.atomcharges and chg in cclibequiv.atomcharges:
+                    assert_array_almost_equal(
+                        self.data.atomcharges[chg][0], cclibequiv.atomcharges[chg][0], decimal=3
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -20,8 +20,8 @@ if sys.version_info[0] == 3:
 from .bridge.testopenbabel import *
 
 if sys.version_info[0] == 2:
+    from .bridge.testhorton import *
     from .bridge.testpyquante import *
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.


### PR DESCRIPTION
Related Issue : #880

This PR is related to Issue #880 and builds upon #882 . This PR adds a bridging function that constructs ccData object from horton 2's IOData object.

Test compares the parsed results (from cclib.io) and converted results (IOData converted using the bridge function).