### PR TITLE
PySCF bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
         source activate p4env
         conda install pytest pytest-cov codecov -c conda-forge
-        pip install pytest-shutil h5py
+        pip install pytest-shutil h5py pyscf
         pip install git+https://github.com/theochem/iodata.git
         
         conda list
@@ -52,7 +52,7 @@ before_install:
         
         source activate hortonenv
         conda install pytest pytest-cov codecov -c conda-forge
-        pip install pytest-shutil
+        pip install pytest-shutil pyscf
         conda list
     
     else

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Bridge for using cclib data in PySCF (https://github.com/pyscf/pyscf)."""
+
+from cclib.parser.utils import find_package
+
+_found_pyscf = find_package("pyscf")
+if _found_pyscf:
+    from pyscf import gto
+
+
+def _check_pyscf(found_pyscf):
+    if not found_pyscf:
+        raise ImportError("You must install `pyscf` to use this function")
+
+
+def makepyscf(atomcoords, atomnos, charge=0, mult=1):
+    """Create a Pyscf Molecule."""
+    _check_pyscf(_found_pyscf)
+    mol = gto.Mole(
+        atom = [['{}'.format(atomnos[i]),atomcoords[i]] for i in range(len(atomcoords))],
+        unit="Angstrom",
+        charge=charge,
+        multiplicity=mult
+    )
+    return  mol
+  
+del find_package

--- a/test/bridge/testpsi4.py
+++ b/test/bridge/testpsi4.py
@@ -22,10 +22,11 @@ class Psi4Test(unittest.TestCase):
         psi4.core.set_output_file("psi4_output.dat", False)
 
         atomnos = np.array([1, 8, 1], "i")
-        a = np.array([[-1, 1, 0], [0, 0, 0], [1, 1, 0]], "f")
-        psi4mol = cclib2psi4.makepsi4(a, atomnos)
+        atomcoords = np.array([[-1, 1, 0], [0, 0, 0], [1, 1, 0]], "f")
+        psi4mol = cclib2psi4.makepsi4(atomcoords, atomnos)
+        psi4.set_options({'scf_type': 'pk'})
         en = energy("scf/6-31G**", molecule=psi4mol)
-        ref = -75.82474605514503
+        ref = -75.824754602
         assert abs(en - ref) < 1.0e-6
 
 

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -24,6 +24,7 @@ class PyscfTest(unittest.TestCase):
         pyscfmol = cclib2pyscf.makepyscf(atomcoords, atomnos)
         pyscfmol.basis = "6-31G**"
         pyscfmol.cart = True
+        pyscfmol.verbose = 0
         pyscfmol.build()
 
         mhf = pyscfmol.HF(conv_tol=1e-6)

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+import unittest
+
+import numpy as np
+
+from cclib.bridge import cclib2pyscf
+
+
+class PyscfTest(unittest.TestCase):
+    """Tests for the cclib2pyscf bridge in cclib."""
+
+    def test_makepyscf(self):
+        import pyscf
+        from pyscf import scf
+
+        atomnos = np.array([1, 8, 1], "i")
+        atomcoords = np.array([[-1, 1, 0], [0, 0, 0], [1, 1, 0]], "f")
+        pyscfmol = cclib2pyscf.makepyscf(atomcoords, atomnos)
+        pyscfmol.basis = "6-31G**"
+        pyscfmol.cart = True
+        pyscfmol.build()
+
+        mhf = pyscfmol.HF(conv_tol=1e-6)
+        en = mhf.kernel()
+        ref = -75.824754602
+        assert abs(en - ref) < 1.0e-6
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -15,6 +15,7 @@ sys.path.insert(1, "bridge")
 if sys.version_info[0] == 3:
     if sys.version_info[1] >= 6:
         from .bridge.testpsi4 import *
+        from .bridge.testpyscf import *
         from .bridge.testhorton import Horton3Test
     if sys.version_info[1] >= 4:
         from .bridge.testbiopython import *


### PR DESCRIPTION
A small PR to add a PySCF bridge and a unit. If there is anything missing from this list, please let me know!
I added a slightly more converged answer to the Psi4 test to allow for consistency between the reference values for the psi4 and the PySCF test. Consistency between these two tests is also the reason for the Cartesian basis functions being used in Pyscf even though that's not the default.

Progress.
- [x] Write the basic bridge to PySCF
- [x] Write corresponding test
- [x] Incorporate PySCF into Travis testing