### PR TITLE
convert Gaussian's grads from input oriantion to standard orientation

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -156,6 +156,15 @@ class Gaussian(logfileparser.Logfile):
             self.atomcoords= \
               [self.atomcoords_BOMD[i] for i in sorted(self.atomcoords_BOMD.keys())]
 
+        # Gaussian prints 'forces' in input orientation unlike other values such as 'moments' or 'vibdisp'.
+        # Therefore, we convert 'grads' to the values in standard orientation with rotation matrix.
+        if hasattr(self, 'grads') and hasattr(self, 'inputcoords') and hasattr(self, 'atomcoords'):
+            grads_std = []
+            for grad, inputcoord, atomcoord in zip(self.grads, self.inputcoords, self.atomcoords):
+                rotation = utils.get_rotation(numpy.array(inputcoord), numpy.array(atomcoord))
+                grads_std.append(rotation.apply(grad))
+            self.grads = numpy.array(grads_std)
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -163,7 +163,7 @@ class Gaussian(logfileparser.Logfile):
             for grad, inputcoord, atomcoord in zip(self.grads, self.inputcoords, self.atomcoords):
                 rotation = utils.get_rotation(numpy.array(inputcoord), numpy.array(atomcoord))
                 grads_std.append(rotation.apply(grad))
-            self.grads = numpy.array(grads_std)
+            self.set_attribute('grads', numpy.array(grads_std))
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -10,6 +10,7 @@
 import sys
 import numpy
 import periodictable
+import scipy.spatial.transform
 
 
 # See https://github.com/kachayev/fn.py/commit/391824c43fb388e0eca94e568ff62cc35b543ecb
@@ -155,6 +156,25 @@ def convertor(value, fromunits, tounits):
 
     return _convertor["%s_to_%s" % (fromunits, tounits)](value)
 
+def get_rotation(a, b):
+    """Get rotation part for transforming a to b, where a and b are same positions with different orientations
+    If one atom positions, i.e (1,3) shape array, are given, it returns identify transformation
+
+    Args:
+        a (np.ndarray): positions with shape(N,3)
+        b (np.ndarray): positions with shape(N,3)
+    Returns:
+        scipy.spatial.transform.Rotation
+    """
+    assert a.shape == b.shape
+    if a.shape[0] == 1:
+        return scipy.spatial.transform.Rotation.from_euler('xyz', [0,0,0])
+    # remove translation part
+    a_ = a - a[0]
+    b_ = b - b[0]
+    # get rotation
+    r, _ = scipy.spatial.transform.Rotation.align_vectors(b_, a_)
+    return r
 
 class PeriodicTable(object):
     """Allows conversion between element name and atomic no."""

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -201,7 +201,7 @@ def get_rotation(a, b):
             rmat = _get_rmat_from_vecs(a_[idx], b_[idx])
             r = scipy.spatial.transform.Rotation.from_dcm(rmat)
         else:
-            # we need to remove b_[0] and a_[1] ( both of them are [0,0,0] ) to avoid SVD unconvergence error
+            # scipy.spatial.transform.Rotation.match_vectors has bug
             # Kabsch Algorithm
             cov = numpy.dot(b_.T, a_)
             V, S, W = numpy.linalg.svd(cov)

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -280,6 +280,13 @@ Note that many programs print atomic coordinates before and after a geometry opt
 
 If the optimisation has finished successfully, the values in the last row should be smaller than the values in geotargets_ (unless the convergence criteria require otherwise).
 
+
+grads
+---------
+The attribute ``grads`` contains the atom forces (gradients) coordinates as taken from the output file. This is an array of rank 3, with a shape (n,m,3) where n is 1 for a single point calculation and >=1 for a geometry optimisation and m is the number of atoms. The orientation of ``grads`` is equal to that of `atomcoords`_.
+
+**Gaussian**: Gaussian calculation prints grads in the input orientaion. The calculation with symmetry outputs ``atomcoords`` and other values in standard orientation, and we converet ``grads`` to that in standard orientation. The calculation without symmetry (e.g. with ``Symmetry=None`` kyword) outputs outputs ``atomcoords`` and other values, and we don't convert ``grads``.
+
 hessian
 -------
 

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -246,6 +246,14 @@ class DALTONGeoOptTest(GenericGeoOptTest):
         self.assertTrue(sum(convergence) >= 2)
 
 
