### PR TITLE
Add vibrational reduced masses and force constants to parse data

### DIFF
--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -168,7 +168,7 @@ class ccData(object):
        "vibanharms":       Attribute(numpy.ndarray,    'anharmonicity constants',     'vibrations'),
        "vibdisps":         Attribute(numpy.ndarray,    'displacement',                'vibrations'),
        "vibfreqs":         Attribute(numpy.ndarray,    'frequencies',                 'vibrations'),
-       "vibfconsts":       Attribute(numpy.ndarray,    'forece concstants',           'vibrations'),
+       "vibfconsts":       Attribute(numpy.ndarray,    'force constants',             'vibrations'),
        "vibirs":           Attribute(numpy.ndarray,    'IR',                          'vibrations:intensities'),
        "vibramans":        Attribute(numpy.ndarray,    'raman',                       'vibrations:intensities'),
        "vibrmasses":       Attribute(numpy.ndarray,    'reduced masses',              'vibrations'),

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -88,8 +88,10 @@ class ccData(object):
         vibanharms -- vibrational anharmonicity constants (array[2], 1/cm)
         vibdisps -- cartesian displacement vectors (array[3], delta angstrom)
         vibfreqs -- vibrational frequencies (array[1], 1/cm)
+        vibfconsts -- force constants of vibrations (array[1], mDyne/angstrom)
         vibirs -- IR intensities (array[1], km/mol)
         vibramans -- Raman activities (array[1], A^4/Da)
+        vibrmasses -- reduced masses of vibrations (array[1], daltons)
         vibsyms -- symmetries of vibrations (list of strings)
         zpve -- zero-point vibrational energy correction (float, hartree/particle)
     (1) The term 'array' refers to a numpy array
@@ -166,8 +168,10 @@ class ccData(object):
        "vibanharms":       Attribute(numpy.ndarray,    'anharmonicity constants',     'vibrations'),
        "vibdisps":         Attribute(numpy.ndarray,    'displacement',                'vibrations'),
        "vibfreqs":         Attribute(numpy.ndarray,    'frequencies',                 'vibrations'),
+       "vibfconsts":       Attribute(numpy.ndarray,    'forece concstants',           'vibrations'),
        "vibirs":           Attribute(numpy.ndarray,    'IR',                          'vibrations:intensities'),
        "vibramans":        Attribute(numpy.ndarray,    'raman',                       'vibrations:intensities'),
+       "vibrmasses":       Attribute(numpy.ndarray,    'reduced masses',              'vibrations'),
        "vibsyms":          Attribute(list,             'vibration symmetry',          'vibrations'),
        "zpve":             Attribute(float,            'zero-point correction',       'properties:energies')
     }

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -786,6 +786,7 @@ class GAMESS(logfileparser.Logfile):
 
             self.vibfreqs = []
             self.vibirs = []
+            self.vibrmasses = []
             self.vibdisps = []
 
             # Need to get to the modes line, which is often preceeded by
@@ -864,6 +865,7 @@ class GAMESS(logfileparser.Logfile):
 
                 # Skip the reduced mass (not always present).
                 if line.find("REDUCED") >= 0:
+                    self.vibrmasses.extend(list(map(float, line.strip().split()[2:])))
                     line = next(inputfile)
 
                 # Not present in numerical Hessian calculations.
@@ -907,6 +909,7 @@ class GAMESS(logfileparser.Logfile):
             # Exclude rotations and translations.
             self.vibfreqs = numpy.array(self.vibfreqs[:startrot-1]+self.vibfreqs[endrot:], "d")
             self.vibirs = numpy.array(self.vibirs[:startrot-1]+self.vibirs[endrot:], "d")
+            self.vibrmasses = numpy.array(self.vibrmasses[:startrot-1]+self.vibrmasses[endrot:], "d")
             self.vibdisps = numpy.array(self.vibdisps[:startrot-1]+self.vibdisps[endrot:], "d")
             if hasattr(self, "vibramans"):
                 self.vibramans = numpy.array(self.vibramans[:startrot-1]+self.vibramans[endrot:], "d")

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -786,7 +786,6 @@ class GAMESS(logfileparser.Logfile):
 
             self.vibfreqs = []
             self.vibirs = []
-            self.vibrmasses = []
             self.vibdisps = []
 
             # Need to get to the modes line, which is often preceeded by
@@ -865,6 +864,8 @@ class GAMESS(logfileparser.Logfile):
 
                 # Skip the reduced mass (not always present).
                 if line.find("REDUCED") >= 0:
