### PR TITLE
Allow writing of natural orbitals to the molden file instead of MOs

### DIFF
--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -58,6 +58,7 @@ class Writer(ABC):
         self.indices = indices
         self.terse = terse
         self.ghost = kwargs.get("ghost")
+        self.naturalorbitals = kwargs.get("naturalorbitals")
 
         self.pt = PeriodicTable()
 

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -135,10 +135,10 @@ class MOLDEN(filewriter.Writer):
         return mocoeffs
 
     def _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter(self, data=None):
+        syms = None
         coeffs = None
         occs = None
         energies = None
-        syms = None
 
         if data is None:
             data = self.ccdata
@@ -160,9 +160,9 @@ class MOLDEN(filewriter.Writer):
             occs = data.nsooccnos
 
         if hasattr(data, 'mosyms') and not self.naturalorbitals:
-            mosyms = data.mosyms
+            syms = data.mosyms
         else:
-            mosyms = numpy.full_like(moenergies, 'A', dtype=str)
+            syms = numpy.full_like(energies, 'A', dtype=str)
 
 
         return syms, coeffs, occs, energies
@@ -216,7 +216,7 @@ class MOLDEN(filewriter.Writer):
         index = -1
         molden_lines.extend(self._coords_from_ccdata(index))
 
-        mosyms, mocoeffs, mooccs, moenergies = _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
+        mosyms, mocoeffs, mooccs, moenergies = self._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
 
         if hasattr(self.ccdata, 'gbasis'):
             molden_lines.append('[GTO]')

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -134,6 +134,38 @@ class MOLDEN(filewriter.Writer):
 
         return mocoeffs
 
