### PR TITLE
Proposing wrapper methods for population analysis methods from horton

### DIFF
--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -21,5 +21,16 @@ if find_package("PyQuante"):
 if find_package("psi4"):
     from cclib.bridge.cclib2psi4 import makepsi4
 
+if find_package("horton"):
+    try:
+        from horton import __version__
+    except Exception:
+        pass
+    else:
+        if (__version__[0] == '2'):
+            from cclib.bridge.cclib2horton import makehorton
+
+if find_package("iodata"):
+    from cclib.bridge.cclib2horton import makehorton
 
 del find_package

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -63,7 +63,7 @@ def makehorton(ccdat):
             if (oldKey in renameAttrs)
         )
 
-        # Rest of attributes need some manupulation in data structure
+        # Rest of attributes need some manipulation in data structure
         if hasattr(ccdat, "atomcoords"):
             # cclib parses the whole history of coordinates in the list, horton keeps the last one.
             attributes["coordinates"] = ccdat.atomcoords[-1]

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -54,32 +54,7 @@ def makehorton(ccdat):
     attributes = {}
 
     if hortonver == 2:
-        renameAttrs = {"atomnos": "numbers", "mult": "ms2", "polarizability": "polar"}
-        inputattrs = ccdat.__dict__
-
-        attributes = dict(
-            (renameAttrs[oldKey], val)
-            for (oldKey, val) in inputattrs.items()
-            if (oldKey in renameAttrs)
-        )
-
-        # Rest of attributes need some manipulation in data structure
-        if hasattr(ccdat, "atomcoords"):
-            # cclib parses the whole history of coordinates in the list, horton keeps the last one.
-            attributes["coordinates"] = ccdat.atomcoords[-1]
-        if hasattr(ccdat, "mocoeffs"):
-            attributes["orb_alpha"] = ccdat.mocoeffs[0]
-            if len(ccdat.mocoeffs) == 2:
-                attributes["orb_beta"] = ccdat.mocoeffs[1]
-        if hasattr(ccdat, "coreelectrons") and isinstance(
-            ccdat.coreelectrons, numpy.ndarray
-        ):  # type-checked
-            attributes["pseudo_numbers"] = ccdat.atomnos - ccdat.coreelectrons
-        if hasattr(ccdat, "atomcharges") and ("mulliken" in ccdat.atomcharges):
-            attributes["mulliken_charges"] = ccdat.atomcharges["mulliken"]
-        if hasattr(ccdat, "atomcharges") and ("natural" in ccdat.atomcharges):
-            attributes["npa_charges"] = ccdat.atomcharges["natural"]
-
+        pass  # Populate with bridge for horton 2 in later PR
     elif hortonver == 3:
         pass  # Populate with bridge for horton 3 in later PR
 
@@ -125,7 +100,6 @@ def makecclib(iodat):
                 attributes["atomcharges"]["natural"] = iodat.npa_charges
         elif hasattr(iodat, "npa_charges"):
             attributes["atomcharges"] = {"natural": iodat.npa_charges}
-
     elif hortonver == 3:
         # Horton 3 IOData class uses attr and does not have __dict__.
         if hasattr(iodat, "atcoords"):

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -125,6 +125,7 @@ def makecclib(iodat):
                 attributes["atomcharges"]["natural"] = iodat.npa_charges
         elif hasattr(iodat, "npa_charges"):
             attributes["atomcharges"] = {"natural": iodat.npa_charges}
+
     elif hortonver == 3:
         # Horton 3 IOData class uses attr and does not have __dict__.
         if hasattr(iodat, "atcoords"):

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -33,7 +33,6 @@ if _found_iodata:
     from iodata import IOData
     from iodata.orbitals import MolecularOrbitals
 
