### PR TITLE
Add horton 3 --> cclib bridge, along with tests

### DIFF
--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -58,8 +58,13 @@ class HortonTest(unittest.TestCase):
                     self._hortonver = 2
                     self.iodat = IOData.from_file(inputfile)
         if self._found_iodata:
-            # Add horton 3 import lines
-            pass
+            from iodata import IOData
+            from iodata.orbitals import MolecularOrbitals
+            from iodata.api import load_one
+
+            self._hortonver = 3
+
+            self.iodat = load_one(filename=inputfile)
 
     def test_makehorton(self):
         """ Check that the bridge from cclib to horton works correctly """

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -15,6 +15,7 @@ sys.path.insert(1, "bridge")
 if sys.version_info[0] == 3:
     if sys.version_info[1] >= 6:
         from .bridge.testpsi4 import *
+        from .bridge.testhorton import *
     if sys.version_info[1] >= 4:
         from .bridge.testbiopython import *
 from .bridge.testopenbabel import *


### PR DESCRIPTION
Related Issue : #880

This PR is related to Issue #880 and builds upon #883 . This PR adds a bridging function that constructs ccData object from Horton 3 IOData object.

Test compares the parsed results (cclib.io) and converted results (horton 3 IOData object converted into ccData object using the bridge function).