+                    if not hasattr(self, "vibrmasses"):
+                        self.vibrmasses = []
                     self.vibrmasses.extend(list(map(float, line.strip().split()[2:])))
                     line = next(inputfile)
 
@@ -909,8 +910,9 @@ class GAMESS(logfileparser.Logfile):
             # Exclude rotations and translations.
             self.vibfreqs = numpy.array(self.vibfreqs[:startrot-1]+self.vibfreqs[endrot:], "d")
             self.vibirs = numpy.array(self.vibirs[:startrot-1]+self.vibirs[endrot:], "d")
-            self.vibrmasses = numpy.array(self.vibrmasses[:startrot-1]+self.vibrmasses[endrot:], "d")
             self.vibdisps = numpy.array(self.vibdisps[:startrot-1]+self.vibdisps[endrot:], "d")
+            if hasattr(self, "vibrmasses"):
+                self.vibrmasses = numpy.array(self.vibrmasses[:startrot-1]+self.vibrmasses[endrot:], "d")
             if hasattr(self, "vibramans"):
                 self.vibramans = numpy.array(self.vibramans[:startrot-1]+self.vibramans[endrot:], "d")
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1278,7 +1278,7 @@ class Gaussian(logfileparser.Logfile):
                     freqs = [utils.float(f) for f in line[15:].split()]
                     self.vibfreqs.extend(freqs)
 
-                if line[1:15] == "Red. masses --":  # note: matches low-precision block, and
+                if line[1:15] == "Red. masses --":  # note: matches only low-precision block
 
                     if not hasattr(self, 'vibrmasses'):
                         self.vibrmasses = []
@@ -1286,7 +1286,7 @@ class Gaussian(logfileparser.Logfile):
                     rmasses = [utils.float(f) for f in line[15:].split()]
                     self.vibrmasses.extend(rmasses)
 
-                if line[1:15] == "Frc consts  --":  # note: matches low-precision block, and
+                if line[1:15] == "Frc consts  --":  # note: matches only low-precision block
 
                     if not hasattr(self, 'vibfconsts'):
                         self.vibfconsts = []

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1226,8 +1226,8 @@ class Gaussian(logfileparser.Logfile):
         # an extra frequency block with higher-precision vibdisps is
         # printed before the normal frequency block.
         # Note that the code parses only the vibsyms and vibdisps
-        # from the high-precision block, but parses vibsyms, vibfreqs,
-        # vibramans and vibirs from the normal block. vibsyms parsed
+        # from the high-precision block, but parses vibsyms, vibfreqs, vibfconsts,
+        # vibramans, vibrmasses and vibirs from the normal block. vibsyms parsed
         # from the high-precision block are discarded and replaced by those
         # from the normal block while the high-precision vibdisps, if present,
         # are used to overwrite default-precision vibdisps at the end of the parse.
@@ -1255,6 +1255,10 @@ class Gaussian(logfileparser.Logfile):
                             self.vibfreqs = []
                         if hasattr(self, 'vibramans'):
                             self.vibramans = []
+                        if hasattr(self, "vibrmasses"):
+                            self.vibrmasses = []
+                        if hasattr(self, "vibfconsts"):
+                            self.vibfconsts = []
                         if hasattr(self, 'vibdisps'):
                             self.vibdisps = []
 
@@ -1273,6 +1277,22 @@ class Gaussian(logfileparser.Logfile):
 
                     freqs = [utils.float(f) for f in line[15:].split()]
                     self.vibfreqs.extend(freqs)
+
+                if line[1:15] == "Red. masses --":  # note: matches low-precision block, and
+
+                    if not hasattr(self, 'vibrmasses'):
+                        self.vibrmasses = []
+
+                    rmasses = [utils.float(f) for f in line[15:].split()]
+                    self.vibrmasses.extend(rmasses)
+
+                if line[1:15] == "Frc consts  --":  # note: matches low-precision block, and
+
+                    if not hasattr(self, 'vibfconsts'):
+                        self.vibfconsts = []
+
+                    fconsts = [utils.float(f) for f in line[15:].split()]
+                    self.vibfconsts.extend(fconsts)
 
                 if line[1:15] == "IR Inten    --":  # note: matches only low-precision block
 

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -613,6 +613,7 @@ class Jaguar(logfileparser.Logfile):
 
             self.vibfreqs = []
             self.vibdisps = []