+    def _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter(self, data=None):
+        coeffs = None
+        occs = None
+        energies = None
+        syms = None
+
+        if data is None:
+            data = self.ccdata
+
+        if not self.naturalorbitals and hasattr(data, 'moenergies') and hasattr(data, 'mocoeffs'):
+            energies = data.moenergies
+            coeffs = data.mocoeffs
+            occs = numpy.zeros((len(data.homos),len(moenergies[0])))
+            occval = 2 // len(data.homos)
+            for i in range(len(data.homos)):
+                occs[i][0:data.homos[i]+1] = occval
+        elif self.naturalorbitals and hasattr(data, 'nooccnos') and hasattr(data, "nocoeffs"):
+            energies = numpy.array([data.nooccnos])
+            coeffs = numpy.array([data.nocoeffs])
+            occs = numpy.array([data.nooccnos])
+        elif self.naturalorbitals and hasattr(data, 'nsooccnos') and hasattr(data, "nsocoeffs"):
+            energies = data.nsooccnos
+            coeffs = data.nsocoeffs
+            occs = data.nsooccnos
+
+        if hasattr(data, 'mosyms') and not self.naturalorbitals:
+            mosyms = data.mosyms
+        else:
+            mosyms = numpy.full_like(moenergies, 'A', dtype=str)
+
+
+        return syms, coeffs, occs, energies
 
     def _mo_from_ccdata(self, mosyms, moenergies, mocoeffs, mooccs):
         """Create [MO] section.
@@ -184,30 +216,7 @@ class MOLDEN(filewriter.Writer):
         index = -1
         molden_lines.extend(self._coords_from_ccdata(index))
 
-        mocoeffs=None
-        mooccs=None
-        moenergies = None
-        if not self.naturalorbitals and hasattr(self.ccdata, 'moenergies') and hasattr(self.ccdata, 'mocoeffs'):
-            moenergies = self.ccdata.moenergies
-            mocoeffs = self.ccdata.mocoeffs
-            mooccs = numpy.zeros((len(self.ccdata.homos),len(moenergies[0])))
-            occval = 2 // len(self.ccdata.homos)
-            for i in range(len(self.ccdata.homos)):
-                mooccs[i][0:self.ccdata.homos[i]+1] = occval
-        elif self.naturalorbitals and hasattr(self.ccdata, 'nooccnos') and hasattr(self.ccdata, "nocoeffs"):
-            moenergies = numpy.array([self.ccdata.nooccnos])
-            mocoeffs = numpy.array([self.ccdata.nocoeffs])
-            mooccs = numpy.array([self.ccdata.nooccnos])
-        elif self.naturalorbitals and hasattr(self.ccdata, 'nsooccnos') and hasattr(self.ccdata, "nsocoeffs"):
-            moenergies = self.ccdata.nsooccnos
-            mocoeffs = self.ccdata.nsocoeffs
-            mooccs = self.ccdata.nsooccnos
-
-        mosyms = None
-        if hasattr(self.ccdata, 'mosyms') and not self.naturalorbitals:
-            mosyms = self.ccdata.mosyms
-        else:
-            mosyms = numpy.full_like(moenergies, 'A', dtype=str)
+        mosyms, mocoeffs, mooccs, moenergies = _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter(self, self.ccdata)
 
         if hasattr(self.ccdata, 'gbasis'):
             molden_lines.append('[GTO]')

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -193,7 +193,7 @@ class MOLDEN(filewriter.Writer):
             mooccs = numpy.zeros((len(self.ccdata.homos),len(moenergies[0])))
             occval = 2 // len(self.ccdata.homos)
             for i in range(len(self.ccdata.homos)):
-                mooccs[i][0:self.ccdata.homos[i]] = occval
+                mooccs[i][0:self.ccdata.homos[i]+1] = occval
         elif self.naturalorbitals and hasattr(self.ccdata, 'nooccnos') and hasattr(self.ccdata, "nocoeffs"):
             moenergies = numpy.array([self.ccdata.nooccnos])
             mocoeffs = numpy.array([self.ccdata.nocoeffs])

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -209,11 +209,10 @@ class MOLDEN(filewriter.Writer):
         else:
             mosyms = numpy.full_like(moenergies, 'A', dtype=str)
 
-        # Either both [GTO] and [MO] should be present or none of them.
-        if hasattr(self.ccdata, 'gbasis') and all(attr is not None for attr in (mosyms, moenergies, mooccs)):
+        if hasattr(self.ccdata, 'gbasis'):
             molden_lines.append('[GTO]')
             molden_lines.extend(self._gto_from_ccdata())
-
+        if all(attr is not None for attr in (mosyms, moenergies, mooccs)):
             molden_lines.append('[MO]')
             molden_lines.extend(self._mo_from_ccdata(mosyms, moenergies, mocoeffs, mooccs))
 

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -153,7 +153,7 @@ class MOLDEN(filewriter.Writer):
         spin = 'Alpha'
         for i in range(len(mooccs)):
             for j in range(len(mooccs[i])):
-                restricted_spin_idx = i // len(mocoeffs)
+                restricted_spin_idx = i % len(mocoeffs)
                 lines.append(' Sym= {}'.format(mosyms[restricted_spin_idx][j]))
                 moenergy = utils.convertor(moenergies[restricted_spin_idx][j], 'eV', 'hartree')
                 lines.append(' Ene= {:10.4f}'.format(moenergy))

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -210,7 +210,7 @@ class MOLDEN(filewriter.Writer):
             mosyms = numpy.full_like(moenergies, 'A', dtype=str)
 
         # Either both [GTO] and [MO] should be present or none of them.
-        if hasattr(self.ccdata, 'gbasis') and mosyms is not None and moenergies is not None and mocoeffs is not None and mooccs is not None:
+        if hasattr(self.ccdata, 'gbasis') and all(attr is not None for attr in (mosyms, moenergies, mooccs)):
             molden_lines.append('[GTO]')
             molden_lines.extend(self._gto_from_ccdata())
 

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -216,7 +216,7 @@ class MOLDEN(filewriter.Writer):
         index = -1
         molden_lines.extend(self._coords_from_ccdata(index))
 
-        mosyms, mocoeffs, mooccs, moenergies = _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter(self, self.ccdata)
+        mosyms, mocoeffs, mooccs, moenergies = _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
 
         if hasattr(self.ccdata, 'gbasis'):
             molden_lines.append('[GTO]')

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -220,6 +220,7 @@ class MOLDEN(filewriter.Writer):
 
         spin = 'Alpha'
         for i in range(len(nooccnos)):
+            lines.append(' Symm= {}'.format("A"))
             lines.append(' Ene= {:10.4f}'.format(nooccnos[i]))
             lines.append(' Spin= %s' % spin)
             lines.append(' Occup= {:10.6f}'.format(nooccnos[i]))
@@ -249,7 +250,7 @@ class MOLDEN(filewriter.Writer):
 
         # Either both [GTO] and [MO] should be present or none of them.
         if hasattr(self.ccdata, 'gbasis') and hasattr(self.ccdata, 'mocoeffs')\
-                and hasattr(self.ccdata, 'moenergies'):
+                and hasattr(self.ccdata, 'moenergies') and not self.naturalorbitals:
 
             molden_lines.append('[GTO]')
             molden_lines.extend(self._gto_from_ccdata())
@@ -258,7 +259,7 @@ class MOLDEN(filewriter.Writer):
             molden_lines.extend(self._mo_from_ccdata())
 
         if hasattr(self.ccdata, 'gbasis') and hasattr(self.ccdata, 'nocoeffs')\
-                and hasattr(self.ccdata, 'nooccnos'):
+                and hasattr(self.ccdata, 'nooccnos') and self.naturalorbitals:
 
             molden_lines.append('[GTO]')
             molden_lines.extend(self._gto_from_ccdata())

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -134,11 +134,11 @@ class MOLDEN(filewriter.Writer):
 
         return mocoeffs
 
-    def _syms_coeffs_occs_energies_from_ccdata_for_moldenwriter(self, data=None):
+    def _syms_energies_occs_coeffs_from_ccdata_for_moldenwriter(self, data=None):
         syms = None
-        coeffs = None
-        occs = None
         energies = None
+        occs = None
+        coeffs = None
 
         if data is None:
             data = self.ccdata
@@ -165,9 +165,9 @@ class MOLDEN(filewriter.Writer):
             syms = numpy.full_like(energies, 'A', dtype=str)
 
 
-        return syms, coeffs, occs, energies
+        return syms, energies, occs, coeffs
 
-    def _mo_from_ccdata(self, mosyms, moenergies, mocoeffs, mooccs):
+    def _mo_from_ccdata(self, mosyms, moenergies, mooccs, mocoeffs):
         """Create [MO] section.
 
         Sym= symmetry_label_1
