### PR TITLE
Fix handling of open shell systems in moldenwriter and wfxwriter

### DIFF
--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -160,17 +160,22 @@ class MOLDEN(filewriter.Writer):
         if hasattr(self.ccdata, 'mosyms'):
             has_syms = True
             syms = self.ccdata.mosyms
+        unres = len(moenergies) > 1
 
         spin = 'Alpha'
-        for i in range(mult):
+        for i in range(len(moenergies)):
             for j in range(len(moenergies[i])):
                 if has_syms:
                     lines.append(' Sym= %s' % syms[i][j])
                 moenergy = utils.convertor(moenergies[i][j], 'eV', 'hartree')
                 lines.append(' Ene= {:10.4f}'.format(moenergy))
                 lines.append(' Spin= %s' % spin)
-                if j <= homos[i]:
-                    lines.append(' Occup= {:10.6f}'.format(2.0 / mult))
+                if unres and j <= homos[i]:
+                    lines.append(' Occup= {:10.6f}'.format(1.0))
+                elif not unres and j <= homos[i] and j <= homos[i+1]:
+                    lines.append(' Occup= {:10.6f}'.format(2.0))
+                elif not unres and j <= homos[i] and j > homos[i+1]:
+                    lines.append(' Occup= {:10.6f}'.format(1.0))
                 else:
                     lines.append(' Occup= {:10.6f}'.format(0.0))
                 # Rearrange mocoeffs according to Molden's lexicographical order.

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -163,7 +163,6 @@ class MOLDEN(filewriter.Writer):
             syms = self.ccdata.mosyms
         unres = len(moenergies) > 1
         openshell = len(homos) > 1
-        print(unres, openshell)
 
         spin = 'Alpha'
         for i in range(len(moenergies)):

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -10,6 +10,7 @@
 import os.path
 import math
 import decimal
+import numpy 
 
 from cclib.parser import utils
 from cclib.io import filewriter
@@ -161,6 +162,8 @@ class MOLDEN(filewriter.Writer):
             has_syms = True
             syms = self.ccdata.mosyms
         unres = len(moenergies) > 1
+        openshell = len(homos) > 1
+        print(unres, openshell)
 
         spin = 'Alpha'
         for i in range(len(moenergies)):
@@ -170,14 +173,22 @@ class MOLDEN(filewriter.Writer):
                 moenergy = utils.convertor(moenergies[i][j], 'eV', 'hartree')
                 lines.append(' Ene= {:10.4f}'.format(moenergy))
                 lines.append(' Spin= %s' % spin)
-                if unres and j <= homos[i]:
-                    lines.append(' Occup= {:10.6f}'.format(1.0))
-                elif not unres and j <= homos[i] and j <= homos[i+1]:
-                    lines.append(' Occup= {:10.6f}'.format(2.0))
-                elif not unres and j <= homos[i] and j > homos[i+1]:
-                    lines.append(' Occup= {:10.6f}'.format(1.0))
+                if unres and openshell: 
+                    if j <= homos[i]:
+                        lines.append(' Occup= {:10.6f}'.format(1.0))
+                    else:
+                        lines.append(' Occup= {:10.6f}'.format(0.0))
+                elif not unres and openshell:
+                    occ = numpy.sum(j <= homos)
+                    if j <= homos[i]:
+                        lines.append(' Occup= {:10.6f}'.format(occ))
+                    else:
+                        lines.append(' Occup= {:10.6f}'.format(0.0))
                 else:
-                    lines.append(' Occup= {:10.6f}'.format(0.0))
+                    if j <= homos[i]:
+                        lines.append(' Occup= {:10.6f}'.format(2.0))
+                    else:
+                        lines.append(' Occup= {:10.6f}'.format(0.0))
                 # Rearrange mocoeffs according to Molden's lexicographical order.
                 mocoeffs[i][j] = self._rearrange_mocoeffs(mocoeffs[i][j])
                 for k, mocoeff in enumerate(mocoeffs[i][j]):

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -182,7 +182,9 @@ class WFXWriter(filewriter.Writer):
 
     def _no_alpha_electrons(self):
         """Section: Number of Alpha Electrons."""
-        return int(numpy.ceil(self.ccdata.nelectrons / 2.0))
+        no_electrons = numpy.sum(self.ccdata.atomnos - self.ccdata.coreelectrons) - self.ccdata.charge
+        no_alpha = (no_electrons + (self.ccdata.mult - 1))//2
+        return int(no_alpha)
 
     def _no_beta_electrons(self):
         """Section: Number of Beta Electrons."""
@@ -394,7 +396,7 @@ class WFXWriter(filewriter.Writer):
         """Return primitve mocoeffs array."""
         prim_mocoeff = []
 
-        for i in range(self.ccdata.mult):
+        for i in range(len(self.ccdata.mocoeffs)):
             for j in range(self._nmos()):
                 mocoeffs = self.ccdata.mocoeffs[i][j]
                 if self.ccdata.metadata['package'] == 'GAMESS':

