### PR TITLE
Fixing bug with two letter chemical symbols

### DIFF
--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -303,7 +303,7 @@ cannot be determined. Rerun without `$molecule read`."""
         line = next(inputfile)
         assert len(line.split()) == min(self.ncolsblock, ncols)
         colcounter = 0
-        split_fixed = utils.WidthSplitter((4, 3, 5, 6, 10, 10, 10, 10, 10, 10))
+        split_fixed = utils.WidthSplitter((4, 4, 4, 6, 10, 10, 10, 10, 10, 10))
         while colcounter < ncols:
             # If the line is just the column header (indices)...
             if line[:5].strip() == '':

--- a/test/regression.py
+++ b/test/regression.py
@@ -2556,6 +2556,16 @@ def testQChem_QChem5_0_argon_out(logfile):
     assert logfile.data.scfenergies[0] == convertor(state_0_energy, 'hartree', 'eV')
     assert abs(logfile.data.etenergies[0] - convertor(state_1_energy - state_0_energy, 'hartree', 'wavenumber')) < 1.0e-1
 
+def testQChem_QChem5_0_Si_out(logfile):
+    """
+    This job includes MOs as a test for this version. This fist MO coefficient is checked to ensure they were parsed.
+    """
+    assert logfile.data.metadata["legacy_package_version"] == "5.0.2"
+    assert logfile.data.metadata["package_version"] == "5.0.2"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
+    assert logfile.data.mocoeffs[0][0,0] == 1.00042
 
 def testQChem_QChem5_1_old_final_print_1_out(logfile):
     """This job has was run from a development version."""


### PR DESCRIPTION
This is to address the issue in #942 . I'm not sure what the best approach is incorporating a test for this behavior would be. Any advice would be appreciated!