@@ -216,14 +216,14 @@ class MOLDEN(filewriter.Writer):
         index = -1
         molden_lines.extend(self._coords_from_ccdata(index))
 
-        mosyms, mocoeffs, mooccs, moenergies = self._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
+        mosyms, moenergies, mooccs, mocoeffs = self._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
 
         if hasattr(self.ccdata, 'gbasis'):
             molden_lines.append('[GTO]')
             molden_lines.extend(self._gto_from_ccdata())
         if all(attr is not None for attr in (mosyms, moenergies, mooccs)):
             molden_lines.append('[MO]')
-            molden_lines.extend(self._mo_from_ccdata(mosyms, moenergies, mocoeffs, mooccs))
+            molden_lines.extend(self._mo_from_ccdata(mosyms, moenergies, mooccs, mocoeffs))
 
         # Omitting until issue #390 is resolved.
         # https://github.com/cclib/cclib/issues/390

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -146,7 +146,7 @@ class MOLDEN(filewriter.Writer):
         if not self.naturalorbitals and hasattr(data, 'moenergies') and hasattr(data, 'mocoeffs'):
             energies = data.moenergies
             coeffs = data.mocoeffs
-            occs = numpy.zeros((len(data.homos),len(moenergies[0])))
+            occs = numpy.zeros((len(data.homos),len(energies[0])))
             occval = 2 // len(data.homos)
             for i in range(len(data.homos)):
                 occs[i][0:data.homos[i]+1] = occval

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1034,7 +1034,9 @@ class GAMESS(logfileparser.Logfile):
         #   55  C  1 XYZ   0.000000   0.000000   0.000000   0.000000   0.000000
         #   56  C  1XXXX  -0.000014  -0.000067   0.000000   0.000000   0.000000
         #
-        if line.find("EIGENVECTORS") == 10 or line.find("MOLECULAR ORBITALS") == 10:
+        if line.find("EIGENVECTORS") == 10 or \
+           line.find("MOLECULAR ORBITALS") == 10 or \
+           line.find("INITIAL GUESS ORBITALS") == 30:
 
             # This is the stuff that we can read from these blocks.
             self.moenergies = [[]]
@@ -1231,7 +1233,8 @@ class GAMESS(logfileparser.Logfile):
         #    2  O  1  S    0.000000   0.754402   0.004472  -0.581970   0.000000
         # ...
         #
-        if line[10:30] == "CIS NATURAL ORBITALS":
+        if line[10:30] == "CIS NATURAL ORBITALS" or \
+           line[10:50] == "NATURAL ORBITALS IN ATOMIC ORBITAL BASIS":
 
             self.nocoeffs = numpy.zeros((self.nmo, self.nbasis), "d")
             self.nooccnos = []

