### PR TITLE
Clean up DDEC6 code

### DIFF
--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -48,9 +48,7 @@ class DDEC6Test(unittest.TestCase):
             vol = volume.Volume((-4, -4, -4), (4, 4, 4), (0.2, 0.2, 0.2))
             delattr(self.data, missing_attribute)
             with self.assertRaises(MissingAttributeError):
-                trialBader = DDEC6(
-                    self.data, vol, os.path.dirname(os.path.realpath(__file__))
-                )
+                trial = DDEC6(self.data, vol, os.path.dirname(os.path.realpath(__file__)))
 
     def test_proatom_read(self):
         """Are proatom densities imported correctly?"""


### PR DESCRIPTION
_Related Issue: #885
Depends upon: #928_

This PR cleans up DDEC6 code by

1. Separating out duplicate code (phi optimization routine in step 3 and 4-6) into a function
2. Add more comments on the phi optimization routine
3. Modify order of class functions
4. Separate out if logic that determines update_kappa

Attempts to address issue #929 