+class GaussianGeoOptTest(GenericGeoOptTest):
+    """Customzed geometry optimization unittest"""
+
+    def testgradsorientation(self):
+        """Are the orientations for grads and atomcoords are same?"""
+        # since z-coordinates of atomcoords are all 0 for dvb, z-values of grads should be all 0
+        assert numpy.alltrue(numpy.abs(self.data.grads[:,:,2]) < 1e-14)
+
 class MolcasGeoOptTest(GenericGeoOptTest):
     """Customized geometry optimization unittest"""
 

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -247,7 +247,7 @@ class DALTONGeoOptTest(GenericGeoOptTest):
 
 
 class GaussianGeoOptTest(GenericGeoOptTest):
-    """Customzed geometry optimization unittest"""
+    """Customized geometry optimization unittest"""
 
     def testgradsorientation(self):
         """Are the orientations for grads and atomcoords are same?"""

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -54,7 +54,12 @@ class GetRotationTest(unittest.TestCase):
 
     def test_default(self):
         """Is the rotation is correct?"""
-        assert numpy.alltrue(numpy.abs(self.r.as_matrix() - utils.get_rotation(self.a, self.b).as_matrix()) < self.delta)
+        _r = utils.get_rotation(self.a, self.b)
+        # as_dcm is renamed to from_matrix in scipy 1.4.0 and will be removed in sicpy 1.6.0
+        if hasattr(self.r, "as_matrix"):
+            numpy.testing.assert_allclose(self.r.as_matrix(), _r.as_matrix(), atol=self.delta)
+        else:
+            numpy.testing.assert_allclose(self.r.as_dcm(), _r.as_dcm(), atol=self.delta)
 
     def test_two_atoms(self):
         """Is the rotation is correct for 2 atoms?"""
@@ -62,13 +67,16 @@ class GetRotationTest(unittest.TestCase):
         b2 = self.b[:2]
         rotated_diff = self.r.apply(a2) - utils.get_rotation(a2, b2).apply(a2)
         # rotated_diff should be translation
-        assert numpy.alltrue(numpy.abs(rotated_diff[0] - rotated_diff[1]) < self.delta)
+        numpy.testing.assert_allclose(rotated_diff[0], rotated_diff[1], atol=self.delta)
 
     def test_one_atom(self):
         """Is the rotation is identity for 1 atom?"""
         a1 = self.a[:1]
         b1 = self.b[:1]
-        assert numpy.alltrue(numpy.abs(numpy.identity(3) - utils.get_rotation(a1, b1).as_matrix()) < self.delta)
+        if hasattr(self.r, "as_matrix"):
+            numpy.testing.assert_allclose(numpy.eye(3), utils.get_rotation(a1, b1).as_matrix(), atol=self.delta)
+        else:
+            numpy.testing.assert_allclose(numpy.eye(3), utils.get_rotation(a1, b1).as_dcm(), atol=self.delta)
 
 
 class PeriodicTableTest(unittest.TestCase):

--- a/test/testdata
+++ b/test/testdata
@@ -137,8 +137,8 @@ GeoOpt    GAMESSUK    GenericGeoOptTest     basicGAMESS-UK8.0     dvb_gopt_ks.ou
 GeoOpt    GAMESS      GenericGeoOptTest     basicFirefly8.0       dvb_gopt_a.out
 GeoOpt    GAMESS      GenericGeoOptTest     basicGAMESS-US2017    dvb_gopt_a.out
 GeoOpt    GAMESS      GenericGeoOptTest     basicGAMESS-US2018    dvb_gopt_a.out
