### PR TITLE
Separate out Hirshfeld method from DDEC6 as a standalone method

### DIFF
--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -15,6 +15,7 @@ from cclib.method.ddec import DDEC6
 from cclib.method.density import Density
 from cclib.method.electrons import Electrons
 from cclib.method.fragments import FragmentAnalysis
+from cclib.method.hirshfeld import Hirshfeld
 from cclib.method.lpa import LPA
 from cclib.method.mbo import MBO
 from cclib.method.moments import Moments
@@ -22,4 +23,5 @@ from cclib.method.mpa import MPA
 from cclib.method.nuclear import Nuclear
 from cclib.method.opa import OPA
 from cclib.method.orbitals import Orbitals
+from cclib.method.stockholder import Stockholder
 from cclib.method.volume import Volume

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from cclib.method.calculationmethod import Method
+from cclib.method.stockholder import Stockholder
 from cclib.method.volume import electrondensity_spin
 from cclib.parser.utils import convertor
 from cclib.parser.utils import find_package
@@ -25,12 +26,14 @@ from typing import List
 class MissingInputError(Exception):
     pass
 
+class ConvergenceError(Exception):
+    pass
 
 class ConvergenceError(Exception):
     pass
 
 
-class DDEC6(Method):
+class DDEC6(Stockholder):
     """DDEC6 charges."""
 
     # All of these are required for DDEC6 charges.