+            self.vibrmasses = []
             forceconstants = False
             intensities = False
             while line.strip():
@@ -646,8 +647,12 @@ class Jaguar(logfileparser.Logfile):
                         self.vibirs = []
                     self.vibirs.extend(list(map(float, line[1:])))
                     line = next(inputfile).split()
+                self.vibrmasses.extend(list(map(float, line[2:])))
                 if forceconstants:
-                    line = next(inputfile)
+                    line = next(inputfile).split()
+                    if not hasattr(self, "vibfconsts"):
+                        self.vibfconsts = []
+                    self.vibfconsts.extend(list(map(float, line[2:])))
 
                 # Start parsing the displacements.
                 # Variable 'q' holds up to 7 lists of triplets.
@@ -671,8 +676,11 @@ class Jaguar(logfileparser.Logfile):
             # Convert new data to arrays.
             self.vibfreqs = numpy.array(self.vibfreqs, "d")
             self.vibdisps = numpy.array(self.vibdisps, "d")
+            self.vibrmasses = numpy.array(self.vibrmasses, "d")
             if hasattr(self, "vibirs"):
                 self.vibirs = numpy.array(self.vibirs, "d")
+            if hasattr(self, "vibfconsts"):
+                self.vibfconsts = numpy.array(self.vibfconsts, "d")
 
         # Parse excited state output (for CIS calculations).
         # Jaguar calculates only singlet states.

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -397,6 +397,11 @@ class Molcas(logfileparser.Logfile):
                     self.vibirs.extend(vibirs)
 
                 if 'Red.' in line:
+                    if not hasattr(self, 'vibrmasses'):
+                        self.vibrmasses = []
+                    vibrmasses = map(float, line.split()[2:])
+                    self.vibrmasses.extend(vibrmasses)
+
                     self.skip_line(inputfile, 'blank')
                     line = next(inputfile)
                     if not hasattr(self, 'vibdisps'):

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -225,6 +225,17 @@ class MOPAC(logfileparser.Logfile):
                 # transform to km/mol
                 self.vibirs.append(math.sqrt(tdipole))
 
+            line = inputfile.next()
+            if 'TRAVEL' in line:
+                pass
+
+            line = inputfile.next()
+            if 'RED. MASS' in line:
+                if not hasattr(self, 'vibrmasses'):
+                    self.vibrmasses = []
+                rmass = float(line.split()[2])
+                self.vibrmasses.append(rmass)
+
         # Orbital eigenvalues, e.g.
         #           ALPHA EIGENVALUES
         #            BETA EIGENVALUES

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -984,7 +984,9 @@ class Psi4(logfileparser.Logfile):
                 assert 'Force constant:' in line
                 if not hasattr(self, "vibfconsts"):
                     self.vibfconsts = []
-                self.vibfconsts.append(float(line.split()[2]))
+                self.vibfconsts.append(
+                    utils.convertor(float(line.split()[2]), "hartree/bohr2", "mDyne/angstrom")
+                )
                 line = next(inputfile)
                 assert 'X       Y       Z           mass' in line
                 line = next(inputfile)

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -981,8 +981,10 @@ class Psi4(logfileparser.Logfile):
                 _vibfreq = Psi4.parse_vibfreq(line[13:].strip())
                 assert abs(vibfreq - _vibfreq) < 1.0e-2
                 line = next(inputfile)
-                # Can't do anything with this for now.
                 assert 'Force constant:' in line
+                if not hasattr(self, "vibfconsts"):
+                    self.vibfconsts = []
+                self.vibfconsts.append(float(line.split()[2]))
                 line = next(inputfile)
                 assert 'X       Y       Z           mass' in line
                 line = next(inputfile)
@@ -1017,6 +1019,8 @@ class Psi4(logfileparser.Logfile):
             vibsyms = []
             vibfreqs = []
             vibdisps = []
+            vibrmasses = []
+            vibfconsts = []
 
             # Skip lines till the first Vibration block
             while not line.strip().startswith('Vibration'):
@@ -1027,10 +1031,12 @@ class Psi4(logfileparser.Logfile):
             while line.strip().startswith('Vibration'):
                 n = len(line.split()) - 1
                 n_modes += n
-                vibfreqs_, vibsyms_, vibdisps_ = self.parse_vibration(n, inputfile)
+                vibfreqs_, vibsyms_, vibdisps_, vibrmasses_, vibfconsts_ = self.parse_vibration(n, inputfile)
                 vibfreqs.extend(vibfreqs_)
                 vibsyms.extend(vibsyms_)
                 vibdisps.extend(vibdisps_)