-GeoOpt    Gaussian    GenericGeoOptTest     basicGaussian09       dvb_gopt.out
-GeoOpt    Gaussian    GenericGeoOptTest     basicGaussian16       dvb_gopt.out
+GeoOpt    Gaussian    GaussianGeoOptTest    basicGaussian09       dvb_gopt.out
+GeoOpt    Gaussian    GaussianGeoOptTest    basicGaussian16       dvb_gopt.out
 GeoOpt    Jaguar      GenericGeoOptTest     basicJaguar7.0        dvb_gopt_b.out
 GeoOpt    Jaguar      GenericGeoOptTest     basicJaguar8.3        dvb_gopt_hf.out
 GeoOpt    Jaguar      GenericGeoOptTest     basicJaguar8.3        dvb_gopt_ks.out


### PR DESCRIPTION
To resolve #924 , I add codes to get rotations for two different orientations and convert Gaussian's `grads` from input orientation to standard orientation. I also add tests for them.

I put parse data with modified codes.
```In [2]:
d = cclib.io.ccread("../data/Gaussian/basicGaussian09/dvb_gopt.out")
print(d.atomcoords[0])
[[ 1.205666e+00  6.768910e-01  0.000000e+00]
 [ 2.200000e-03  1.375535e+00  0.000000e+00]
 [-1.205666e+00  6.892860e-01  0.000000e+00]
 [-1.205666e+00 -6.768910e-01  0.000000e+00]
 [-2.200000e-03 -1.375535e+00  0.000000e+00]
 [ 6.730000e-03  2.470443e+00  0.000000e+00]
 [-2.150459e+00  1.244759e+00  0.000000e+00]
 [-6.730000e-03 -2.470443e+00  0.000000e+00]
 [-2.492798e+00 -1.419218e+00  0.000000e+00]
 [-2.577785e+00 -2.759452e+00  0.000000e+00]
 [-1.654345e+00 -3.363669e+00  0.000000e+00]
 [-3.397785e+00 -7.969190e-01  0.000000e+00]
 [-3.516212e+00 -3.273509e+00  0.000000e+00]
 [ 2.492798e+00  1.419218e+00  0.000000e+00]
 [ 3.397785e+00  7.969190e-01  0.000000e+00]
 [ 2.577785e+00  2.759452e+00  0.000000e+00]
 [ 1.654345e+00  3.363669e+00  0.000000e+00]
 [ 3.516212e+00  3.273509e+00  0.000000e+00]
 [ 1.205666e+00 -6.892860e-01  0.000000e+00]
 [ 2.150459e+00 -1.244759e+00  0.000000e+00]]


In [3]:
print(d.grads[0])
[[ 2.48091490e-02  4.39314689e-02  2.77548848e-18]
 [-1.70627408e-02  1.82563631e-02 -5.95048205e-19]
 [-6.16954350e-03  4.83438670e-02  9.16300244e-19]
 [-2.48091490e-02 -4.39314689e-02 -2.77548848e-18]
 [ 1.70627408e-02 -1.82563631e-02  5.95048205e-19]
 [-1.72486383e-03 -2.56511599e-04 -1.17129917e-19]
 [-1.51493650e-03  8.78288353e-05 -9.43871231e-20]
 [ 1.72486383e-03  2.56511599e-04  1.17129917e-19]
 [-7.70123000e-03 -7.52178374e-03 -6.95803873e-19]
 [ 2.14866236e-02  9.76491600e-03  1.63715802e-18]
 [-1.04593019e-02 -1.24611701e-03 -7.01872810e-19]
 [-1.71598614e-03 -3.99897730e-04 -1.20449400e-19]
 [-1.87451833e-02 -1.16391976e-02 -1.51284969e-18]
 [ 7.70123000e-03  7.52178374e-03  6.95803873e-19]
 [ 1.71598614e-03  3.99897730e-04  1.20449400e-19]
 [-2.14866236e-02 -9.76491600e-03 -1.63715802e-18]
 [ 1.04593019e-02  1.24611701e-03  7.01872810e-19]
 [ 1.87451833e-02  1.16391976e-02  1.51284969e-18]
 [ 6.16954350e-03 -4.83438670e-02 -9.16300244e-19]
 [ 1.51493650e-03 -8.78288353e-05  9.43871231e-20]]
```