### PR TITLE
Change from numpy.nan to numpy.inf for printing full arrays

### DIFF
--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -91,7 +91,7 @@ def ccget():
 
     # Toggle full print behaviour for numpy arrays.
     if full:
-        numpy.set_printoptions(threshold=numpy.nan)
+        numpy.set_printoptions(threshold=numpy.inf)
 
     # We need at least one attribute and the filename, so two arguments, or
     # just one filename if we want to list attributes that can be extracted.


### PR DESCRIPTION
Previously the `numpy.nan` was causing an error. 
```
Traceback (most recent call last):
  File "/home/shiv/.local/bin/ccget", line 11, in <module>
    load_entry_point('cclib', 'console_scripts', 'ccget')()
  File "/home/shiv/Documents/cclib/cclib/scripts/ccget.py", line 94, in ccget
    numpy.set_printoptions(threshold=numpy.nan)
  File "/home/shiv/.local/lib/python3.8/site-packages/numpy/core/arrayprint.py", line 257, in set_printoptions
    opt = _make_options_dict(precision, threshold, edgeitems, linewidth,
  File "/home/shiv/.local/lib/python3.8/site-packages/numpy/core/arrayprint.py", line 95, in _make_options_dict
    raise ValueError("threshold must be non-NAN, try "
ValueError: threshold must be non-NAN, try sys.maxsize for untruncated representation
```
`numpy.inf` is [accepted as well which seems more explicit](https://stackoverflow.com/questions/1987694/how-to-print-the-full-numpy-array-without-truncation) than `sys.maxsize`