### PR TITLE
Add optional weight argument for integrate method in volume

### DIFF
--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -213,10 +213,8 @@ class Bader(Method):
         self.fragcharges = numpy.zeros(len(self.data.atomcoords[-1]), "d")
 
         for atom_index, baderarea_index in enumerate(self.matches):
-            # turn off all other grid points
-            chargedensity = copy.deepcopy(self.chgdensity)
-            mask = self.fragresults == baderarea_index
-            chargedensity.data *= mask
-            self.fragcharges[atom_index] = chargedensity.integrate()
+            self.fragcharges[atom_index] = self.chgdensity.integrate(
+                weights=(self.fragresults == baderarea_index)
+            )
 
         return True

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -178,23 +178,28 @@ class Volume(object):
         )
         v.tofile(filename)
 
-    def integrate(self):
-        boxvol = (
-            self.spacing[0]
-            * self.spacing[1]
-            * self.spacing[2]
-            * convertor(1, "Angstrom", "bohr") ** 3
-        )
-        return sum(self.data.ravel()) * boxvol
+    def integrate(self, weights=None):
+        weights = numpy.ones_like(self.data) if weights is None else weights
 
-    def integrate_square(self):
         boxvol = (
             self.spacing[0]
             * self.spacing[1]
             * self.spacing[2]
             * convertor(1, "Angstrom", "bohr") ** 3
         )
-        return sum(self.data.ravel() ** 2) * boxvol
+
+        return numpy.sum(self.data * weights) * boxvol
+
+    def integrate_square(self, weights=None):
+        weights = numpy.ones_like(self.data) if weights is None else weights
+
+        boxvol = (
+            self.spacing[0]
+            * self.spacing[1]
+            * self.spacing[2]
+            * convertor(1, "Angstrom", "bohr") ** 3
+        )
+        return numpy.sum((self.data * weights) ** 2) * boxvol
 
     def writeascube(self, filename):
         # Remember that the units are bohr, not Angstroms


### PR DESCRIPTION
From [#915](https://github.com/cclib/cclib/pull/915#discussion_r464784099)
Related: #885 

This PR adds an optional argument of weights applied on each grid point for `integrate` and `integrate_square` method of `Volume` class.
`Bader` class has been modified as well to take advantage of the optional argument.

`DDEC6` class will also be modified accordingly based on this PR.