--- a/cclib/scripts/ccwrite.py
+++ b/cclib/scripts/ccwrite.py
@@ -49,6 +49,10 @@ def main() -> None:
                         default=None,
                         help='optional zero-based index for which structure to extract')
 
+    parser.add_argument('-n', '--naturalorbitals',
+                        action='store_true',
+                        help='(molden only) write natural orbitals out instead of molecular orbitals.')
+
     args = parser.parse_args()
 
     outputtype = args.outputtype
@@ -58,6 +62,7 @@ def main() -> None:
     future = args.future
     index = args.index
     ghost = args.ghost
+    naturalorbitals = args.naturalorbitals
 
     for filename in filenames:
 
@@ -93,6 +98,8 @@ def main() -> None:
             ccwrite_kwargs['future'] = True
         if ghost:
             ccwrite_kwargs['ghost'] = ghost
+        if naturalorbitals:
+            ccwrite_kwargs['naturalorbitals'] = True
         # For XYZ files, write the last geometry unless otherwise
         # specified.
         if not index:

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -103,8 +103,8 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
-        nosyms, nooccnos, nocoeffs, nooccnos = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
-        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, nooccnos, nocoeffs, nooccnos))))
+        nosyms, nocoeffs, nooccs, noenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
+        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, noenergies, nocoeffs, nooccs))))
         assert size_no_writer == size_no_ccdata
 
     def test_round_molden(self):

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -106,8 +106,10 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
+        nooccnos = numpy.array([self.ccdata.nooccnos])
+        nocoeffs = numpy.array([self.ccdata.nocoeffs])
         nosyms = numpy.full_like(data.nooccnos, 'A', dtype=str)
-        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, data.nooccnos, data.nocoeffs, data.nooccnos))))
+        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, nooccnos, nocoeffs, nooccnos))))
         assert size_no_writer == size_no_ccdata
 
     def test_round_molden(self):

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -86,7 +86,11 @@ class MOLDENTest(unittest.TestCase):
             size_mo_ccdata += len(data.moenergies[i]) *\
                                 (len(data.mocoeffs[i][0]) + extra)
         # Filter blank lines.
-        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(data.mosyms, data.moenergies, data.mocoeffs, data.mooccs))))
+        mooccs = numpy.zeros((len(data.homos),len(data.moenergies[0])))
+        occval = 2 // len(data.homos)
+        for i in range(len(data.homos)):
+            mooccs[i][0:data.homos[i]] = occval
+        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(data.mosyms, data.moenergies, data.mocoeffs, mooccs))))
         assert size_mo_writer == size_mo_ccdata
 
     def test_no_section_size(self):

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -106,8 +106,8 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
-        nooccnos = numpy.array([self.ccdata.nooccnos])
-        nocoeffs = numpy.array([self.ccdata.nocoeffs])
+        nooccnos = numpy.array([data.nooccnos])
+        nocoeffs = numpy.array([data.nocoeffs])
         nosyms = numpy.full_like(data.nooccnos, 'A', dtype=str)
         size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, nooccnos, nocoeffs, nooccnos))))
         assert size_no_writer == size_no_ccdata

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -108,7 +108,7 @@ class MOLDENTest(unittest.TestCase):
         # Filter blank lines.
         nooccnos = numpy.array([data.nooccnos])
         nocoeffs = numpy.array([data.nocoeffs])
-        nosyms = numpy.full_like(data.nooccnos, 'A', dtype=str)
+        nosyms = numpy.full_like(nooccnos, 'A', dtype=str)
         size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, nooccnos, nocoeffs, nooccnos))))
         assert size_no_writer == size_no_ccdata
 

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -14,6 +14,7 @@ import cclib
 from cclib.io.filewriter import MissingAttributeError
 from cclib.io.moldenwriter import MoldenReformatter
 from cclib.io.moldenwriter import round_molden
+import numpy
 import pytest
 
 __filedir__ = os.path.dirname(__file__)
@@ -101,10 +102,9 @@ class MOLDENTest(unittest.TestCase):
         writer = cclib.io.moldenwriter.MOLDEN(data)
         # Check size of NO section.
         size_no_ccdata = 0
-        extra = 4 
-        for i in range(data.mult):
-            size_no_ccdata += len(data.nooccnos[i]) *\
-                                (len(data.nocoeffs[i][0]) + extra)
+        extra = 4
+        size_no_ccdata += len(data.nooccnos) *\
+                                (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
         nosyms = numpy.full_like(moenergies, 'A', dtype=str)
         size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, data.nooccnos, data.nocoeffs, data.nooccnos))))

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -86,8 +86,25 @@ class MOLDENTest(unittest.TestCase):
             size_mo_ccdata += len(data.moenergies[i]) *\
                                 (len(data.mocoeffs[i][0]) + extra)
         # Filter blank lines.
