### PR TITLE
Disable caching Python install dirs in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ before_install:
         export PATH="$HOME/miniconda/bin:$PATH"
 
         hash -r
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c conda-forge -c openbabel -c psi4/label/dev python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
+        conda create -q -n condaenv -c openbabel -c psi4/label/dev python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
 
         source activate condaenv
-        conda install pytest pytest-cov codecov -c conda-forge
+        conda install pytest pytest-cov codecov
         pip install pytest-shutil h5py pyscf
         pip install git+https://github.com/theochem/iodata.git
 
@@ -46,13 +48,15 @@ before_install:
         export PATH="$HOME/miniconda/bin:$PATH"
 
         hash -r
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c conda-forge -c openbabel -c psi4/label/dev -c theochem python=$TRAVIS_PYTHON_VERSION ci-psi4 horton openbabel psi4
+        conda create -q -n condaenv -c openbabel -c psi4/label/dev -c theochem python=$TRAVIS_PYTHON_VERSION ci-psi4 horton openbabel psi4
 
         source activate condaenv
-        conda install pytest pytest-cov codecov -c conda-forge
+        conda install pytest pytest-cov codecov
         pip install pytest-shutil pyscf
 
         conda list
@@ -62,8 +66,7 @@ before_install:
         python -m pip install openbabel
         python -m pip install -U pytest pytest-cov h5py
     fi
-
-    pip install -r requirements.txt
+  - pip install -r requirements.txt
 
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ addons:
 before_install:
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu eoan universe"
   - sudo apt update
-  # Add this back once we migrate to a pip-only/pip+conda testing matrix
-  # - sudo apt install libopenbabel-dev
-  #
   # For Python 3.6+ machine, horton 3 IOData is installed from source. For Python 2.7 machine, horton 2 is installed from conda.
   # From the documentation, horton 3 works with Python 3.6+ and horton 2 does with Python 2.7
   - |
@@ -35,13 +32,7 @@ before_install:
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION \
-            -c conda-forge \
-            -c openbabel \
-            -c psi4/label/dev \
-            ci-psi4 \
-            openbabel \
-            psi4
+        conda create -q -n condaenv -c conda-forge -c openbabel -c psi4/label/dev python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
 
         source activate condaenv
         conda install pytest pytest-cov codecov -c conda-forge
@@ -59,22 +50,17 @@ before_install:
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION \
-            -c conda-forge \
-            -c openbabel \
-            -c psi4/label/dev \
-            -c theochem \
-            ci-psi4 \
-            horton \
-            openbabel \
-            psi4
+        conda create -q -n condaenv -c conda-forge -c openbabel -c psi4/label/dev -c theochem python=$TRAVIS_PYTHON_VERSION ci-psi4 horton openbabel psi4
 
         source activate condaenv
         conda install pytest pytest-cov codecov -c conda-forge
         pip install pytest-shutil pyscf
-        conda list
 
+        conda list
     else
+        # Python 3.5
+        sudo apt install libopenbabel-dev
+        python -m pip install openbabel
         python -m pip install -U pytest pytest-cov h5py
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 python:
   - 2.7
@@ -17,8 +18,6 @@ addons:
 #     - $HOME/miniconda
 
 before_install:
-  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu eoan universe"
-  - sudo apt update
   # For Python 3.6+ machine, horton 3 IOData is installed from source. For Python 2.7 machine, horton 2 is installed from conda.
   # From the documentation, horton 3 works with Python 3.6+ and horton 2 does with Python 2.7
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ addons:
 before_install:
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu eoan universe"
   - sudo apt update
-  - sudo apt install libopenbabel-dev
+  # Add this back once we migrate to a pip-only/pip+conda testing matrix
+  # - sudo apt install libopenbabel-dev
+  #
   # For Python 3.6+ machine, horton 3 IOData is installed from source. For Python 2.7 machine, horton 2 is installed from conda.
   # From the documentation, horton 3 works with Python 3.6+ and horton 2 does with Python 2.7
   - |
