### PR TITLE
ORCA: constrained geom opt has an extra line before gradients

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -546,6 +546,12 @@ Dispersion correction           -0.016199959
                 self.skip_lines(inputfile, ['dashes', 'blank'])
 
             line = next(inputfile).strip()
+            if 'CONSTRAINED CARTESIAN COORDINATES' in line:
+                self.skip_line(
+                    inputfile, 'constrained Cartesian coordinate warning'
+                )
+                line = next(inputfile).strip()
+
             while line:
                 tokens = line.split()
                 x, y, z = float(tokens[-3]), float(tokens[-2]), float(tokens[-1])

--- a/test/regression.py
+++ b/test/regression.py
@@ -1673,6 +1673,17 @@ def testORCA_ORCA4_1_single_atom_freq_out(logfile):
     numpy.testing.assert_almost_equal(logfile.data.freeenergy, -460.16182, 6)
 
 
+def testORCA_ORCA4_2_947_out(logfile):
+    """A constrained geometry optimization which prints the extra line
+
+    WARNING: THERE ARE 5 CONSTRAINED CARTESIAN COORDINATES
+
+    just before the gradient.
+    """
+    assert len(logfile.data.atomcoords) == 7
+    assert len(logfile.data.grads) == 6
+
+
 def testORCA_ORCA4_2_MP2_gradient_out(logfile):
     """ORCA numerical frequency calculation with gradients."""
     assert logfile.data.metadata["package_version"] == "4.2.0"


### PR DESCRIPTION
Closes #947 

The associated regression test is https://github.com/cclib/cclib-data/pull/136.