### PR TITLE
Up minimum version for pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ https://sourceforge.net/projects/pyquante/files/PyQuante-1.6/PyQuante-1.6.5/PyQu
 sphinx
 
 # For testing
-pytest>=3.6
+pytest>=4.6
 coverage
 pytest-cov
 # This library is in the standard library starting from Python 3.3.


### PR DESCRIPTION
This was trying to fix what seems like a minimum version requirement for pytest_cov for master on Travis:
```
pkg_resources.VersionConflict: (pytest 4.1.0 (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages), Requirement.parse('pytest>=4.6'))
```
... but #874 seems to have fixed it already.