-
 def check_horton():
     if _old_horton:
         raise ImportError(
@@ -45,7 +44,6 @@ def check_horton():
         return 3
     elif _found_horton:
         return 2
-
 
 def makehorton(ccdat):
     """ Create horton IOData object from ccData object """

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Bridge for using cclib data in horton (http://theochem.github.io/horton)."""
+
+import numpy
+from cclib.parser.data import ccData
+from cclib.parser.utils import find_package
+
+# First check horton version
+_old_horton = False
+_found_horton = find_package('horton')
+_found_iodata = find_package('iodata')
+
+if _found_horton: # Detect whether horton 2 is present or not
+    try: # Older horton packages do not have __version__, causing exceptions.
+        from horton import __version__
+    except:
+        _old_horton = True
+    else:
+        if __version__[0] == "2":
+            from horton.io.iodata import IOData
+
+if _found_iodata: # Detect whether iodata (part of horton 3) is present or not; Horton 3 is divided into smaller (sub)packages that each take different functionalities.
+    from iodata import IOData
+    from iodata.orbitals import MolecularOrbitals
+    
+def check_horton():
+    if _old_horton:
+        raise ImportError("You must have at least version 2 of `horton` to use this function.")
+    elif not _found_horton and not _found_iodata:
+        raise ImportError("You must install `horton` to use this function.")
+    if (_found_iodata):
+        return 3
+    elif (_found_horton):
+        return 2
+
+def makehorton(ccdat):
+    """ Create horton IOData object from ccData object """
+    
+    hortonver = check_horton()
+    attributes = {}
+    
+    if (hortonver == 2):
+        pass # Populate with bridge for horton 2 in later PR
+    elif (hortonver == 3):
+        pass # Populate with bridge for horton 3 in later PR
+    
+    return IOData(**attributes) # Pass collected attributes into IOData constructor
+    
+def makecclib(iodat):
+    """ Create cclib ccData object from horton IOData object """
+    
+    hortonver = check_horton()
+    attributes = {}
+    
+    if(hortonver == 2):
+        pass
+    elif (hortonver == 3):
+        pass
+    
+    return ccData(attributes)
+    

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -54,7 +54,32 @@ def makehorton(ccdat):
     attributes = {}
 
     if hortonver == 2:
-        pass  # Populate with bridge for horton 2 in later PR
+        renameAttrs = {"atomnos": "numbers", "mult": "ms2", "polarizability": "polar"}
+        inputattrs = ccdat.__dict__
+
+        attributes = dict(
+            (renameAttrs[oldKey], val)
+            for (oldKey, val) in inputattrs.items()
+            if (oldKey in renameAttrs)
+        )
+
+        # Rest of attributes need some manupulation in data structure
+        if hasattr(ccdat, "atomcoords"):
+            # cclib parses the whole history of coordinates in the list, horton keeps the last one.
+            attributes["coordinates"] = ccdat.atomcoords[-1]
+        if hasattr(ccdat, "mocoeffs"):
+            attributes["orb_alpha"] = ccdat.mocoeffs[0]
+            if len(ccdat.mocoeffs) == 2:
+                attributes["orb_beta"] = ccdat.mocoeffs[1]
+        if hasattr(ccdat, "coreelectrons") and isinstance(
+            ccdat.coreelectrons, numpy.ndarray
+        ):  # type-checked
+            attributes["pseudo_numbers"] = ccdat.coreelectrons
+        if hasattr(ccdat, "atomcharges") and ("mulliken" in ccdat.atomcharges):
+            attributes["mulliken_charges"] = ccdat.atomcharges["mulliken"]
+        if hasattr(ccdat, "atomcharges") and ("natural" in ccdat.atomcharges):
+            attributes["npa_charges"] = ccdat.atomcharges["natural"]
+
     elif hortonver == 3:
         pass  # Populate with bridge for horton 3 in later PR
 

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -36,7 +36,9 @@ if _found_iodata:
 
 def check_horton():
     if _old_horton:
-        raise ImportError("You must have at least version 2 of `horton` to use this function.")
+        raise ImportError(
+            "You must have at least version 2 of `horton` to use this function."
+        )
     elif not _found_horton and not _found_iodata:
         raise ImportError("You must install `horton` to use this function.")
     if _found_iodata:
@@ -52,7 +54,32 @@ def makehorton(ccdat):
     attributes = {}
 
     if hortonver == 2:
-        pass  # Populate with bridge for horton 2 in later PR
+        renameAttrs = {"atomnos": "numbers", "mult": "ms2", "polarizability": "polar"}
+        inputattrs = ccdat.__dict__
+
+        attributes = dict(
+            (renameAttrs[oldKey], val)
+            for (oldKey, val) in inputattrs.items()
+            if (oldKey in renameAttrs)
+        )
+
+        # Rest of attributes need some manupulation in data structure
+        if hasattr(ccdat, "atomcoords"):
+            # cclib parses the whole history of coordinates in the list, horton keeps the last one.
+            attributes["coordinates"] = ccdat.atomcoords[-1]
+        if hasattr(ccdat, "mocoeffs"):
+            attributes["orb_alpha"] = ccdat.mocoeffs[0]
+            if len(ccdat.mocoeffs) == 2:
+                attributes["orb_beta"] = ccdat.mocoeffs[1]
+        if hasattr(ccdat, "coreelectrons") and isinstance(
+            ccdat.coreelectrons, numpy.ndarray
+        ):  # type-checked
+            attributes["pseudo_numbers"] = ccdat.atomnos - ccdat.coreelectrons
+        if hasattr(ccdat, "atomcharges") and ("mulliken" in ccdat.atomcharges):
+            attributes["mulliken_charges"] = ccdat.atomcharges["mulliken"]
+        if hasattr(ccdat, "atomcharges") and ("natural" in ccdat.atomcharges):
+            attributes["npa_charges"] = ccdat.atomcharges["natural"]
+
     elif hortonver == 3:
         pass  # Populate with bridge for horton 3 in later PR
 

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -125,7 +125,24 @@ def makecclib(iodat):
                 attributes["atomcharges"]["natural"] = iodat.npa_charges
         elif hasattr(iodat, "npa_charges"):
             attributes["atomcharges"] = {"natural": iodat.npa_charges}
-    elif hortonver == 3:
-        pass
 
+    elif hortonver == 3:
+        # Horton 3 IOData class uses attr and does not have __dict__.
+        if hasattr(iodat, "atcoords"):
+            # cclib parses the whole history of coordinates in the list, horton keeps the last one.
+            attributes["atomcoords"] = [iodat.atcoords]
+        if hasattr(iodat, "mo"):
+            # MO coefficient should be transposed to match the dimensions.
+            attributes["mocoeffs"] = [iodat.mo.coeffs[: iodat.mo.norba].T]
+            if iodat.mo.kind == "unrestricted":
+                attributes["mocoeffs"].append(iodat.mo.coeffs[iodat.mo.norba :].T)
+        if hasattr(iodat, "spinpol"):
+            # IOData stores 2S, ccData stores 2S+1.
+            attributes["mult"] = iodat.spinpol + 1
+        if hasattr(iodat, "atnums"):
+            attributes["atnums"] = iodat.atnums
+        if hasattr(iodat, "atcorenums"):
+            attributes["coreelectrons"] = iodat.atnums - iodat.atcorenums
+        if hasattr(iodat, "atcharges"):
+            attributes["atomcharges"] = iodat.atcharges
     return ccData(attributes)

--- a/cclib/method/becke.py
+++ b/cclib/method/becke.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Calculation of Becke charges using bridge to horton."""
+
+import random
+
+import numpy
+
+from cclib.parser.utils import find_package
+from cclib.method.population import Population
+from cclib.method.density import Density
+from cclib.bridge.cclib2horton import makehorton
+
+class Becke(Method):
+    """Becke Population Analysis"""
+
+    def __init__(self, *args):
+
+        # Call the __init__ method of the superclass.
+        super(Becke, self).__init__(logname="Becke Population Analysis", *args)
+        
+        # horton 3 does not have denspart released yet
+        try:
+            from horton import __version__
+        except:
+            raise ImportError(
+                "You must have horton 2 installed to use this function."
+            )
+        else:
+            from horton import BeckeMolGrid
+            from horton import getgobasis
+            from horton.matrix.dense import DenseTwoIndex
+
+    def __str__(self):
+        """Return a string representation of the object."""
+        return "Becke charges of {}".format(self.data)
+
+    def __repr__(self):
+        """Return a representation of the object."""
+        return "Becke({})".format(self.data)
+
+    def calculate(self, indices=None, fupdate=0.05):
+        """Perform a Becke population analysis."""
+        # Based on horton documentation
+        # (https://theochem.github.io/horton/2.1.0/user_postproc_aim.html#horton-wpart-py-aim-analysis-based-on-a-wavefunction-file)
+        # Use bridging function to create horton IOData object
+        iodat = makehorton(self.data)
+        
+        # Calculate density matrix and convert to object used in horton
+        d = Density(self.data)
+        d.calculate()
+        den = DenseTwoIndex(len(iodat.orb_alpha))
+        
+        if len(d.density) == 1:
+            # restricted case
+            den._array = d.density[0]
+        elif len(d.density) == 2:
+            # unrestricted case
+            den._array = d.density[0] + d.density[1]
+        
+        # Create integration grid
+        grid = BeckeMolGrid(iodat.coordinates, iodat.numbers, iodat.pseudo_numbers, mode='only')
+        
+        # Define Gaussian basis set
+        # -- This needs to be modified so that it first generates GOBasisFamily instance from cclib's gbasis attribute and passes it to 'default' argument
+        gob = get_gobasis(iodat.coordinates, iodat.numbers, default = 'STO-3G')
+
+        # Calculate grid density
+        moldens = gob.compute_grid_density_dm(den, grid.points)
+        
+        # Partition charges
+        self.logger.info("Creating fragcharges: array[1]")
+        wpart = BeckeWPart(ht.coordinates, ht.numbers, ht.pseudo_numbers, grid, moldens, local=True)
+        wpart.do_charges()
+        
+        # Save charges into applicable format
+        self.fragcharges = wpart['charges']
+
+        return True

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -56,8 +56,13 @@ class HortonTest(unittest.TestCase):
                     self._hortonver = 2
                     self.iodat = IOData.from_file(inputfile)
         if self._found_iodata:
-            # Add horton 3 import lines
-            pass
+            from iodata import IOData
+            from iodata.orbitals import MolecularOrbitals
+            from iodata.api import load_one
+
+            self._hortonver = 3
+
+            self.iodat = load_one(filename=inputfile)
 
     def test_makehorton(self):
         """ Check that the bridge from cclib to horton works correctly """
@@ -139,6 +144,7 @@ class HortonTest(unittest.TestCase):
                         cclibequiv.atomcharges[chg][0],
                         decimal=3,
                     )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -56,56 +56,11 @@ class HortonTest(unittest.TestCase):
                     self._hortonver = 2
                     self.iodat = IOData.from_file(inputfile)
         if self._found_iodata:
-            from iodata import IOData
-            from iodata.orbitals import MolecularOrbitals
-            from iodata.api import load_one
-
-            self._hortonver = 3
-
-            self.iodat = load_one(filename=inputfile)
+            # Add horton 3 import lines
+            pass
 
     def test_makehorton(self):
-        """ Check that the bridge from cclib to horton works correctly """
-        # First use `makehorton` function to generate IOData object converted from cclib ccData
-        hortonequiv = cclib2horton.makehorton(self.data)
-
-        if self._hortonver == 2:
-            # Identify attributes that should be verified
-            check = ["pseudo_numbers", "ms2"]  # float or int
-            checkArr = [
-                "coordinates",
-                "numbers",
-                "orb_alpha",
-                "orb_beta",
-                "mulliken_charges",
-                "npa_charges",
-            ]  # one dimensional arrays
-            checkArrArr = ["polar"]  # two dimensional arrays
-
-            for attr in check:
-                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
-                    self.assertAlmostEqual(
-                        getattr(self.iodat, attr),
-                        getattr(hortonequiv, attr),
-                        delta=1.0e-3,
-                    )
-
-            for attr in checkArr:
-                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
-                    assert_array_almost_equal(
-                        getattr(self.iodat, attr), getattr(hortonequiv, attr), decimal=3
-                    )
-
-            for attr in checkArrArr:
-                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
-                    assert_array_almost_equal(
-                        getattr(self.iodat, attr)[0],
-                        getattr(hortonequiv, attr)[0],
-                        decimal=3,
-                    )
-
-        elif self._hortonver == 3:
-            pass
+        pass
 
     def test_makecclib(self):
         """ Check that the bridge from horton to cclib works correctly """

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -24,9 +24,15 @@ class HortonTest(unittest.TestCase):
     def setUp(self):
         super(HortonTest, self).setUp()
 
-        self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"])
-        datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "data"))
-        inputfile = os.path.join(datadir, "Gaussian", "basicGaussian16", "dvb_un_sp.fchk")
+        self.data, self.logfile = getdatafile(
+            "Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"]
+        )
+        datadir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "data")
+        )
+        inputfile = os.path.join(
+            datadir, "Gaussian", "basicGaussian16", "dvb_un_sp.fchk"
+        )
 
         self._old_horton = False
         self._found_horton = find_package("horton")
@@ -54,7 +60,47 @@ class HortonTest(unittest.TestCase):
             pass
 
     def test_makehorton(self):
-        pass
+        """ Check that the bridge from cclib to horton works correctly """
+        # First use `makehorton` function to generate IOData object converted from cclib ccData
+        hortonequiv = cclib2horton.makehorton(self.data)
+
+        if self._hortonver == 2:
+            # Identify attributes that should be verified
+            check = ["pseudo_numbers", "ms2"]  # float or int
+            checkArr = [
+                "coordinates",
+                "numbers",
+                "orb_alpha",
+                "orb_beta",
+                "mulliken_charges",
+                "npa_charges",
+            ]  # one dimensional arrays
+            checkArrArr = ["polar"]  # two dimensional arrays
+
+            for attr in check:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    self.assertAlmostEqual(
+                        getattr(self.iodat, attr),
+                        getattr(hortonequiv, attr),
+                        delta=1.0e-3,
+                    )
+
+            for attr in checkArr:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    assert_array_almost_equal(
+                        getattr(self.iodat, attr), getattr(hortonequiv, attr), decimal=3
+                    )
+
+            for attr in checkArrArr:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    assert_array_almost_equal(
+                        getattr(self.iodat, attr)[0],
+                        getattr(hortonequiv, attr)[0],
+                        decimal=3,
+                    )
+
+        elif self._hortonver == 3:
+            pass
 
     def test_makecclib(self):
         """ Check that the bridge from horton to cclib works correctly """
@@ -89,7 +135,9 @@ class HortonTest(unittest.TestCase):
             for chg in checkChg:
                 if chg in self.data.atomcharges and chg in cclibequiv.atomcharges:
                     assert_array_almost_equal(
-                        self.data.atomcharges[chg][0], cclibequiv.atomcharges[chg][0], decimal=3
+                        self.data.atomcharges[chg][0],
+                        cclibequiv.atomcharges[chg][0],
+                        decimal=3,
                     )
 
 

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -140,6 +140,5 @@ class HortonTest(unittest.TestCase):
                         decimal=3,
                     )
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -56,8 +56,13 @@ class HortonTest(unittest.TestCase):
                     self._hortonver = 2
                     self.iodat = IOData.from_file(inputfile)
         if self._found_iodata:
-            # Add horton 3 import lines
-            pass
+            from iodata import IOData
+            from iodata.orbitals import MolecularOrbitals
+            from iodata.api import load_one
+
+            self._hortonver = 3
+
+            self.iodat = load_one(filename=inputfile)
 
     def test_makehorton(self):
         """ Check that the bridge from cclib to horton works correctly """

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -60,7 +60,47 @@ class HortonTest(unittest.TestCase):
             pass
 
     def test_makehorton(self):
-        pass
+        """ Check that the bridge from cclib to horton works correctly """
+        # First use `makehorton` function to generate IOData object converted from cclib ccData
+        hortonequiv = cclib2horton.makehorton(self.data)
+
+        if self._hortonver == 2:
+            # Identify attributes that should be verified
+            check = ["pseudo_numbers", "ms2"]  # float or int
+            checkArr = [
+                "coordinates",
+                "numbers",
+                "orb_alpha",
+                "orb_beta",
+                "mulliken_charges",
+                "npa_charges",
+            ]  # one dimensional arrays
+            checkArrArr = ["polar"]  # two dimensional arrays
+
+            for attr in check:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    self.assertAlmostEqual(
+                        getattr(self.iodat, attr),
+                        getattr(hortonequiv, attr),
+                        delta=1.0e-3,
+                    )
+
+            for attr in checkArr:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    assert_array_almost_equal(
+                        getattr(self.iodat, attr), getattr(hortonequiv, attr), decimal=3
+                    )
+
+            for attr in checkArrArr:
+                if hasattr(self.iodat, attr) and hasattr(hortonequiv, attr):
+                    assert_array_almost_equal(
+                        getattr(self.iodat, attr)[0],
+                        getattr(hortonequiv, attr)[0],
+                        decimal=3,
+                    )
+
+        elif self._hortonver == 3:
+            pass
 
     def test_makecclib(self):
         """ Check that the bridge from horton to cclib works correctly """

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+import unittest
+import os, sys
+import numpy
+
+from cclib.bridge import cclib2horton
+from ..test_data import getdatafile
+from cclib.parser.utils import find_package
+
+from numpy.testing import assert_array_almost_equal
+
+
+class HortonTest(unittest.TestCase):
+    """ Tests for the horton bridge in cclib """
+
+    # Both horton and cclib can read in fchk files. The test routine utilizes this fact and compares the attributes that were directly loaded from each package and the attributes that were converted.
+
+    def setUp(self):
+        super(HortonTest, self).setUp()
+
+        self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"])
+        datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "data"))
+        inputfile = os.path.join(datadir, "Gaussian", "basicGaussian16", "dvb_un_sp.fchk")
+
+        self._old_horton = False
+        self._found_horton = find_package("horton")
+        self._found_iodata = find_package("iodata")
+
+        if self._found_horton:
+            try:
+                from horton import __version__
+            except:
+                self._old_horton = (
+                    True  # Old horton versions do not have this __version__ attribute
+                )
+            else:
+                if __version__[0] == "2":
+                    from horton.io.iodata import IOData
+                    from horton import log
+
+                    log.set_level(
+                        0
+                    )  # This suppresses horton outputs so that they do not flood the test log.
+                    self._hortonver = 2
+                    self.iodat = IOData.from_file(inputfile)
+        if self._found_iodata:
+            # Add horton 3 import lines
+            pass
+
+    def test_makehorton(self):
+        pass
+
+    def test_makecclib(self):
+        """ Check that the bridge from horton to cclib works correctly """
+        # First use `makecclib` function to generate ccData object converted from horton IOData
+        cclibequiv = cclib2horton.makecclib(self.iodat)
+
+        # Identify attributes that should be verified
+        check = ["mult", "coreelectrons"]  # float or int
+        checkArr = ["atomcoords", "atomnos", "mocoeffs"]  # one dimensional arrays
+        checkArrArr = ["polarizability"]  # two dimensional arrays
+        checkChg = ["mulliken", "natural"]  # partial charges
+
+        for attr in check:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                self.assertAlmostEqual(
+                    getattr(self.data, attr), getattr(cclibequiv, attr), delta=1.0e-3
+                )
+
+        for attr in checkArr:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                assert_array_almost_equal(
+                    getattr(self.data, attr), getattr(cclibequiv, attr), decimal=3
+                )
+
+        for attr in checkArrArr:
+            if hasattr(self.data, attr) and hasattr(cclibequiv, attr):
+                assert_array_almost_equal(
+                    getattr(self.data, attr)[0], getattr(cclibequiv, attr)[0], decimal=3
+                )
+
+        if hasattr(self.data, "atomcharges") and hasattr(cclibequiv, "atcomcharges"):
+            for chg in checkChg:
+                if chg in self.data.atomcharges and chg in cclibequiv.atomcharges:
+                    assert_array_almost_equal(
+                        self.data.atomcharges[chg][0], cclibequiv.atomcharges[chg][0], decimal=3
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -105,7 +105,34 @@ class HortonTest(unittest.TestCase):
                     )
 
         elif self._hortonver == 3:
-            pass
+            # Identify attributes that should be verified
+            check = ["spinpol"]  # float or int
+            checkArr = ["atcoords", "atnums", "atcorenums"]  # one dimensional arrays
+
+            # IOData in horton 3 uses attr and initializes all possible attributes by default value of None. Thus, hasattr cannot be used here by its own.
+            for attr in check:
+                if (
+                    hasattr(self.iodat, attr)
+                    and hasattr(hortonequiv, attr)
+                    and getattr(self.iodat, attr) != None
+                    and getattr(hortonequiv, attr) != None
+                ):
+                    self.assertAlmostEqual(
+                        getattr(self.iodat, attr),
+                        getattr(hortonequiv, attr),
+                        delta=1.0e-3,
+                    )
+
+            for attr in checkArr:
+                if (
+                    hasattr(self.iodat, attr)
+                    and hasattr(hortonequiv, attr)
+                    and isinstance(getattr(self.iodat, attr), numpy.ndarray)
+                    and isinstance(getattr(hortonequiv, attr), numpy.ndarray)
+                ):
+                    assert_array_almost_equal(
+                        getattr(self.iodat, attr), getattr(hortonequiv, attr), decimal=3
+                    )
 
     def test_makecclib(self):
         """ Check that the bridge from horton to cclib works correctly """
@@ -144,6 +171,7 @@ class HortonTest(unittest.TestCase):
                         cclibequiv.atomcharges[chg][0],
                         decimal=3,
                     )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -145,6 +145,5 @@ class HortonTest(unittest.TestCase):
                         decimal=3,
                     )
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -15,6 +15,7 @@ sys.path.insert(1, "bridge")
 if sys.version_info[0] == 3:
     if sys.version_info[1] >= 6:
         from .bridge.testpsi4 import *
+        from .bridge.testhorton import *
     if sys.version_info[1] >= 4:
         from .bridge.testbiopython import *
 from .bridge.testopenbabel import *

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -20,8 +20,8 @@ if sys.version_info[0] == 3:
 from .bridge.testopenbabel import *
 
 if sys.version_info[0] == 2:
+    from .bridge.testhorton import *
     from .bridge.testpyquante import *
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.


### PR DESCRIPTION
Related Issue: #880 

This is a draft PR intended to ask for input on whether it would be necessary to have wrapper methods that basically take care of the steps needed to calculate population analysis methods in `horton`, using the bridge function. An alternative is to provide a similar example code in the documentation.

If we decide to create a wrapper, some decisions may have to be made on whether a parent class for `cclib.method.Population` needs to be created. (b/c some charges are not based on the basis sets and will not have `aoresults`.)

Implementation not intended to work / tested at the moment