### PR TITLE
Add pyquante2 to Travis configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ biopython==1.76
 openbabel==2.4.1
 # For some reason PyQuante can't be installed from PyPI.
 https://sourceforge.net/projects/pyquante/files/PyQuante-1.6/PyQuante-1.6.5/PyQuante-1.6.5.tar.gz  ; python_version <= '2.7'
+git+https://github.com/rpmuller/pyquante2.git ; python_version > '3.0'
 
 # For building the documentation
 sphinx


### PR DESCRIPTION
Related Issue: #886 

This is a first PR associated with issue #886. It adds pyquante2 into the list of packages to install for Travis builds. Subsequent PRs will build upon this PR.