+                vibrmasses.extend(vibrmasses_)
+                vibfconsts.extend(vibfconsts_)
                 line = next(inputfile)
 
             # It looks like the symmetry of the normal mode may be missing 
@@ -1044,6 +1050,12 @@ class Psi4(logfileparser.Logfile):
 
             if len(vibdisps) == n_modes:
                 self.set_attribute('vibdisps', vibdisps)
+
+            if len(vibdisps) == n_modes:
+                self.set_attribute('vibrmasses', vibrmasses)
+
+            if len(vibdisps) == n_modes:
+                self.set_attribute('vibfconsts', vibfconsts)
 
         # If finite difference is used to compute forces (i.e. by displacing
         # slightly all the atoms), a series of additional scf calculations is
@@ -1127,9 +1139,13 @@ class Psi4(logfileparser.Logfile):
 
         line = next(inputfile)
         assert 'Reduced mass' in line
+        chomp = line.split()
+        vibrmasses = [utils.float(x) for x in chomp[3:]]
 
         line = next(inputfile)
         assert 'Force const' in line
+        chomp = line.split()
+        vibfconsts = [utils.float(x) for x in chomp[3:]]
 
         line = next(inputfile)
         assert 'Turning point' in line
@@ -1155,7 +1171,7 @@ class Psi4(logfileparser.Logfile):
 
             line = next(inputfile)
 