--- a/test/regression.py
+++ b/test/regression.py
@@ -69,7 +69,7 @@ from cclib.parser import Psi4
 from cclib.parser import QChem
 from cclib.parser import Turbomole
 
-from cclib.io import ccopen
+from cclib.io import ccopen, ccread, moldenwriter
 
 # This assume that the cclib-data repository is located at a specific location
 # within the cclib repository. It would be better to figure out a more natural
@@ -668,18 +668,18 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
         parse_version(logfile.data.metadata["package_version"]), Version
     )
 
-def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename):
+def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(logfile):
     """Check if the molden writer can handle an unrestricted case
     """
-    data = cclib.io.ccread(os.path.join(__filedir__,filename))
-    writer = cclib.io.moldenwriter.MOLDEN(data)
+    data = ccread(os.path.join(__filedir__,logfile))
+    writer = moldenwriter.MOLDEN(data)
     # Check size of Atoms section.
-    self.assertEqual(len(writer._mo_from_ccdata()), (data.nbasis+4)*(data.nmo*2))
+    assert len(writer._mo_from_ccdata()) == (data.nbasis + 4) * (data.nmo * 2)
     # check docc orbital
-    beta_idx = (data.nbasis+4)*(data.nmo)
-    self.assertEqual("Beta" in writer._mo_from_ccdata()[beta_idx+2])
-    self.assertEqual("Occup=   1.000000" in writer._mo_from_ccdata()[beta_idx+3])
-    self.assertEqual("0.989063" in writer._mo_from_ccdata()[beta_idx+4])
+    beta_idx = (data.nbasis + 4) * data.nmo
+    assert "Beta" in writer._mo_from_ccdata()[beta_idx + 2]
+    assert "Occup=   1.000000" in writer._mo_from_ccdata()[beta_idx + 3]
+    assert "0.989063" in writer._mo_from_ccdata()[beta_idx + 4]
 
 
 # GAMESS-UK #

--- a/test/regression.py
+++ b/test/regression.py
@@ -674,12 +674,12 @@ def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename)
     data = cclib.io.ccread(os.path.join(__filedir__,filename))
     writer = cclib.io.moldenwriter.MOLDEN(data)
     # Check size of Atoms section.
-    self.assertEqual(len(writer._mo_from_ccdata()), ((4+len(data.gbasis))*len(data.mocoeffs[0])*2))
+    self.assertEqual(len(writer._mo_from_ccdata()), (data.nbasis+4)*(data.nmo*2))
     # check docc orbital
-    beta_idx = (4+len(data.gbasis) * data.mocoeffs[0])
+    beta_idx = (data.nbasis+4)*(data.nmo)
     self.assertEqual("Beta" in writer._mo_from_ccdata()[beta_idx+2])
     self.assertEqual("Occup=   1.000000" in writer._mo_from_ccdata()[beta_idx+3])
-    self.assertEqual("0.989063" in writer._mo_from_ccdata()[beta_idx+5])
+    self.assertEqual("0.989063" in writer._mo_from_ccdata()[beta_idx+4])
 
 
 # GAMESS-UK #

--- a/test/regression.py
+++ b/test/regression.py
@@ -668,6 +668,14 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
         parse_version(logfile.data.metadata["package_version"]), Version
     )
 
+def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename):
+    """Check if the molden writer can handle an unrestricted (ROHF) case
+    """
+    data = cclib.io.ccread(os.path.join(__filedir__,filename))
+    writer = cclib.io.moldenwriter.MOLDEN(data)
+    # Check size of Atoms section.
+    self.assertEqual(len(writer._mo_from_ccdata()), ((4+len(data.gbasis))*len(data.mocoeffs)))
+
 
 # GAMESS-UK #
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -669,12 +669,17 @@ def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     )
 
 def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename):
-    """Check if the molden writer can handle an unrestricted (ROHF) case
+    """Check if the molden writer can handle an unrestricted case
     """
     data = cclib.io.ccread(os.path.join(__filedir__,filename))
     writer = cclib.io.moldenwriter.MOLDEN(data)
     # Check size of Atoms section.
-    self.assertEqual(len(writer._mo_from_ccdata()), ((4+len(data.gbasis))*len(data.mocoeffs)))
+    self.assertEqual(len(writer._mo_from_ccdata()), ((4+len(data.gbasis))*len(data.mocoeffs[0])*2))
+    # check docc orbital
+    beta_idx = (4+len(data.gbasis) * data.mocoeffs[0])
+    self.assertEqual("Beta" in writer._mo_from_ccdata()[beta_idx+2])
+    self.assertEqual("Occup=   1.000000" in writer._mo_from_ccdata()[beta_idx+3])
+    self.assertEqual("0.989063" in writer._mo_from_ccdata()[beta_idx+5])
 
 
 # GAMESS-UK #


### PR DESCRIPTION
#937 showed that the moldenwriter and wfx writer needed work to handle open shell systems. This PR properly calculated the number of electrons in the wfx writer and removes a loop over the multiplicity. 