### PR TITLE
Add a function that conditions reference density in DDEC6

### DIFF
--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -79,11 +79,9 @@ class DDEC6(Method):
             pt1 and pt2 are numpy arrays representing a point in Cartesian coordinates. """
         return numpy.sqrt(numpy.dot(pt1 - pt2, pt1 - pt2))
 
-    def _read_proatom(self, 
-                      directory,        # type = str
-                      atom_num,         # type = int
-                      charge            # type = float
-                      ):
+    def _read_proatom(
+        self, directory, atom_num, charge  # type = str  # type = int  # type = float
+    ):
         # type: (...) -> numpy.ndarray, numpy.ndarray
         """Return a list containing proatom reference densities."""
         # TODO: Treat calculations with psuedopotentials
@@ -100,17 +98,20 @@ class DDEC6(Method):
         # the densities of the ion/atom with floor(charge) and ceiling(charge)
         charge_floor = int(math.floor(charge))
         charge_ceil = int(math.ceil(charge))
-        
+
         chargemol_path_floor = os.path.join(
             directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(atom_num, atom_num, atom_num - charge_floor),
+            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
+                atom_num, atom_num, atom_num - charge_floor
+            ),
         )
         chargemol_path_ceil = os.path.join(
             directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(atom_num, atom_num, atom_num - charge_ceil),
+            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
+                atom_num, atom_num, atom_num - charge_ceil
+            ),
         )
         horton_path = os.path.join(directory, "atoms.h5")
-
 
         if os.path.isfile(chargemol_path_floor) or os.path.isfile(chargemol_path_ceil):
             # Use chargemol proatom densities
@@ -124,9 +125,11 @@ class DDEC6(Method):
                 density_ceil = numpy.array([0])
             else:
                 density_ceil = numpy.loadtxt(chargemol_path_ceil, skiprows=12, dtype=float)
-            
-            density = (charge_ceil - charge) * density_floor + (charge - charge_floor) * density_ceil
-            radiusgrid = numpy.arange(1, len(density + 1)) * 0.05
+
+            density = (charge_ceil - charge) * density_floor + (
+                charge - charge_floor
+            ) * density_ceil
+            radiusgrid = numpy.arange(1, len(density) + 1) * 0.05
 
         elif os.path.isfile(horton_path):
             # Use horton proatom densities
@@ -141,7 +144,7 @@ class DDEC6(Method):
                 else:
                     keystring_floor = "Z={}_Q={:+d}".format(atom_num, charge_floor)
                     density_floor = numpy.asanyarray(list(proatomdb[keystring_floor]["rho"]))
-                    
+
                     # gridspec is specification of integration grid for proatom densities in horton.
                     # Example -- ['PowerRTransform', '1.1774580743206259e-07', '20.140888089596444', '41']
                     #   is constructed using PowerRTransform grid
@@ -149,21 +152,23 @@ class DDEC6(Method):
                     #        rmax = 20.140888089596444
                     #   and  ngrid = 41
                     # PowerRTransform is default in horton-atomdb.py.
-                    gridtype, gridmin, gridmax, gridn = proatomdb[keystring_floor].attrs["rtransform"].split()
+                    gridtype, gridmin, gridmax, gridn = (
+                        proatomdb[keystring_floor].attrs["rtransform"].split()
+                    )
                     gridmin = convertor(float(gridmin), "bohr", "Angstrom")
                     gridmax = convertor(float(gridmax), "bohr", "Angstrom")
                     gridn = int(gridn)
                     # Convert byte to string in Python3
                     if sys.version[0] == "3":
                         gridtype = gridtype.decode("UTF-8")
-    
+
                     # First verify that it is one of recognized grids
                     assert gridtype in [
                         "LinearRTransform",
                         "ExpRTransform",
                         "PowerRTransform",
                     ], "Grid type not recognized."
-    
+
                     if gridtype == "LinearRTransform":
                         # Linear transformation. r(t) = rmin + t*(rmax - rmin)/(npoint - 1)
                         gridcoeff = (gridmax - gridmin) / (gridn - 1)
@@ -184,7 +189,9 @@ class DDEC6(Method):
                     keystring_ceil = "Z={}_Q={:+d}".format(atom_num, charge_ceil)
                     density_ceil = numpy.asanyarray(list(proatomdb[keystring_ceil]["rho"]))
 
-                density = (charge_ceil - charge) * density_floor + (charge - charge_floor) * density_ceil
+                density = (charge_ceil - charge) * density_floor + (
+                    charge - charge_floor
+                ) * density_ceil
 
                 del h5py
 
@@ -240,7 +247,9 @@ class DDEC6(Method):
         self.proatom_density = []
         self.radial_grid_r = []
         for i, atom_number in enumerate(self.data.atomnos):
-            density, r = self._read_proatom(self.proatom_path, atom_number, float(self.refcharges[0][i]))
+            density, r = self._read_proatom(
+                self.proatom_path, atom_number, float(self.refcharges[0][i])
+            )
             self.proatom_density.append(density)
             self.radial_grid_r.append(r)
 
@@ -250,7 +259,25 @@ class DDEC6(Method):
         self._localizedcharges.append(loc)
         self._stockholdercharges.append(stock)
 
+        # STEP 3
+        # Load new proatom densities.
+        self.proatom_density = []
+        self.radial_grid_r = []
+        for i, atom_number in enumerate(self.data.atomnos):
+            density, r = self._read_proatom(
+                self.proatom_path, atom_number, float(self.refcharges[1][i])
+            )
+            self.proatom_density.append(density)
+            self.radial_grid_r.append(r)
+
+        # Carry out step 3 of DDEC6 algorithm [Determine conditioned charge density and tau]
+        self.logger.info("Conditioning charge densities.")
+        self.condition_densities()
+
     def calculate_refcharges(self):
+        """ Calculate reference charges from proatom density and molecular density
+            [STEP 1 and 2]
+        """
         # Generator object to iterate over the grid
         xshape, yshape, zshape = self.chgdensity.data.shape
         atoms = len(self.data.atomnos)
@@ -264,6 +291,7 @@ class DDEC6(Method):
 
         stockholder_w = numpy.zeros((atoms, xshape, yshape, zshape))
         localized_w = numpy.zeros((atoms, xshape, yshape, zshape))
+        self.closest_r_index = numpy.zeros((atoms, xshape, yshape, zshape), dtype=int)
 
         for atomi, xindex, yindex, zindex in indices:
             # Distance of the grid from atom grid
@@ -271,11 +299,13 @@ class DDEC6(Method):
                 self.data.atomcoords[-1][atomi],
                 self.chgdensity.coordinates([xindex, yindex, zindex]),
             )
-            closest_r_index = numpy.abs(self.radial_grid_r[atomi] - dist_r).argmin()
+            self.closest_r_index[atomi][xindex][yindex][zindex] = numpy.abs(
+                self.radial_grid_r[atomi] - dist_r
+            ).argmin()
 
             # Equation 54 in doi: 10.1039/c6ra04656h
             stockholder_w[atomi][xindex][yindex][zindex] = self.proatom_density[atomi][
-                closest_r_index
+                self.closest_r_index[atomi][xindex][yindex][zindex]
             ]
 
         # Equation 55 in doi: 10.1039/c6ra04656h
@@ -300,6 +330,327 @@ class DDEC6(Method):
 
             # In DDEC6, weights of 1/3 and 2/3 are assigned for stockholder and localized charges.
             # (Equation 50 and 58 in doi: 10.1039/c6ra04656h)
-            refcharges[atomi] = (stockholdercharges[atomi] / 3.0) + (localizedcharges[atomi] * 2.0 / 3.0)
-        
+            refcharges[atomi] = (stockholdercharges[atomi] / 3.0) + (
+                localizedcharges[atomi] * 2.0 / 3.0
+            )
+
         return refcharges, localizedcharges, stockholdercharges
+
+    def condition_densities(self):
+        """ Calculate conditioned densities
+            [STEP 3]
+        """
+        # Generator object to iterate over the grid
+        xshape, yshape, zshape = self.chgdensity.data.shape
+        atoms = len(self.data.atomnos)
+        indices = (
+            (i, x, y, z)
+            for i in range(atoms)
+            for x in range(xshape)
+            for y in range(yshape)
+            for z in range(zshape)
+        )
+
+        self._rho_ref = numpy.zeros((xshape, yshape, zshape))
+
+        for atomi, xindex, yindex, zindex in indices:
+            # rho_ref -- Equation 41 in doi: 10.1039/c6ra04656h
+            self._rho_ref[xindex][yindex][zindex] += self.proatom_density[atomi][
+                self.closest_r_index[atomi][xindex][yindex][zindex]
+            ]
+
+        self._candidates_bigPhi = []
+        self._candidates_phi = []
+
+        # Initial conditions are detailed in Figure S1 in doi: 10.1039/c6ra04656h
+        phiAI = numpy.zeros_like(self.data.atomnos, dtype=float)
+        bigphiAI = numpy.zeros_like(self.data.atomnos, dtype=float)
+        self._y_a = []
+        self._cond_density = []
+
+        for atomi in range(len(self.data.atomnos)):
+            # y_a -- equation 40 in doi: 10.1039/c6ra04656h
+            self._y_a.append(self._ya(self.proatom_density, atomi))
+            # rho_A^cond -- equation S97 in doi: 10.1039/c6ra04656h
+            self._cond_density.append(
+                self._y_a[atomi] + bigphiAI[atomi] * numpy.sqrt(self._y_a[atomi])
+            )
+            # Monotonic Decrease Condition (as expressed in equation S99)
+            self._cond_density[atomi] = numpy.minimum.accumulate(self._cond_density[atomi])
+            # phi_A^I -- Equation S100 in doi: 10.1039/c6ra04656h
+            phiAI[atomi] = (
+                self._integrate_from_radial([self._cond_density[atomi]], [atomi])
+                - self.data.atomnos[atomi]
+                + self.refcharges[-1][atomi]
+            )
+
+            self._candidates_bigPhi.append([bigphiAI[atomi]])
+            self._candidates_phi.append([phiAI[atomi]])
+
+            fitphi = True  # when convergence is reached, this is modified to False.
+
+            while phiAI[atomi] <= 0:
+                # Iterative algorithm until convergence
+                # Refer to S101 in doi: 10.1039/c6ra04656h
+                bigphiAI[atomi] = 2 * bigphiAI[atomi] - phiAI[atomi] / self._integrate_from_radial(
+                    [numpy.sqrt(self._y_a[atomi])], [atomi]
+                )
+
+                # When Phi is updated, related quantities are updated as well
+                # Refer to S100 in doi: 10.1039/c6ra04656h
+                phiAI[atomi], self._cond_density[atomi] = self._phiai(
+                    self._y_a[atomi], bigphiAI[atomi], atomi
+                )
+
+                self._candidates_phi[atomi].append(phiAI[atomi])
+                self._candidates_bigPhi[atomi].append(bigphiAI[atomi])
+
+            # lowerbigPhi is largest negative Phi.
+            # upperbigPhi is smallest positive Phi.
+            if fitphi:
+                self._candidates_phi[atomi] = numpy.array(self._candidates_phi[atomi], dtype=float)
+                self._candidates_bigPhi[atomi] = numpy.array(
+                    self._candidates_bigPhi[atomi], dtype=float
+                )
+                if numpy.count_nonzero(self._candidates_phi[atomi] < 0) > 0:
+                    lower_ind = numpy.where(
+                        self._candidates_phi[atomi]
+                        == self._candidates_phi[atomi][self._candidates_phi[atomi] < 0].max()
+                    )[0][0]
+                    lowerbigPhi = self._candidates_bigPhi[atomi][lower_ind]
+                    lowerphi = self._candidates_phi[atomi][lower_ind]
+                else:  # assign some large negative number
+                    lowerbigPhi = numpy.NINF
+                    lowerphi = numpy.NINF
+                if numpy.count_nonzero(self._candidates_phi[atomi] > 0) > 0:
+                    upper_ind = numpy.where(
+                        self._candidates_phi[atomi]
+                        == self._candidates_phi[atomi][self._candidates_phi[atomi] > 0].min()
+                    )[0][0]
+                    upperbigPhi = self._candidates_bigPhi[atomi][upper_ind]
+                    upperphi = self._candidates_phi[atomi][upper_ind]
+                else:  # assign some large positive number
+                    upperbigPhi = numpy.PINF
+                    upperphi = numpy.PINF
+
+            iter = 0
+            while fitphi and iter < 50:
+                # Flow diagram on Figure S1 in doi: 10.1039/c6ra04656h details the procedure.
+                iter = iter + 1
+                midbigPhi = (lowerbigPhi + upperbigPhi) / 2.0
+                midphi = self._phiai(self._y_a[atomi], midbigPhi, atomi)[0]
+                # Exit conditions
+                if abs(lowerphi) < 1e-10:
+                    bigphiAI[atomi] = lowerbigPhi
+                    fitphi = False
+                elif abs(upperphi) < 1e-10:
+                    bigphiAI[atomi] = upperbigPhi
+                    fitphi = False
+                elif abs(midphi) < 1e-10:
+                    bigphiAI[atomi] = midbigPhi
+                    fitphi = False
+                else:
+                    # Parabolic fitting as described on Figure S1 in doi: 10.1039/c6ra04656h
+                    # Type casting here converts from size 1 numpy.ndarray to float
+                    xpts = numpy.array(
+                        [float(lowerbigPhi), float(midbigPhi), float(upperbigPhi)], dtype=float
+                    )
+                    ypts = numpy.array(
+                        [float(lowerphi), float(midphi), float(upperphi)], dtype=float
+                    )
+                    fit = numpy.polyfit(xpts, ypts, 2)
+                    roots = numpy.roots(fit)  # max two roots (bigPhi)
+
+                    belowphi = self._phiai(self._y_a[atomi], roots.min(), atomi)[0]
+                    abovephi = self._phiai(self._y_a[atomi], roots.max(), atomi)[0]
+
+                    if abs(abovephi) < 1e-10:
+                        bigphiAI[atomi] = roots.min()
+                        fitphi = False
+                    elif abs(belowphi) < 1e-10:
+                        bigphiAI[atomi] = roots.max()
+                        fitphi = False
+                    else:
+                        if 3 * abs(abovephi) < abs(belowphi):
+                            corbigPhi = roots.max() - 2.0 * abovephi * (
+                                roots.max() - roots.min()
+                            ) / (abovephi - belowphi)
+                        elif 3 * abs(belowphi) < abs(abovephi):
+                            corbigPhi = roots.min() - 2.0 * belowphi * (
+                                roots.max() - roots.min()
+                            ) / (abovephi - belowphi)
+                        else:
+                            corbigPhi = (roots.max() + roots.min()) / 2.0
+                        # New candidates
+                        corphi = self._phiai(self._y_a[atomi], corbigPhi, atomi)[0]
+                        self._candidates_bigPhi[atomi] = numpy.array(
+                            [
+                                lowerbigPhi,
+                                midbigPhi,
+                                upperbigPhi,
+                                roots.max(),
+                                roots.min(),
+                                corbigPhi,
+                            ],
+                            dtype=float,
+                        )
+                        self._candidates_phi[atomi] = numpy.array(
+                            [lowerphi, midphi, upperphi, abovephi, belowphi, corphi], dtype=float
+                        )
+
+                        # Update upperphi and lowerphi
+                        lower_ind = numpy.where(
+                            self._candidates_phi[atomi]
+                            == self._candidates_phi[atomi][self._candidates_phi[atomi] < 0].max()
+                        )[0][0]
+                        upper_ind = numpy.where(
+                            self._candidates_phi[atomi]
+                            == self._candidates_phi[atomi][self._candidates_phi[atomi] > 0].min()
+                        )[0][0]
+
+                        lowerphi = self._candidates_phi[atomi][lower_ind]
+                        upperphi = self._candidates_phi[atomi][upper_ind]
+
+                        if abs(lowerphi) < 1e-10:
+                            bigphiAI[atomi] = self._candidates_bigPhi[atomi][lower_ind]
+                            fitphi = False
+                        elif abs(upperphi) < 1e-10:
+                            bigphiAI[atomi] = self._candidates_bigPhi[atomi][upper_ind]
+                            fitphi = False
+                        else:
+                            # Fitting needs to continue in this case.
+                            lowerbigPhi = self._candidates_bigPhi[atomi][lower_ind]
+                            lowerphi = self._candidates_phi[atomi][lower_ind]
+                            upperbigPhi = self._candidates_bigPhi[atomi][upper_ind]
+                            upperphi = self._candidates_phi[atomi][upper_ind]
+
+            assert not fitphi, "Iterative conditioning failed to converge."
+
+            # Set final conditioned density using chosen Phi
+            self._cond_density[atomi] = self._phiai(self._y_a[atomi], bigphiAI[atomi], atomi)[1]
+
+        self.logger.info("Calculating tau and combined conditioned densities.")
+
+        # Calculate tau(r) and rho^cond(r)
+        # Refer to equation 65 and 66 in doi: 10.1039/c6ra04656h
+        # Assign rho^cond on grid using generator object
+        self.rho_cond = copy.deepcopy(self.chgdensity)
+        self.rho_cond.data = numpy.zeros_like(self.rho_cond.data, dtype=float)
+        rho_cond_sqrt = numpy.zeros_like(self.rho_cond.data, dtype=float)
+
+        # Generator object to iterate over the grid
+        xshape, yshape, zshape = self.chgdensity.data.shape
+        atoms = len(self.data.atomnos)
+        indices = (
+            (i, x, y, z)
+            for i in range(atoms)
+            for x in range(xshape)
+            for y in range(yshape)
+            for z in range(zshape)
+        )
+
+        self._leftterm = numpy.zeros((atoms, xshape, yshape, zshape), dtype=float)
+        self.tau = []
+
+        # rho_cond -- equation 65 in doi: 10.1039/c6ra04656h
+        for atomi, xindex, yindex, zindex in indices:
+            self.rho_cond.data[xindex][yindex][zindex] += self._cond_density[atomi][
+                self.closest_r_index[atomi][xindex][yindex][zindex]
+            ]
+
+        rho_cond_sqrt = numpy.sqrt(self.rho_cond.data)
+
+        for atomi in range(len(self.data.atomnos)):
+            self.tau.append(numpy.zeros_like(self.proatom_density[atomi], dtype=float))
+            grid = ((x, y, z) for x in range(xshape) for y in range(yshape) for z in range(zshape))
+            for xindex, yindex, zindex in grid:
+                # leftterm is the first spherical average term in equation 66.
+                # <rho^cond_A(r_A) / sqrt(rho^cond(r))>
+                self._leftterm[atomi][xindex][yindex][zindex] = self._cond_density[atomi][
+                    self.closest_r_index[atomi][xindex][yindex][zindex]
+                ]
+            self._leftterm[atomi] = self._leftterm[atomi] / rho_cond_sqrt
+            for radiusi in range(len(self.tau[atomi])):
+                grid_filter = self.closest_r_index[atomi] == radiusi
+                num_grid_filter = numpy.count_nonzero(grid_filter)
+                if num_grid_filter < 1:
+                    self.tau[atomi][radiusi] = 0.0
+                else:
+                    leftaverage = numpy.sum(grid_filter * self._leftterm[atomi]) / num_grid_filter
+                    rightaverage = numpy.sum(grid_filter * rho_cond_sqrt) / num_grid_filter
+                    if leftaverage < 1e-20:
+                        self.tau[atomi][radiusi] = 0.0
+                    else:
+                        self.tau[atomi][radiusi] = numpy.divide(
+                            leftaverage,
+                            rightaverage,
+                            out=numpy.zeros_like(leftaverage),
+                            where=rightaverage != 0.0,
+                        )
+            # Make tau monotonic decreasing
+            self.tau[atomi] = numpy.maximum.accumulate(self.tau[atomi][::-1])[::-1]
+
+    def _phiai(self, ya, bigphiAI, atomi):
+        """ Evaluate phi_A^I based on equation S100
+        """
+        # Re-evaluate cond_density
+        if isinstance(bigphiAI, float) and not numpy.isinf(bigphiAI):
+            cond_density = ya + bigphiAI * numpy.sqrt(ya)
+        else:
+            cond_density = ya
+
+        # Monotonic Decrease Condition
+        cond_density = numpy.minimum.accumulate(cond_density)
+
+        # Re-evaluate phi_AI
+        phiAI = (
+            self._integrate_from_radial([cond_density], [atomi])
+            - self.data.atomnos[atomi]
+            + self.refcharges[-1][atomi]
+        )
+
+        return phiAI, cond_density
+
+    def _ya(self, proatom_density, atomi):
+        # Function that calculates Y_a^avg
+        # See Eq. 40-41 in doi: 10.1039/c6ra04656h
+        rho_ref = self._rho_ref
+        # Y_a^avg -- Equation 40 in doi: 10.1039/c6ra04656h
+        ya = numpy.zeros_like(proatom_density[atomi], dtype=float)
+        weights = self.chgdensity.data / rho_ref
+        for radiusi in range(len(ya)):
+            grid_filter = self.closest_r_index[atomi] == radiusi
+            num_grid_filter = numpy.count_nonzero(grid_filter)
+            if num_grid_filter < 1:
+                ya[radiusi] = 0.0
+            else:
+                spherical_avg = numpy.sum(grid_filter * weights) / num_grid_filter
+                ya[radiusi] = proatom_density[atomi][radiusi] * spherical_avg
+
+        # Make y_a monotonic decreasing
+        # Refer to module_reshaping_functions.f08::77-79
+        ya = numpy.maximum.accumulate(ya[::-1])[::-1]
+        ya = numpy.minimum.accumulate(ya)
+
+        # Normalize y_a (see module_DDEC6_valence_iterator.f08::284)
+        nelec = self._integrate_from_radial([ya], [atomi])
+        ya *= (self.data.atomnos[atomi] - self.refcharges[-1][atomi]) / nelec
+
+        return ya
+
+    def _integrate_from_radial(self, radial_density_list, atom_list):
+        # Function that reads in list of radial densities, projects it on Cartesian grid,
+        # and returns integrated value
+        grid = copy.deepcopy(self.chgdensity)
+        grid.data = numpy.zeros_like(grid.data)
+
+        xshape, yshape, zshape = self.chgdensity.data.shape
+        indices = ((x, y, z) for x in range(xshape) for y in range(yshape) for z in range(zshape))
+
+        for density, atomi in zip(radial_density_list, atom_list):
+            for x, y, z in indices:
+                grid.data[x][y][z] = (
+                    grid.data[x][y][z] + density[self.closest_r_index[atomi][x][y][z]]
+                )
+
+        return grid.integrate()

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -180,6 +180,9 @@ class Volume(object):
 
     def integrate(self, weights=None):
         weights = numpy.ones_like(self.data) if weights is None else weights
+        assert (
+            weights.shape == self.data.shape
+        ), "Shape of weights do not match with shape of Volume data."
 
         boxvol = (
             self.spacing[0]


### PR DESCRIPTION
_Related Issue: #885
Depends upon: #916_

This PR adds a functionality to apply conditioning for the proatomic densities and thus implements the third step of DDEC6 algorithm. Tests ensure that the integrated charges of conditioned densities match expected values and that tau values (equation 66) match values reported by `chargemol`.