-        return vibfreqs, vibsyms, vibdisps
+        return vibfreqs, vibsyms, vibdisps, vibrmasses, vibfconsts
 
     @staticmethod
     def parse_vibfreq(vibfreq):

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1479,6 +1479,18 @@ cannot be determined. Rerun without `$molecule read`."""
                         vibfreqs = map(float, line.split()[1:])
                         self.vibfreqs.extend(vibfreqs)
 
+                    if 'Force Cnst:' in line:
+                        if not hasattr(self, 'vibfconsts'):
+                            self.vibfconsts = []
+                        vibfconsts = map(float, line.split()[2:])
+                        self.vibfconsts.extend(vibfconsts)
+
+                    if 'Red. Mass' in line:
+                        if not hasattr(self, 'vibrmasses'):
+                            self.vibrmasses = []
+                        vibrmasses = map(float, line.split()[2:])
+                        self.vibrmasses.extend(vibrmasses)
+
                     if 'IR Intens:' in line:
                         if not hasattr(self, 'vibirs'):
                             self.vibirs = []

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -151,6 +151,7 @@ def convertor(value, fromunits, tounits):
         "ebohr4_to_Debye.ang3": lambda x: x * 0.3766479268,
         "ebohr5_to_Debye.ang4": lambda x: x * 0.1993134985,
 
+        "hartree/bohr2_to_mDyne/angstrom": lambda x: x * 8.23872350 / 0.5291772109
     }
 
     return _convertor["%s_to_%s" % (fromunits, tounits)](value)

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -571,7 +571,6 @@ vibfconsts
 
 The attribute ``vibrmasses`` stores the force constants in :math:`\mathrm{Å^4/Da}` from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
 
-
 vibrmasses
 --------
 

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -565,3 +565,15 @@ vibdisps
 --------
 
 The attribute ``vibdisps`` stores the Cartesian displacement vectors from the output of a vibrational frequency calculation. It is a rank 3 array having dimensions ``M x N x 3``, where ``M`` is the number of normal modes and ``N`` is the number of atoms. ``M`` is typically ``3N-6`` (``3N-5`` for linear molecules).
+
+vibfconsts
+--------
+
+The attribute ``vibrmasses`` stores the force constants in :math:`\mathrm{Å^4/Da}` from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
+
+
+vibrmasses
+--------
+
+The attribute ``vibrmasses`` stores the reduced masses in Daltons (Da) from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
+

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -10,7 +10,7 @@
 import os
 import unittest
 
-from skip import skipForParser
+from skip import skipForParser, skipForLogfile
 
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
@@ -69,6 +69,8 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('Molpro', 'Molpro cannot print force constants')
     @skipForParser('ORCA', 'ORCA cannot print force constants')
     @skipForParser('Turbomole', 'Turbomole cannot print force constants')
+    @skipForLogfile('Jaguar/Jaguar4.2', 'Data file does not contain force constants')
+    @skipForLogfile('Psi4/Psi4-1.0', 'Data file contains vibrational info with non-mass-weighted coordinates')
     def testvibfconsts(self):
         """Is the maximum force constant 10. +/- 0.1 mDyn/angstrom?"""
         self.assertAlmostEqual(max(self.data.vibfconsts), self.max_force_constant, delta=0.1)
@@ -78,6 +80,8 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('GAMESSUK', 'GAMESSUK cannot print reduced masses')
     @skipForParser('Molpro', 'Molpro cannot print reduced masses')
     @skipForParser('ORCA', 'ORCA cannot print reduced masses')
+    @skipForLogfile('GAMESS/PCGAMESS', 'Data file does not contain reduced masses')
+    @skipForLogfile('Psi4/Psi4-1.0', 'Data file does not contain reduced masses')
     def testvibrmasses(self):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -70,7 +70,7 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('ORCA', 'ORCA cannot print force constants')
     @skipForParser('Turbomole', 'Turbomole cannot print force constants')
     @skipForLogfile('Jaguar/Jaguar4.2', 'Data file does not contain force constants')
-    @skipForLogfile('Psi4/Psi4-1.0', 'Data file contains vibrational info with non-mass-weighted coordinates')
+    @skipForLogfile('Psi4/Psi4-1.0', 'Data file contains vibrational info with cartesian coordinates')
     def testvibfconsts(self):
         """Is the maximum force constant 10. +/- 0.1 mDyn/angstrom?"""
         self.assertAlmostEqual(max(self.data.vibfconsts), self.max_force_constant, delta=0.1)

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -110,6 +110,7 @@ class GaussianIRTest(GenericIRTest):
 class JaguarIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
+    # Jagur outputs vibrational info with cartesian coordinates
     max_force_constant = 3.7
     max_reduced_mass = 2.3
 
@@ -247,6 +248,7 @@ class GamessIRTest(GenericIRTest):
 class Psi4IRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
+    # RHF is used for Psi4 IR test data instead of B3LYP
     max_force_constant = 9.37
 
 

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -37,12 +37,16 @@ class GenericIRTest(unittest.TestCase):
                          (self.numvib, len(self.data.atomnos), 3))
 
     def testlengths(self):
-        """Are the lengths of vibfreqs and vibirs (and if present, vibsyms) correct?"""
+        """Are the lengths of vibfreqs and vibirs (and if present, vibsyms, vibfconnsts and vibrmasses) correct?"""
         self.assertEqual(len(self.data.vibfreqs), self.numvib)
         if hasattr(self.data, 'vibirs'):
             self.assertEqual(len(self.data.vibirs), self.numvib)
         if hasattr(self.data, 'vibsyms'):
             self.assertEqual(len(self.data.vibsyms), self.numvib)
+        if hasattr(self.data, 'vibfconsts'):
+            self.assertEqual(len(self.data.vibfconsts), self.numvib)
+        if hasattr(self.data, 'vibrmasses'):
+            self.assertEqual(len(self.data.vibrmasses), self.numvib)
 
     def testfreqval(self):
         """Is the highest freq value 3630 +/- 200 wavenumber?"""
@@ -63,10 +67,21 @@ class FireflyIRTest(GenericIRTest):
 class GaussianIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
+    max_force_constant = 10.0
+    max_reduced_mass = 6.9
+
+    def testvibfconsts(self):
+        """Is the maximum force constants 10. +/- 0.1 mDyn/angstrom?"""
+        self.assertAlmostEqual(max(self.data.vibfconsts), self.max_force_constant, delta=0.1)
+
+    def testvibrmasses(self):
+        """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
+        self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
+
     def testvibsyms(self):
         """Is the length of vibsyms correct?"""
         self.assertEqual(len(self.data.vibsyms), self.numvib)
-        
+
     def testzeropointcorrection(self):
         # reference zero-point correction from dvb_ir.out
         zpve = 0.1771

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -22,6 +22,10 @@ class GenericIRTest(unittest.TestCase):
     # Unit tests should normally give this value for the largest IR intensity.
     max_IR_intensity = 100
 
+    # Unit tests may give these values for the largest force constant and reduced mass, respectively.
+    max_force_constant = 10.0
+    max_reduced_mass = 6.9
+
     def setUp(self):
         """Initialize the number of vibrational frequencies on a per molecule basis"""
         self.numvib = 3*len(self.data.atomnos) - 6