-        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata())))
+        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(data.mosyms, data.moenergies, data.mocoeffs, data.mooccs))))
         assert size_mo_writer == size_mo_ccdata
+
+    def test_no_section_size(self):
+        """Check if size of NO section is equal to expected."""
+        fpath = os.path.join(__datadir__,
+                             "data/GAMESS/basicGAMESS-US2018/water_cis_dets.out")
+        data = cclib.io.ccread(fpath)
+        writer = cclib.io.moldenwriter.MOLDEN(data)
+        # Check size of NO section.
+        size_no_ccdata = 0
+        extra = 4 
+        for i in range(data.mult):
+            size_no_ccdata += len(data.nooccnos[i]) *\
+                                (len(data.nocoeffs[i][0]) + extra)
+        # Filter blank lines.
+        nosyms = numpy.full_like(moenergies, 'A', dtype=str)
+        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, data.nooccnos, data.nocoeffs, data.nooccnos))))
+        assert size_no_writer == size_no_ccdata
 
     def test_round_molden(self):
         """Check if Molden Style number rounding works as expected."""

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -106,7 +106,7 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
-        nosyms = numpy.full_like(moenergies, 'A', dtype=str)
+        nosyms = numpy.full_like(data.nooccnos, 'A', dtype=str)
         size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, data.nooccnos, data.nocoeffs, data.nooccnos))))
         assert size_no_writer == size_no_ccdata
 

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -87,11 +87,8 @@ class MOLDENTest(unittest.TestCase):
             size_mo_ccdata += len(data.moenergies[i]) *\
                                 (len(data.mocoeffs[i][0]) + extra)
         # Filter blank lines.
-        mooccs = numpy.zeros((len(data.homos),len(data.moenergies[0])))
-        occval = 2 // len(data.homos)
-        for i in range(len(data.homos)):
-            mooccs[i][0:data.homos[i]] = occval
-        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(data.mosyms, data.moenergies, data.mocoeffs, mooccs))))
+        mosyms, mocoeffs, mooccs, moenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
+        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(mosyms, moenergies, mocoeffs, mooccs))))
         assert size_mo_writer == size_mo_ccdata
 
     def test_no_section_size(self):
@@ -106,9 +103,7 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
-        nooccnos = numpy.array([data.nooccnos])
-        nocoeffs = numpy.array([data.nocoeffs])
-        nosyms = numpy.full_like(nooccnos, 'A', dtype=str)
+        nosyms, nooccnos, nocoeffs, nooccnos = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
         size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, nooccnos, nocoeffs, nooccnos))))
         assert size_no_writer == size_no_ccdata
 

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -87,8 +87,8 @@ class MOLDENTest(unittest.TestCase):
             size_mo_ccdata += len(data.moenergies[i]) *\
                                 (len(data.mocoeffs[i][0]) + extra)
         # Filter blank lines.
-        mosyms, mocoeffs, mooccs, moenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
-        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(mosyms, moenergies, mocoeffs, mooccs))))
+        mosyms, moenergies, mooccs, mocoeffs = writer._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
+        size_mo_writer = len(list(filter(None, writer._mo_from_ccdata(mosyms, moenergies, mooccs, mocoeffs))))
         assert size_mo_writer == size_mo_ccdata
 
     def test_no_section_size(self):
@@ -103,8 +103,8 @@ class MOLDENTest(unittest.TestCase):
         size_no_ccdata += len(data.nooccnos) *\
                                 (len(data.nocoeffs[0]) + extra)
         # Filter blank lines.
-        nosyms, nocoeffs, nooccs, noenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
-        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, noenergies, nocoeffs, nooccs))))
+        nosyms, noenergies, nooccs, nocoeffs = writer._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
+        size_no_writer = len(list(filter(None, writer._mo_from_ccdata(nosyms, noenergies, nooccs, nocoeffs))))
         assert size_no_writer == size_no_ccdata
 
     def test_round_molden(self):