@@ -66,30 +69,14 @@ class DDEC6(Method):
                 total densities that are partitioned resemble the proatom densities and to prevent
                 the numerical algorithm from failing to converge.
         """
-        super(DDEC6, self).__init__(data, progress, loglevel, logname)
+        super(DDEC6, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
 
-        self.volume = volume
-        self.fragresults = None
-        self.proatom_path = proatom_path
         self.convergence_level = convergence_level
         self.max_iteration = max_iteration
 
         if numpy.sum(self.data.coreelectrons) != 0:
             # TODO: Pseudopotentials should be added back
             pass
-
-        # Check whether proatom_path is a valid directory or not.
-        assert os.path.isdir(
-            proatom_path
-        ), "Directory that contains proatom densities should be added as an input."
-
-        # Read in reference charges.
-        self.proatom_density = []
-        self.radial_grid_r = []
-        for atom_number in self.data.atomnos:
-            density, r = self._read_proatom(proatom_path, atom_number, 0)
-            self.proatom_density.append(density)
-            self.radial_grid_r.append(r)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -110,154 +97,15 @@ class DDEC6(Method):
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float
     ):
-        # type: (...) -> numpy.ndarray, numpy.ndarray
-        """Return a list containing proatom reference densities."""
-        # TODO: Treat calculations with psuedopotentials
-        # TODO: Modify so that proatom densities are read only once for horton
-        #       [https://github.com/cclib/cclib/pull/914#discussion_r464039991]
-        # File name format:
-        #   ** Chargemol **
-        #       c2_[atom number]_[nuclear charge]_[electron count]_[cutoff radius]_[# shells]
-        #   ** Horton **
-        #       atoms.h5
-        # File format:
-        #   Starting from line 13, each line contains the charge densities for each shell
-        # If `charge` is not an integer, proatom densities have to be linearly interpolated between
-        # the densities of the ion/atom with floor(charge) and ceiling(charge)
-        charge_floor = int(math.floor(charge))
-        charge_ceil = int(math.ceil(charge))
-
-        chargemol_path_floor = os.path.join(
-            directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
-                atom_num, atom_num, atom_num - charge_floor
-            ),
-        )
-        chargemol_path_ceil = os.path.join(
-            directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
-                atom_num, atom_num, atom_num - charge_ceil
-            ),
-        )
-        horton_path = os.path.join(directory, "atoms.h5")
-
-        if os.path.isfile(chargemol_path_floor) or os.path.isfile(chargemol_path_ceil):
-            # Use chargemol proatom densities
-            # Each shell is .05 angstroms apart (uniform).
-            # *scalefactor* = 10.58354497764173 bohrs in module_global_parameter.f08
-            if atom_num <= charge_floor:
-                density_floor = numpy.array([0])
-            else:
-                density_floor = numpy.loadtxt(chargemol_path_floor, skiprows=12, dtype=float)
-            if atom_num >= charge_ceil:
-                density_ceil = numpy.array([0])
-            else:
-                density_ceil = numpy.loadtxt(chargemol_path_ceil, skiprows=12, dtype=float)
-
-            density = (charge_ceil - charge) * density_floor + (
-                charge - charge_floor
-            ) * density_ceil
-            radiusgrid = numpy.arange(1, len(density) + 1) * 0.05
-
-        elif os.path.isfile(horton_path):
-            # Use horton proatom densities
-            assert find_package("h5py"), "h5py is needed to read in proatom densities from horton."
-
-            import h5py
-
-            with h5py.File(horton_path, "r") as proatomdb:
-                if atom_num <= charge_floor:
-                    density_floor = numpy.array([0])
-                    radiusgrid = numpy.array([0])
-                else:
-                    keystring_floor = "Z={}_Q={:+d}".format(atom_num, charge_floor)
-                    density_floor = numpy.asanyarray(list(proatomdb[keystring_floor]["rho"]))
-
-                    # gridspec is specification of integration grid for proatom densities in horton.
-                    # Example -- ['PowerRTransform', '1.1774580743206259e-07', '20.140888089596444', '41']
-                    #   is constructed using PowerRTransform grid
-                    #   with rmin = 1.1774580743206259e-07
-                    #        rmax = 20.140888089596444
-                    #   and  ngrid = 41
-                    # PowerRTransform is default in horton-atomdb.py.
-                    gridtype, gridmin, gridmax, gridn = (
-                        proatomdb[keystring_floor].attrs["rtransform"].split()
-                    )
-                    gridmin = convertor(float(gridmin), "bohr", "Angstrom")
-                    gridmax = convertor(float(gridmax), "bohr", "Angstrom")
-                    gridn = int(gridn)
-                    # Convert byte to string in Python3
-                    if sys.version[0] == "3":
-                        gridtype = gridtype.decode("UTF-8")
-
-                    # First verify that it is one of recognized grids
-                    assert gridtype in [
-                        "LinearRTransform",
-                        "ExpRTransform",
-                        "PowerRTransform",
-                    ], "Grid type not recognized."
-
-                    if gridtype == "LinearRTransform":
-                        # Linear transformation. r(t) = rmin + t*(rmax - rmin)/(npoint - 1)
-                        gridcoeff = (gridmax - gridmin) / (gridn - 1)
-                        radiusgrid = gridmin + numpy.arange(1, gridn + 1) * gridcoeff
-                    elif gridtype == "ExpRTransform":
-                        # Exponential transformation. r(t) = rmin*exp(t*log(rmax/rmin)/(npoint - 1))
-                        gridcoeff = math.log(gridmax / gridmin) / (gridn - 1)
-                        radiusgrid = gridmin * numpy.exp(numpy.arange(1, gridn + 1) * gridcoeff)
-                    elif gridtype == "PowerRTransform":
-                        # Power transformation. r(t) = rmin*t^power
-                        # with  power = log(rmax/rmin)/log(npoint)
-                        gridcoeff = math.log(gridmax / gridmin) / math.log(gridn)
-                        radiusgrid = gridmin * numpy.power(numpy.arange(1, gridn + 1), gridcoeff)
-
-                if atom_num <= charge_ceil:
-                    density_ceil = numpy.array([0])
-                else:
-                    keystring_ceil = "Z={}_Q={:+d}".format(atom_num, charge_ceil)
-                    density_ceil = numpy.asanyarray(list(proatomdb[keystring_ceil]["rho"]))
-
-                density = (charge_ceil - charge) * density_floor + (
-                    charge - charge_floor
-                ) * density_ceil
-
-                del h5py
-
-        else:
-            raise MissingInputError("Pro-atom densities were not found in the specified path.")
-
-        if charge == charge_floor:
-            density = density_floor
-
-        return density, radiusgrid
+        return super(DDEC6, self)._read_proatom(directory, atom_num, charge)
 
     def calculate(self, indices=None, fupdate=0.05):
         """
         Calculate DDEC6 charges based on doi: 10.1039/c6ra04656h paper.
         Cartesian, uniformly spaced grids are assumed for this function.
         """
-        # Obtain charge densities on the grid if it does not contain one.
-        if not numpy.any(self.volume.data):
-            self.logger.info("Calculating charge densities on the provided empty grid.")
-            if len(self.data.mocoeffs) == 1:
-                self.charge_density = electrondensity_spin(
-                    self.data, self.volume, [self.data.mocoeffs[0][: self.data.homos[0] + 1]]
-                )
-                self.charge_density.data *= 2
-            else:
-                self.charge_density = electrondensity_spin(
-                    self.data,
-                    self.volume,
-                    [
-                        self.data.mocoeffs[0][: self.data.homos[0] + 1],
-                        self.data.mocoeffs[1][: self.data.homos[1] + 1],
-                    ],
-                )
-        # If charge densities are provided beforehand, log this information
-        # `Volume` object does not contain (nor rely on) information about the constituent atoms.
-        else:
-            self.logger.info("Using charge densities from the provided Volume object.")
-            self.charge_density = self.volume
+
+        super(DDEC6, self).calculate()
 
         # Notify user about the total charge in the density grid
         integrated_density = self.charge_density.integrate()

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Calculation of DDEC charges based on data parsed by cclib."""
+import copy
+import random
+import numpy
+import logging
+import math
+import os
+import sys
+
+from cclib.method.calculationmethod import Method
+from cclib.method.stockholder import Stockholder
+from cclib.method.volume import electrondensity_spin
+from cclib.parser.utils import find_package
+
+from typing import List
+
+
+class MissingInputError(Exception):
+    pass
+
+
+class ConvergenceError(Exception):
+    pass
+
+
+class Hirshfeld(Stockholder):
+    """Hirshfeld charges."""
+
+    # All of these are required for DDEC6 charges.
+    required_attrs = ("homos", "mocoeffs", "nbasis", "gbasis")
+
+    def __init__(
+        self,
+        data,
+        volume,
+        proatom_path=None,
+        progress=None,
+        loglevel=logging.INFO,
+        logname="Log",
+    ):
+        """ Initialize Hirshfeld object.
+            Inputs are:
+                data -- ccData object that describe target molecule.
+                volume -- Volume object that describe target Cartesian grid.
+                proatom_path -- path to proatom densities
+                (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
+        """
+        super(Hirshfeld, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
+
+    def __str__(self):
+        """Return a string representation of the object."""
+        return "Hirshfeld charges of {}".format(self.data)
+
+    def __repr__(self):
+        """Return a representation of the object."""
+        return "Hirshfeld({})".format(self.data)
+
+    def _check_required_attributes(self):
+        super(Hirshfeld, self)._check_required_attributes()
+
+    def _cartesian_dist(self, pt1, pt2):
+        """ Small utility function that calculates Euclidian distance between two points
+            pt1 and pt2 are numpy arrays representing a point in Cartesian coordinates. """
+        return numpy.sqrt(numpy.dot(pt1 - pt2, pt1 - pt2))
+
+    def _read_proatom(
+        self, directory, atom_num, charge  # type = str  # type = int  # type = float
+    ):
+        return super(Hirshfeld, self)._read_proatom(directory, atom_num, charge)
+
+    def calculate(self):
+        """ Calculate Hirshfeld charges
+        """
+        super(Hirshfeld, self).calculate()
+
+        # Generator object to iterate over the grid
+        ngridx, ngridy, ngridz = self.charge_density.data.shape
+        indices = (
+            (i, x, y, z)
+            for i in range(self.data.natom)
+            for x in range(ngridx)
+            for y in range(ngridy)
+            for z in range(ngridz)
+        )
+        grid_shape = (self.data.natom, ngridx, ngridy, ngridz)
+
+        stockholder_w = numpy.zeros(grid_shape)
+        self.closest_r_index = numpy.zeros(grid_shape, dtype=int)
+
+        for atomi, xindex, yindex, zindex in indices:
+            # Distance of the grid from atom grid
+            dist_r = self._cartesian_dist(
+                self.data.atomcoords[-1][atomi],
+                self.charge_density.coordinates([xindex, yindex, zindex]),
+            )
+            self.closest_r_index[atomi][xindex][yindex][zindex] = numpy.abs(
+                self.radial_grid_r[atomi] - dist_r
+            ).argmin()
+
+            # stockholder_w is radial proatom density projected on Cartesian grid
+            stockholder_w[atomi][xindex][yindex][zindex] = self.proatom_density[atomi][
+                self.closest_r_index[atomi][xindex][yindex][zindex]
+            ]
+
+        # Equation 3 in doi:10.1007/BF01113058
+        # stockholder_bigW represents the denominator in this equation
+        # \sum{eta_chi(r_chi)}_chi
+        # where eta is proatom density, chi is index of atoms in the molecule, and r_chi is
+        # radial distance from center of atom chi.
+        stockholder_bigW = numpy.sum(stockholder_w, axis=0)
+
+        self.fragcharges = numpy.zeros((self.data.natom))
+        self.logger.info("Creating fragcharges: array[1]")
+
+        for atomi in range(self.data.natom):
+            # Equation 1 in doi:10.1007/BF01113058
+            # The weights supplied for integrate function correspond to W_A in the equation.
+            # Q_A = Z_A - \integral(W_A(r) * q_A(r) dr)
+            # where Q_A is Hirshfeld charges, W_A is weights determined on each grid and on each
+            # atom, and q_A is total charge densities on the Cartesian grid.
+            self.fragcharges[atomi] = self.data.atomnos[atomi] - self.charge_density.integrate(
+                weights=(stockholder_w[atomi] / stockholder_bigW)
+            )
+
+        return True

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Stockholder partitioning based on cclib data."""
+import copy
+import random
+import numpy
+import logging
+import math
+import os
+import sys
+
+from cclib.method.calculationmethod import Method
+from cclib.method.volume import electrondensity_spin
+from cclib.parser.utils import convertor
+from cclib.parser.utils import find_package
+
+from typing import List
+
+
+class MissingInputError(Exception):
+    pass
+
+
+class Stockholder(Method):
+    """An abstract base class for stockholder-type methods."""
+
+    # All of these are required for stockholder-type charges.
+    required_attrs = ("homos", "mocoeffs", "nbasis", "gbasis")
+
+    def __init__(
+        self,
+        data,
+        volume,
+        proatom_path=None,
+        progress=None,
+        loglevel=logging.INFO,
+        logname="Log",
+    ):
+        """ Initialize Stockholder-type method object.
+            Inputs are:
+                data -- ccData object that describe target molecule.
+                volume -- Volume object that describe target Cartesian grid.
+                proatom_path -- path to proatom densities
+                (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
+        """
+        super(Stockholder, self).__init__(data, progress, loglevel, logname)
+
+        self.volume = volume
+        self.proatom_path = proatom_path
+
+        # Check whether proatom_path is a valid directory or not.
+        assert os.path.isdir(
+            proatom_path
+        ), "Directory that contains proatom densities should be added as an input."
+
+        # Read in reference charges.
+        self.proatom_density = []
+        self.radial_grid_r = []
+        for atom_number in self.data.atomnos:
+            density, r = self._read_proatom(self.proatom_path, atom_number, 0)
+            self.proatom_density.append(density)
+            self.radial_grid_r.append(r)
+
+    def __str__(self):
+        """Return a string representation of the object."""
+        return "Stockholder"
+
+    def __repr__(self):
+        """Return a representation of the object."""
+        return "Stockholder"
+
+    def _check_required_attributes(self):
+        super(Stockholder, self)._check_required_attributes()
+
+    def _read_proatom(
+        self, directory, atom_num, charge  # type = str  # type = int  # type = float
+    ):
+        # type: (...) -> numpy.ndarray, numpy.ndarray
+        """Return a list containing proatom reference densities."""
+        # TODO: Treat calculations with psuedopotentials
+        # TODO: Modify so that proatom densities are read only once for horton
+        #       [https://github.com/cclib/cclib/pull/914#discussion_r464039991]
+        # File name format:
+        #   ** Chargemol **
+        #       c2_[atom number]_[nuclear charge]_[electron count]_[cutoff radius]_[# shells]
+        #   ** Horton **
+        #       atoms.h5
+        # File format:
+        #   Starting from line 13, each line contains the charge densities for each shell
+        # If `charge` is not an integer, proatom densities have to be linearly interpolated between
+        # the densities of the ion/atom with floor(charge) and ceiling(charge)
+        charge_floor = int(math.floor(charge))
+        charge_ceil = int(math.ceil(charge))
+
+        chargemol_path_floor = os.path.join(
+            directory,
+            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
+                atom_num, atom_num, atom_num - charge_floor
+            ),
+        )
+        chargemol_path_ceil = os.path.join(
+            directory,
+            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
+                atom_num, atom_num, atom_num - charge_ceil
+            ),
+        )
+        horton_path = os.path.join(directory, "atoms.h5")
+
+        if os.path.isfile(chargemol_path_floor) or os.path.isfile(chargemol_path_ceil):
+            # Use chargemol proatom densities
+            # Each shell is .05 angstroms apart (uniform).
+            # *scalefactor* = 10.58354497764173 bohrs in module_global_parameter.f08
+            if atom_num <= charge_floor:
+                density_floor = numpy.array([0])
+            else:
+                density_floor = numpy.loadtxt(chargemol_path_floor, skiprows=12, dtype=float)
+            if atom_num >= charge_ceil:
+                density_ceil = numpy.array([0])
+            else:
+                density_ceil = numpy.loadtxt(chargemol_path_ceil, skiprows=12, dtype=float)
+
+            density = (charge_ceil - charge) * density_floor + (
+                charge - charge_floor
+            ) * density_ceil
+            radiusgrid = numpy.arange(1, len(density) + 1) * 0.05
+
+        elif os.path.isfile(horton_path):
+            # Use horton proatom densities
+            assert find_package("h5py"), "h5py is needed to read in proatom densities from horton."
+
+            import h5py
+
+            with h5py.File(horton_path, "r") as proatomdb:
+                if atom_num <= charge_floor:
+                    density_floor = numpy.array([0])
+                    radiusgrid = numpy.array([0])
+                else:
+                    keystring_floor = "Z={}_Q={:+d}".format(atom_num, charge_floor)
+                    density_floor = numpy.asanyarray(list(proatomdb[keystring_floor]["rho"]))
+
+                    # gridspec is specification of integration grid for proatom densities in horton.
+                    # Example -- ['PowerRTransform', '1.1774580743206259e-07', '20.140888089596444', '41']
+                    #   is constructed using PowerRTransform grid
+                    #   with rmin = 1.1774580743206259e-07
+                    #        rmax = 20.140888089596444
+                    #   and  ngrid = 41
+                    # PowerRTransform is default in horton-atomdb.py.
+                    gridtype, gridmin, gridmax, gridn = (
+                        proatomdb[keystring_floor].attrs["rtransform"].split()
+                    )
+                    gridmin = convertor(float(gridmin), "bohr", "Angstrom")
+                    gridmax = convertor(float(gridmax), "bohr", "Angstrom")
+                    gridn = int(gridn)
+                    # Convert byte to string in Python3
+                    if sys.version[0] == "3":
+                        gridtype = gridtype.decode("UTF-8")
+
+                    # First verify that it is one of recognized grids
+                    assert gridtype in [
+                        "LinearRTransform",
+                        "ExpRTransform",
+                        "PowerRTransform",
+                    ], "Grid type not recognized."
+
+                    if gridtype == "LinearRTransform":
+                        # Linear transformation. r(t) = rmin + t*(rmax - rmin)/(npoint - 1)
+                        gridcoeff = (gridmax - gridmin) / (gridn - 1)
+                        radiusgrid = gridmin + numpy.arange(1, gridn + 1) * gridcoeff
+                    elif gridtype == "ExpRTransform":
+                        # Exponential transformation. r(t) = rmin*exp(t*log(rmax/rmin)/(npoint - 1))
+                        gridcoeff = math.log(gridmax / gridmin) / (gridn - 1)
+                        radiusgrid = gridmin * numpy.exp(numpy.arange(1, gridn + 1) * gridcoeff)
+                    elif gridtype == "PowerRTransform":
+                        # Power transformation. r(t) = rmin*t^power
+                        # with  power = log(rmax/rmin)/log(npoint)
+                        gridcoeff = math.log(gridmax / gridmin) / math.log(gridn)
+                        radiusgrid = gridmin * numpy.power(numpy.arange(1, gridn + 1), gridcoeff)
+
+                if atom_num <= charge_ceil:
+                    density_ceil = numpy.array([0])
+                else:
+                    keystring_ceil = "Z={}_Q={:+d}".format(atom_num, charge_ceil)
+                    density_ceil = numpy.asanyarray(list(proatomdb[keystring_ceil]["rho"]))
+
+                density = (charge_ceil - charge) * density_floor + (
+                    charge - charge_floor
+                ) * density_ceil
+
+                del h5py
+
+        else:
+            raise MissingInputError("Pro-atom densities were not found in the specified path.")
+
+        if charge == charge_floor:
+            density = density_floor
+
+        return density, radiusgrid
+
+    def calculate(self, indices=None, fupdate=0.05):
+        """ Charge density on a Cartesian grid is a common routine required for Stockholder-type
+            and related methods. This abstract class prepares the grid if input Volume object
+            is empty.
+        """
+        # Obtain charge densities on the grid if it does not contain one.
+        if not numpy.any(self.volume.data):
+            self.logger.info("Calculating charge densities on the provided empty grid.")
+            if len(self.data.mocoeffs) == 1:
+                self.charge_density = electrondensity_spin(
+                    self.data, self.volume, [self.data.mocoeffs[0][: self.data.homos[0] + 1]]
+                )
+                self.charge_density.data *= 2
+            else:
+                self.charge_density = electrondensity_spin(
+                    self.data,
+                    self.volume,
+                    [
+                        self.data.mocoeffs[0][: self.data.homos[0] + 1],
+                        self.data.mocoeffs[1][: self.data.homos[1] + 1],
+                    ],
+                )
+        # If charge densities are provided beforehand, log this information
+        # `Volume` object does not contain (nor rely on) information about the constituent atoms.
+        else:
+            self.logger.info("Using charge densities from the provided Volume object.")
+            self.charge_density = self.volume

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Test the Hirshfeld Method in cclib"""
+
+from __future__ import print_function
+
+import sys
+import os
+import logging
+import unittest
+
+import numpy
+
+from cclib.method import Hirshfeld, volume
+from cclib.parser import Psi4
+from cclib.io import ccread
+from cclib.method.calculationmethod import MissingAttributeError
+
+from numpy.testing import assert_allclose
+
+from ..test_data import getdatafile
+
+
+class HirshfeldTest(unittest.TestCase):
+    """Hirshfeld method tests."""
+
+    def setUp(self):
+        super(HirshfeldTest, self).setUp()
+        self.parse()
+
+    def parse(self):
+        self.data, self.logfile = getdatafile(Psi4, "basicPsi4-1.2.1", ["water_mp2.out"])
+        self.volume = volume.Volume((-4, -4, -4), (4, 4, 4), (0.2, 0.2, 0.2))
+
+    def testmissingrequiredattributes(self):
+        """Is an error raised when required attributes are missing?"""
+        for missing_attribute in Hirshfeld.required_attrs:
+            self.parse()
+            delattr(self.data, missing_attribute)
+            with self.assertRaises(MissingAttributeError):
+                trialBader = Hirshfeld(
+                    self.data, self.volume, os.path.dirname(os.path.realpath(__file__))
+                )
+
+    def test_proatom_read(self):
+        """Are proatom densities imported correctly?"""
+
+        self.parse()
+        self.analysis = Hirshfeld(self.data, self.volume, os.path.dirname(os.path.realpath(__file__)))
+
+        refH_den = [
+            2.66407645e-01,
+            2.66407645e-01,
+            2.66407643e-01,
+            2.66407612e-01,
+            2.66407322e-01,
+        ]  # Hydrogen first five densities
+        refH_r = [
+            1.17745807e-07,
+            4.05209491e-06,
+            3.21078677e-05,
+            1.39448474e-04,
+            4.35643929e-04,
+        ]  # Hydrogen first five radii
+        refO_den = [
+            2.98258510e02,
+            2.98258510e02,
+            2.98258509e02,
+            2.98258487e02,
+            2.98258290e02,
+        ]  # Oxygen first five densities
+        refO_r = [
+            5.70916728e-09,
+            1.97130512e-07,
+            1.56506399e-06,
+            6.80667366e-06,
+            2.12872046e-05,
+        ]  # Oxygen first five radii
+
+        assert_allclose(self.analysis.proatom_density[0][0:5], refO_den, rtol=1e-3)
+        assert_allclose(self.analysis.proatom_density[1][0:5], refH_den, rtol=1e-3)
+        assert_allclose(self.analysis.proatom_density[2][0:5], refH_den, rtol=1e-3)
+
+    def test_water_charges(self):
+        """ Are Hirshfeld charges calculated correctly for water?
+        
+            Note. Table 1 in doi:10.1007/BF01113058 reports Hirshfeld charge for Hydrogen atom as
+                  0.11 when STO-3G basis set was used and
+                  0.18 when 6-311G** basis set was used.
+                  Here, Psi4 calculation was done using STO-3G.
+        """
+
+        self.parse()
+        # use precalculated fine cube file
+        imported_vol = volume.read_from_cube(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "water_fine.cube")
+        )
+
+        analysis = Hirshfeld(self.data, imported_vol, os.path.dirname(os.path.realpath(__file__)))
+        analysis.calculate()
+
+        # Check assigned charges
+        assert_allclose(analysis.fragcharges, [-0.29084274,  0.14357639,  0.14357639], atol=0.1)
+
+    def test_chgsum_h2(self):
+        """ Are Hirshfeld charges for hydrogen atoms in nonpolar H2 small as expected?
+        """
+
+        h2path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "h2.out")
+        data = ccread(h2path)
+        vol = volume.Volume((-3, -3, -3), (3, 3, 3), (0.1, 0.1, 0.1))
+        analysis = Hirshfeld(data, vol, os.path.dirname(os.path.realpath(__file__)))
+        analysis.calculate()
+
+        self.assertAlmostEqual(numpy.sum(analysis.fragcharges), 0, delta=1e-2)
+        self.assertAlmostEqual(analysis.fragcharges[0], analysis.fragcharges[1], delta=1e-6)
+
+    def test_chgsum_co(self):
+        """ Are Hirshfeld charges for carbon monoxide reported as expected?
+        
+            Note. Table 1 in doi:10.1007/BF01113058 reports Hirshfeld charge for Carbon atom as
+                  0.06 when STO-3G basis set was used and
+                  0.14 when 6-311G** basis set was used.
+                  Here, Psi4 calculation was done using STO-3G.
+        """
+
+        copath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "co.out")
+        data = ccread(copath)
+        vol = volume.read_from_cube(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "co.cube")
+        )
+        analysis = Hirshfeld(data, vol, os.path.dirname(os.path.realpath(__file__)))
+        analysis.calculate()
+
+        self.assertAlmostEqual(numpy.sum(analysis.fragcharges), 0, delta=1e-2)
+        assert_allclose(analysis.fragcharges, [ 0.10590126, -0.11277786], atol=1e-3)

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -16,6 +16,7 @@ from .method.testbader import *
 from .method.testcda import *
 from .method.testddec import *
 from .method.testelectrons import *
+from .method.testhirshfeld import *
 from .method.testmbo import *
 from .method.testmoments import *
 from .method.testnuclear import *


### PR DESCRIPTION
_Related Issue: #885
Depends upon: #926_

This PR separates out Hirshfeld method (which was part of Step 1 in DDEC6) as a standalone method.