@@ -33,15 +35,20 @@ before_install:
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n p4env python=$TRAVIS_PYTHON_VERSION ci-psi4 psi4 numpy matplotlib jupyter scipy cython -c psi4/label/dev -c defaults -c conda-forge -c anaconda
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION \
+            -c conda-forge \
+            -c openbabel \
+            -c psi4/label/dev \
+            ci-psi4 \
+            openbabel \
+            psi4
 
-        source activate p4env
+        source activate condaenv
         conda install pytest pytest-cov codecov -c conda-forge
         pip install pytest-shutil h5py pyscf
         pip install git+https://github.com/theochem/iodata.git
-        
+
         conda list
-    
     elif [[ $(echo "$TRAVIS_PYTHON_VERSION < 3.0" | bc -l) == 1 ]];
     then
         wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
@@ -52,13 +59,21 @@ before_install:
         conda config --set always_yes yes --set changeps1 no
         conda update -q conda
         conda info -a
-        conda create -q -n hortonenv python=$TRAVIS_PYTHON_VERSION horton openbabel -c theochem -c conda-forge -c openbabel
-        
-        source activate hortonenv
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION \
+            -c conda-forge \
+            -c openbabel \
+            -c psi4/label/dev \
+            -c theochem \
+            ci-psi4 \
+            horton \
+            openbabel \
+            psi4
+
+        source activate condaenv
         conda install pytest pytest-cov codecov -c conda-forge
         pip install pytest-shutil pyscf
         conda list
-    
+
     else
         python -m pip install -U pytest pytest-cov h5py
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,10 @@ before_install:
 
         hash -r
         conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda config --set always_yes yes --set changeps1 no
+        conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c openbabel -c psi4/label/dev python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
+        conda create -q -n condaenv -c openbabel -c psi4 python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
 
         source activate condaenv
         conda install pytest pytest-cov codecov
@@ -49,11 +48,10 @@ before_install:
 
         hash -r
         conda config --add channels conda-forge
-        conda config --set channel_priority strict
-        conda config --set always_yes yes --set changeps1 no
+        conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c openbabel -c psi4/label/dev -c theochem python=$TRAVIS_PYTHON_VERSION ci-psi4 horton openbabel psi4
+        conda create -q -n condaenv -c openbabel -c theochem python=$TRAVIS_PYTHON_VERSION horton openbabel
 
         source activate condaenv
         conda install pytest pytest-cov codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ addons:
     apt:
       packages:
         - swig
-cache:
-  pip: true
-  directories:
-    - $HOME/miniconda
+
+# Disable caching (#936), see
+# https://github.com/cclib/cclib/pull/930#issuecomment-680869933.
+#
+# cache:
+#   pip: true
+#   directories:
+#     - $HOME/miniconda
 
 before_install:
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu eoan universe"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ addons:
 before_install:
   # For Python 3.6+ machine, horton 3 IOData is installed from source. For Python 2.7 machine, horton 2 is installed from conda.
   # From the documentation, horton 3 works with Python 3.6+ and horton 2 does with Python 2.7
+  #
+  # For Open Babel,
+  # - 2.7: Use 2.4.1 from conda, because PyQuante 1.x requires the 2.4.x API.
+  # - 3.5: Use the latest version from PyPI and build the bindings to the
+  #   OS-provided libraries. The Ubuntu package doesn't install a pkgconfig
+  #   file for the OB setup.py file to find, so it incorrectly guesses header
+  #   and library paths under /usr/local. Pass the correct paths to the
+  #   underlying "python setup.py build_ext" command.
+  # - >= 3.6: Use the latest version from conda.
   - |
     if [[ $(echo "$TRAVIS_PYTHON_VERSION >= 3.6" | bc -l) == 1 ]];
     then
@@ -33,7 +42,7 @@ before_install:
         conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel=2.4.1 psi4
 
         source activate condaenv
         conda install pytest pytest-cov codecov pytest-shutil
