### PR TITLE
Fix a typo in Bader method

### DIFF
--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -143,7 +143,7 @@ class Bader(Method):
                         # when one or more directions indicate max grad (of 0), prioritize
                         # to include all points in the Bader space
                         if directions[0] == [1, 1, 1]:
-                            next_direction = [ind - 1 for ind in direction[1]]
+                            next_direction = [ind - 1 for ind in directions[1]]
 
                     listcoord.append((xindex, yindex, zindex))
                     bader_candidate_index = self.fragresults[


### PR DESCRIPTION
This PR fixes a small typo in Bader method.

The line of code that contains the fix is executed only when one or more positions in the walker that identifies Bader spaces have gradients of exactly (0.0, 0.0, 0.0).