--- a/test/regression.py
+++ b/test/regression.py
@@ -764,18 +764,7 @@ def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename)
     """
     data = ccread(os.path.join(__filedir__,filename))
     writer = moldenwriter.MOLDEN(data)
-    moenergies = data.moenergies
-    mocoeffs = data.mocoeffs
-    mooccs = numpy.zeros((len(data.homos),len(moenergies[0])))
-    occval = 2 // len(data.homos)
-    for i in range(len(data.homos)):
-        mooccs[i][0:data.homos[i]+1] = occval
-    mosyms = None
-    if hasattr(data, 'mosyms'):
-        mosyms = data.mosyms
-    else:
-        mosyms = numpy.full_like(moenergies, 'A', dtype=str)
-
+    mosyms, mocoeffs, mooccs, moenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
     molden_lines = writer._mo_from_ccdata(mosyms,moenergies,mocoeffs,mooccs)
     # Check size of Atoms section.
     assert len(molden_lines) == (data.nbasis + 4) * (data.nmo * 2)

--- a/test/regression.py
+++ b/test/regression.py
@@ -764,7 +764,7 @@ def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename)
     """
     data = ccread(os.path.join(__filedir__,filename))
     writer = moldenwriter.MOLDEN(data)
-    mosyms, mocoeffs, mooccs, moenergies = writer._syms_coeffs_occs_energies_from_ccdata_for_moldenwriter()
+    mosyms, mocoeffs, mooccs, moenergies = writer._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
     molden_lines = writer._mo_from_ccdata(mosyms,moenergies,mocoeffs,mooccs)
     # Check size of Atoms section.
     assert len(molden_lines) == (data.nbasis + 4) * (data.nmo * 2)

--- a/test/regression.py
+++ b/test/regression.py
@@ -764,8 +764,8 @@ def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename)
     """
     data = ccread(os.path.join(__filedir__,filename))
     writer = moldenwriter.MOLDEN(data)
-    mosyms, mocoeffs, mooccs, moenergies = writer._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
-    molden_lines = writer._mo_from_ccdata(mosyms,moenergies,mocoeffs,mooccs)
+    mosyms, moenergies, mooccs, mocoeffs = writer._syms_energies_occs_coeffs_from_ccdata_for_moldenwriter()
+    molden_lines = writer._mo_from_ccdata(mosyms,moenergies,mooccs,mocoeffs)
     # Check size of Atoms section.
     assert len(molden_lines) == (data.nbasis + 4) * (data.nmo * 2)
     # check docc orbital

--- a/test/regression.py
+++ b/test/regression.py
@@ -764,13 +764,26 @@ def testnoparseGAMESS_WinGAMESS_H2O_def2SVPD_triplet_2019_06_30_R1_out(filename)
     """
     data = ccread(os.path.join(__filedir__,filename))
     writer = moldenwriter.MOLDEN(data)
+    moenergies = data.moenergies
+    mocoeffs = data.mocoeffs
+    mooccs = numpy.zeros((len(data.homos),len(moenergies[0])))
+    occval = 2 // len(data.homos)
+    for i in range(len(data.homos)):
+        mooccs[i][0:data.homos[i]+1] = occval
+    mosyms = None
+    if hasattr(data, 'mosyms'):
+        mosyms = data.mosyms
+    else:
+        mosyms = numpy.full_like(moenergies, 'A', dtype=str)
+
+    molden_lines = writer._mo_from_ccdata(mosyms,moenergies,mocoeffs,mooccs)
     # Check size of Atoms section.
-    assert len(writer._mo_from_ccdata()) == (data.nbasis + 4) * (data.nmo * 2)
+    assert len(molden_lines) == (data.nbasis + 4) * (data.nmo * 2)
     # check docc orbital
     beta_idx = (data.nbasis + 4) * data.nmo
-    assert "Beta" in writer._mo_from_ccdata()[beta_idx + 2]
-    assert "Occup=   1.000000" in writer._mo_from_ccdata()[beta_idx + 3]
-    assert "0.989063" in writer._mo_from_ccdata()[beta_idx + 4]
+    assert "Beta" in molden_lines[beta_idx + 2]
+    assert "Occup=   1.000000" in molden_lines[beta_idx + 3]
+    assert "0.989063" in molden_lines[beta_idx + 4]
 
 
 # GAMESS-UK #


### PR DESCRIPTION
This will need to be rebased on #945 

This adds a flag to write natural orbitals if they are present. Since the corresponding eigenvalues are occupation numbers rather than mo energies, the mo energies are just set to the occupation numbers. Let me know if this sounds inappropriate.

To Do:
Add test