@@ -62,7 +71,7 @@ before_install:
     else
         # Python 3.5
         sudo apt install libopenbabel-dev
-        python -m pip install openbabel
+        python -m pip install --global-option=build_ext --global-option='-I/usr/include/openbabel3' --global-option='-L/usr/lib/openbabel3' openbabel
         python -m pip install -U pytest pytest-cov
     fi
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
   # For Python 3.6+ machine, horton 3 IOData is installed from source. For Python 2.7 machine, horton 2 is installed from conda.
   # From the documentation, horton 3 works with Python 3.6+ and horton 2 does with Python 2.7
   #
+  # h5py is needed for both Horton 2 and Horton 3.
+  #
   # For Open Babel,
   # - 2.7: Use 2.4.1 from conda, because PyQuante 1.x requires the 2.4.x API.
   # - 3.5: Use the latest version from PyPI and build the bindings to the
@@ -72,7 +74,7 @@ before_install:
         # Python 3.5
         sudo apt install libopenbabel-dev
         python -m pip install --global-option=build_ext --global-option='-I/usr/include/openbabel3' --global-option='-L/usr/lib/openbabel3' openbabel
-        python -m pip install -U pytest pytest-cov
+        python -m pip install -U pytest pytest-cov h5py
     fi
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,16 @@ before_install:
 
         hash -r
         conda config --add channels conda-forge
+        conda config --add channels psi4
         conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c openbabel -c psi4 python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
 
         source activate condaenv
-        conda install pytest pytest-cov codecov
-        pip install pytest-shutil h5py pyscf
-        pip install git+https://github.com/theochem/iodata.git
+        conda install pytest pytest-cov codecov pytest-shutil
+        python -m pip install h5py pyscf
+        python -m pip install git+https://github.com/theochem/iodata.git
 
         conda list
     elif [[ $(echo "$TRAVIS_PYTHON_VERSION < 3.0" | bc -l) == 1 ]];
@@ -48,21 +49,21 @@ before_install:
 
         hash -r
         conda config --add channels conda-forge
+        conda config --add channels theochem
         conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv -c openbabel -c theochem python=$TRAVIS_PYTHON_VERSION horton openbabel
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION horton openbabel
 
         source activate condaenv
-        conda install pytest pytest-cov codecov
-        pip install pytest-shutil pyscf
+        conda install pytest pytest-cov codecov pytest-shutil
 
         conda list
     else
         # Python 3.5
         sudo apt install libopenbabel-dev
         python -m pip install openbabel
-        python -m pip install -U pytest pytest-cov h5py
+        python -m pip install -U pytest pytest-cov
     fi
   - pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
         conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel=2.4.1 psi4
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION ci-psi4 openbabel psi4
 
         source activate condaenv
         conda install pytest pytest-cov codecov pytest-shutil
@@ -62,7 +62,7 @@ before_install:
         conda config --set always_yes yes --set changeps1 no --set channel_priority flexible
         conda update -q conda
         conda info -a
-        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION horton openbabel
+        conda create -q -n condaenv python=$TRAVIS_PYTHON_VERSION horton openbabel=2.4.1
 
         source activate condaenv
         conda install pytest pytest-cov codecov pytest-shutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ periodictable
 
 # bridges
 biopython==1.76
-openbabel==2.4.1
 # For some reason PyQuante can't be installed from PyPI.
 https://sourceforge.net/projects/pyquante/files/PyQuante-1.6/PyQuante-1.6.5/PyQuante-1.6.5.tar.gz  ; python_version <= '2.7'
 git+https://github.com/rpmuller/pyquante2.git ; python_version > '3.0'


### PR DESCRIPTION
Closes #936 

This PR also
- Updates the distro from Xenial to Focal (20.04 LTS)
- Removes Open Babel from `requirements.txt` in favor of specifying it explicitly in `.travis.yml`