### PR TITLE
Speed up `Volume.electrondensity_spin` and `Volume.wavefunction`

### DIFF
--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -62,10 +62,23 @@ if _found_pyquante:
 
         return bfs
 
-    # Small wrapper PyQuante & pyquante2 function that evaluates basis function on a given point
-    # Used in both `wavefunction` and `electrondensity`
     def pyamp(bfs, bs, points):
-        # 1D numpy array with size 1 is returned from __call__ here.
+        """Wrapper for evaluating basis functions at one or more grid points.
+
+        Parameters
+        ----------
+        bfs : list
+            List of PyQuante 1 `CGBFs`s (contracted Gaussian basis functions).
+        bs : int
+            Index into the list of CGBFs for the basis function to evaluate.
+        points : numpy.ndarray
+            An [n, 3] array of `n` Cartesian grid points on which to evaluate the basis function.
+
+        Returns
+        -------
+        out : numpy.ndarray
+            An [n, ] array of the requested basis function's value on each grid point.
+        """
         mesh_vals = numpy.zeros(len(points))
         for i in range(len(points)):
             mesh_vals[i] = bfs[bs].amp(points[i][0], points[i][1], points[i][2])
@@ -103,10 +116,23 @@ if _found_pyquante2:
 
         return bfs
 
-    # Small wrapper PyQuante & pyquante2 function that evaluates basis function on a given point
-    # Used in both `wavefunction` and `electrondensity`
     def pyamp(bfs, bs, points):
-        # 1D numpy array with size 1 is returned from __call__ here.
+        """Wrapper for evaluating basis functions at one or more grid points.
+
+        Parameters
+        ----------
+        bfs : list
+            List of pyquante2 `cgbf`s (contracted Gaussian basis functions).
+        bs : int
+            Index into the list of CGBFs for the basis function to evaluate.
+        points : numpy.ndarray
+            An [n, 3] array of `n` Cartesian grid points on which to evaluate the basis function.
+
+        Returns
+        -------
+        out : numpy.ndarray
+            An [n, ] array of the requested basis function's value on each grid point.
+        """
         return bfs[bs].mesh(points)
 
 

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -64,8 +64,12 @@ if _found_pyquante:
 
     # Small wrapper PyQuante & pyquante2 function that evaluates basis function on a given point
     # Used in both `wavefunction` and `electrondensity`
-    def pyamp(bfs, bs, x, y, z):
-        return bfs[bs].amp(x, y, z)
+    def pyamp(bfs, bs, points):
+        # 1D numpy array with size 1 is returned from __call__ here.
+        mesh_vals = numpy.zeros(len(points))
+        for i in range(len(points)):
+            mesh_vals[i] = bfs[bs].amp(points[i][0], points[i][1], points[i][2])
+        return mesh_vals
 
 
 _found_pyquante2 = find_package("pyquante2")

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -317,6 +317,7 @@ def wavefunction(ccdata, volume, mocoeffs):
     Output:
         Volume object with wavefunction at each grid point stored in data attribute
     """
+    _check_pyquante()
     bfs = getbfs(ccdata)
 
     wavefn = copy.copy(volume)
@@ -360,7 +361,7 @@ def electrondensity_spin(ccdata, volume, mocoeffslist):
     assert (
         len(mocoeffslist) == 1
     ), "mocoeffslist input to the function should have length of 1."
-
+    _check_pyquante()
     bfs = getbfs(ccdata)
 
     density = copy.copy(volume)


### PR DESCRIPTION
Being able to remove explicit indexing and passing single points for calculating basis function amplitudes on a grid brought this code from 124 to 7 seconds, now almost completely in the Bader code:
```python
from pathlib import Path
from cclib.method import Bader, volume
from cclib.io import ccread
import numpy as np

path_data = Path("/home/eric/development/cclib_berquist/test/method/hf.out")
data = ccread(str(path_data))
vol = volume.Volume((-6, -6, -6), (6, 6, 6), (0.2, 0.2, 0.2))
analysis = Bader(data, vol)
analysis.calculate()
np.testing.assert_allclose(analysis.fragcharges, [10.58407202, 0.35639819], atol=1.0e-8)
```
and the non-regression test suite time from 547 to 214 seconds.

The current breakdown for non-regression test times is:
```
55.73s call     test_method.py::BaderTest::test_symms_benzene                                                                                                                
33.80s call     test_method.py::HirshfeldTest::test_water_charges                                                                                                            
18.47s call     test_method.py::HirshfeldTest::test_chgsum_co
7.84s call     test_method.py::DDEC6Test::test_water_charges
7.72s call     test_data.py::test_all[parsers0-modules0-True-False-40-True-True]
6.30s call     test_method.py::HirshfeldTest::test_chgsum_h2
5.72s call     test_method.py::BaderTest::test_chgsum_hf
5.33s call     test_method.py::DDEC6Test::test_chgsum_co
2.77s call     test_method.py::DDEC6Test::test_chg_nh3
1.68s call     test_method.py::BaderTest::test_val
```
and everything else took less than a second each.