### PR TITLE
Set up the grid and calculate localized charge and stockholder-type charge for DDEC6

### DIFF
--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -229,6 +229,10 @@ class Volume(object):
         with open(filename, "w") as outputfile:
             outputfile.write("\n".join(ans))
 
+    def coordinates(self, indices):
+        """Return [x, y, z] coordinates that correspond to input indices"""
+        return self.origin + self.spacing * indices
+
 
 def scinotation(num):
     """Write in scientific notation."""

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -82,3 +82,16 @@ class DDEC6Test(unittest.TestCase):
         assert_allclose(self.analysis.proatom_density[0][0:5], refO_den, rtol=1e-3)
         assert_allclose(self.analysis.proatom_density[1][0:5], refH_den, rtol=1e-3)
         assert_allclose(self.analysis.proatom_density[2][0:5], refH_den, rtol=1e-3)
+
+    def test_step1_charges(self):
+        """Are step 1 charges calculated correctly?"""
+
+        self.parse()
+        # use precalculated fine cube file
+        imported_vol = volume.read_from_cube(os.path.join(os.path.dirname(os.path.realpath(__file__)), "water_fine.cube"))
+        
+        analysis = DDEC6(self.data, imported_vol, os.path.dirname(os.path.realpath(__file__)))
+        analysis.calculate()
+        
+        # values from `chargemol` calculation
+        assert_allclose(analysis.refcharges, [-0.513006, 0.256231, 0.256775], rtol=.1)


### PR DESCRIPTION
_Related Issue: #885 
Builds upon: #914 and #917_

This PR finishes setting up the integration grid for DDEC6 charges based on what has been read through the function added in PR 914. Also, it calculates stockholder charges and localized charges to evaluate reference charges. This amounts to the 'first' step in the seven-step-long DDEC6 algorithm as described in the original paper.

Test suite compares the results with what was obtained in `chargemol`.