### PR TITLE
Add pyquante2 routines in volume method

### DIFF
--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -43,8 +43,8 @@ class VolumeTest(unittest.TestCase):
         integral = wavefn.integrate()
         integral_square = wavefn.integrate_square()
 
-        self.assertTrue(abs(integral) < 1e-6) # not necessarily true for all wavefns
-        self.assertTrue(abs(integral_square - 1.00) < 1e-3) #   true for all wavefns
+        self.assertAlmostEqual(integral, 0, delta = 1e-6) # not necessarily true for all wavefns
+        self.assertAlmostEqual(integral_square, 1.00, delta = 1e-2) # true for all wavefns
         print(integral, integral_square)
 
     def test_density(self):

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -19,9 +19,7 @@ from .method.testmoments import *
 from .method.testnuclear import *
 from .method.testorbitals import *
 from .method.testpopulation import *
-
-if sys.version_info[0] == 2:
-    from .method.testvolume import *
+from .method.testvolume import *
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_Related Issue: #886
Builds upon: #896_ 


This PR updates volume method to support pyquante2.

Subsequent PR would build upon this PR and would add more testing to the volume method (which built upon existing method and was updated in #896 and #897) so that the calculated electron densities are verified for individual points in Cartesian coordinates.