@@ -57,6 +61,27 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum IR intensity 100 +/- 10 km/mol?"""
         self.assertAlmostEqual(max(self.data.vibirs), self.max_IR_intensity, delta=10)
 
+    @skipForParser('ADF', 'ADF cannot print force constants')
+    @skipForParser('DALTON', 'DALTON cannot print force constants')
+    @skipForParser('GAMESS', 'GAMESS-US cannot print force constants')
+    @skipForParser('GAMESSUK', 'GAMESS-UK cannot print force constants')
+    @skipForParser('Molcas', 'Molcas cannot print force constants')
+    @skipForParser('Molpro', 'Molpro cannot print force constants')
+    @skipForParser('ORCA', 'ORCA cannot print force constants')
+    @skipForParser('Turbomole', 'Turbomole cannot print force constants')
+    def testvibfconsts(self):
+        """Is the maximum force constant 10. +/- 0.1 mDyn/angstrom?"""
+        self.assertAlmostEqual(max(self.data.vibfconsts), self.max_force_constant, delta=0.1)
+
+    @skipForParser('ADF', 'ADF cannot print reduced masses')
+    @skipForParser('DALTON', 'DALTON cannot print reduced masses')
+    @skipForParser('GAMESSUK', 'GAMESSUK cannot print reduced masses')
+    @skipForParser('Molpro', 'Molpro cannot print reduced masses')
+    @skipForParser('ORCA', 'ORCA cannot print reduced masses')
+    def testvibrmasses(self):
+        """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
+        self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
+
 
 class FireflyIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
@@ -66,17 +91,6 @@ class FireflyIRTest(GenericIRTest):
 
 class GaussianIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
-
-    max_force_constant = 10.0
-    max_reduced_mass = 6.9
-
-    def testvibfconsts(self):
-        """Is the maximum force constants 10. +/- 0.1 mDyn/angstrom?"""
-        self.assertAlmostEqual(max(self.data.vibfconsts), self.max_force_constant, delta=0.1)
-
-    def testvibrmasses(self):
-        """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
-        self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
     def testvibsyms(self):
         """Is the length of vibsyms correct?"""
@@ -91,6 +105,9 @@ class GaussianIRTest(GenericIRTest):
 
 class JaguarIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
+
+    max_force_constant = 3.7
+    max_reduced_mass = 2.3
 
     def testvibsyms(self):
         """Is the length of vibsyms correct?"""
@@ -222,6 +239,13 @@ class GamessIRTest(GenericIRTest):
          """Is the freeenergy reasonable"""
          self.assertAlmostEqual(-381.90808120060200, self.data.freeenergy, self.freeenergy_places)
 
+
+class Psi4IRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    max_force_constant = 9.37
+
+
 class GenericIRimgTest(unittest.TestCase):
     """Generic imaginary vibrational frequency unittest"""
 
@@ -309,7 +333,6 @@ class QChemRamanTest(GenericRamanTest):
     """Customized Raman unittest"""
 
     max_raman_intensity = 588
-
 
 if __name__=="__main__":
 

--- a/test/testdata
+++ b/test/testdata
@@ -348,8 +348,8 @@ vib       Molpro      GenericIRTest         basicMolpro2006       dvb_ir.out    
 vib       Molpro      GenericIRTest         basicMolpro2012       dvb_ir.out            dvb_ir.log
 vib       ORCA        GenericIRTest         basicORCA4.1          dvb_ir.out
 vib       ORCA        GenericIRTest         basicORCA4.2          dvb_ir.out
-vib       Psi4        GenericIRTest         basicPsi4-1.2.1       dvb_ir_rhf.out
-vib       Psi4        GenericIRTest         basicPsi4-1.3.1       dvb_ir_rhf.out
+vib       Psi4        Psi4IRTest            basicPsi4-1.2.1       dvb_ir_rhf.out
+vib       Psi4        Psi4IRTest            basicPsi4-1.3.1       dvb_ir_rhf.out
 vib       QChem       QChemIRTest           basicQChem4.2         dvb_ir.out
 vib       QChem       QChemIRTest           basicQChem5.1         dvb_ir.out
 vib       Turbomole   GenericIRTest         basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out


### PR DESCRIPTION
Add `vibrmasses`, reduced masses, and `vibfconsts`, force constants for parse data.
`vibrmasses` is supported for Gaussian, GAMESS(US), Molcas, Psi4, QChem and Turbomole, and `vibfconsts` is supported for Gaussian, Psi4 and QChem.
The units of `vibrmases` and `vibconsts` are dalton and mDyne/angstrom, respectively.

