### PR TITLE
Extend pyscf bridge to handle MOs

### DIFF
--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -27,4 +27,6 @@ if find_package("ase"):
 if find_package("iodata"):
     from cclib.bridge.cclib2horton import makehorton
 
+if find_package("pyscf"):
+    from cclib.bridge.cclib2pyscf import makepyscf, makepyscf_mos
 del find_package

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -30,7 +30,7 @@ def makepyscf(data, charge=0, mult=1):
     """Create a Pyscf Molecule."""
     _check_pyscf(_found_pyscf)
     # if hasattr(data, "gbasis"):
-    #     basis = 
+    #     basis =
     inputattrs = data.__dict__
     required_attrs = {"atomcoords", "atomnos"}
     missing = [x for x in required_attrs if not hasattr(data, x)]
@@ -46,7 +46,7 @@ def makepyscf(data, charge=0, mult=1):
         ],
     unit="Angstrom",
     charge=charge,
-    multiplicity=mult  
+    multiplicity=mult
     )
     inputattr = data.__dict__
     pt = PeriodicTable()
@@ -79,12 +79,13 @@ def makepyscf_mos(ccdata,mol):
         cclib object from parsed output
     mol: pyscf Molecule object
        molecule object that must contain the mol.basis attribute
+
     Returns
     ----
     mo_coeff : n_spin x nmo x nao ndarray
         molecular coeffcients, unnormalized according to pyscf standards
     mo_occ : array
-        molecular orbital occupation 
+        molecular orbital occupation
     mo_syms : array
        molecular orbital symmetry labels
     mo_spin: array
@@ -96,8 +97,8 @@ def makepyscf_mos(ccdata,mol):
         mol.build()
         s = mol.intor('int1e_ovlp')
         if np.shape(ccdata.mocoeffs)[0] == 1:
-            mo_coeff = ccdata.mocoeffs[0].T
-            mo_coeff = np.einsum('i,ij->ij', np.sqrt(1/s.diagonal()), mo_coeff)
+            mo_coeffs = ccdata.mocoeffs[0].T
+            mo_coeffs = np.einsum('i,ij->ij', np.sqrt(1/s.diagonal()), mo_coeffs)
             mo_occ = np.zeros(ccdata.nmo)
             mo_occ[:ccdata.homos[0]+1] = 2
             if hasattr(ccdata, 'mosyms'):
@@ -106,11 +107,14 @@ def makepyscf_mos(ccdata,mol):
                 mo_syms = np.full_like(ccdata.moenergies, 'A', dtype=str)
             mo_energies = ccdata.moenergies
         elif np.shape(ccdata.mocoeffs)[0] == 2:
-            mo_coeff = ccdata.mocoeffs
-            mo_coeff = np.einsum('i,ij->ij', np.sqrt(1/s.diagonal()), mo_coeff)
+            mo_coeff_a = ccdata.mocoeffs[0].T
+            mo_coeff_b = ccdata.mocoeffs[1].T
+            mo_coeff_a = np.einsum('i,ij->ij', np.sqrt(1/s.diagonal()), mo_coeff_a)
+            mo_coeff_b = np.einsum('i,ij->ij', np.sqrt(1/s.diagonal()), mo_coeff_b)
             mo_occ = np.zeros((2,ccdata.nmo))
             mo_occ[0,:ccdata.homos[0]+1] = 1
             mo_occ[1,:ccdata.homos[1]+1] = 1
+            mo_coeffs = np.array([mo_coeff_a,mo_coeff_b])
             if hasattr(ccdata, 'mosyms'):
                 mo_syms = ccdata.mosyms
             else:
@@ -119,7 +123,7 @@ def makepyscf_mos(ccdata,mol):
 
 
 
-    return mo_coeff, mo_occ, mo_syms, mo_energies
+    return mo_coeffs, mo_occ, mo_syms, mo_energies
 
 
 

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -29,8 +29,6 @@ def _check_pyscf(found_pyscf):
 def makepyscf(data, charge=0, mult=1):
     """Create a Pyscf Molecule."""
     _check_pyscf(_found_pyscf)
-    # if hasattr(data, "gbasis"):
-    #     basis =
     inputattrs = data.__dict__
     required_attrs = {"atomcoords", "atomnos"}
     missing = [x for x in required_attrs if not hasattr(data, x)]
@@ -40,13 +38,13 @@ def makepyscf(data, charge=0, mult=1):
             "Could not create pyscf molecule due to missing attribute: {}".format(missing)
         )
     mol = gto.Mole(
-    atom=[
-        ["{}".format(data.atomnos[i]), data.atomcoords[-1][i]]
-        for i in range(data.natom)
+        atom=[
+            ["{}".format(data.atomnos[i]), data.atomcoords[-1][i]]
+            for i in range(data.natom)
         ],
-    unit="Angstrom",
-    charge=charge,
-    multiplicity=mult
+        unit="Angstrom",
+        charge=charge,
+        multiplicity=mult
     )
     inputattr = data.__dict__
     pt = PeriodicTable()

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -13,6 +13,19 @@ from cclib.parser.utils import find_package, convertor
 
 
 class PyscfTest(unittest.TestCase):
+    
+"""
+    def setUp(self):
+        super(PyscfTest, self).setUp()
+        if not find_package("pyscf"):
+            raise ImportError("Must install pyscf to run this test")
+        self.data, self.logfile = getdatafile(
+            "Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"]
+        )
+        datadir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "data")
+        )
+"""
     """Tests for the cclib2pyscf bridge in cclib."""
 
     def setUp(self):
@@ -20,7 +33,7 @@ class PyscfTest(unittest.TestCase):
         if not find_package("pyscf"):
             raise ImportError("Must install pyscf to run this test")
         self.data, self.logfile = getdatafile(
-            "GAMESS", "basicGAMESS-US2018", ["water_mp2.out"]
+            "GAMESS", "basicGAMESS-US2018", ["water_ccd.out"]
         )
 
     def test_makepyscf(self):
@@ -41,6 +54,16 @@ class PyscfTest(unittest.TestCase):
         pyscfmol2 = cclib2pyscf.makepyscf(self.data)
         assert pyscfmol2.basis == "sto-3g"
 
+    def test_makepyscf_mos(self):
+        pyscfmol, pyscf_data = cclib2pyscf.makepyscf(self.data)
+        mo_coeff, mo_occ, mo_syms, mo_energies = cclib.bridge.cclib2pyscf.makepyscf_mos(self.data,pyscfmol)
+        assert np.allclose(mo_energies, self.data['mo_energy'])
+        # check first MO coefficient 
+        assert mo_coeff[0] == self.data['mo_coeff'][0][0]
+        # check a random middle MO coefficient 
+        assert mo_coeff[10] == self.data['mo_coeff'][0][10]  
+
 
 if __name__ == "__main__":
     unittest.main()
+    PyscfTest.test_makepyscf_from_molden()

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -6,11 +6,13 @@
 # the terms of the BSD 3-Clause License.
 
 import unittest
+
 import numpy as np
-from test.test_data import getdatafile
+
 from cclib.bridge import cclib2pyscf
 from cclib.parser.utils import find_package, convertor
-import os
+
+from test.test_data import getdatafile
 
 
 class PyscfTest(unittest.TestCase):
@@ -25,9 +27,6 @@ class PyscfTest(unittest.TestCase):
         self.udata, self.ulogfile = getdatafile(
             "GAMESS", "basicGAMESS-US2018", ["dvb_un_sp.out"]
         )
-        # datadir = os.path.abspath(
-        #     os.path.join(os.path.dirname(__file__), "..", "..", "data")
-        # )
 
     def test_makepyscf(self):
         import pyscf

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -22,9 +22,12 @@ class PyscfTest(unittest.TestCase):
         self.data, self.logfile = getdatafile(
             "GAMESS", "basicGAMESS-US2018", ["dvb_sp.out"]
         )
-        datadir = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "data")
+        self.udata, self.ulogfile = getdatafile(
+            "GAMESS", "basicGAMESS-US2018", ["dvb_un_sp.out"]
         )
+        # datadir = os.path.abspath(
+        #     os.path.join(os.path.dirname(__file__), "..", "..", "data")
+        # )
 
     def test_makepyscf(self):
         import pyscf
@@ -48,13 +51,19 @@ class PyscfTest(unittest.TestCase):
     def test_makepyscf_mos(self):
         pyscfmol = cclib2pyscf.makepyscf(self.data)
         mo_coeff, mo_occ, mo_syms, mo_energies = cclib2pyscf.makepyscf_mos(self.data,pyscfmol)
-        assert np.allclose(mo_energies, self.data.moenergies)
+        assert np.allclose(mo_energies,convertor(np.array(self.data.moenergies),"eV","hartree"))
         # check first MO coefficient
-        print(np.shape(np.array(self.data.mocoeffs)))
         assert np.allclose(mo_coeff[0][0], self.data.mocoeffs[0][0][0])
         # check a random middle MO coefficient
         assert np.allclose(mo_coeff[0][10],self.data.mocoeffs[0][10][0])
-
+        # test unrestricted code.
+        pyscfmol = cclib2pyscf.makepyscf(self.udata)
+        mo_coeff, mo_occ, mo_syms, mo_energies = cclib2pyscf.makepyscf_mos(self.udata,pyscfmol)
+        assert np.allclose(mo_energies,convertor(np.array(self.udata.moenergies),"eV","hartree"))
+        # check first MO coefficient
+        assert np.allclose(mo_coeff[0][0][0], self.udata.mocoeffs[0][0][0])
+        # check a random middle MO coefficient
+        assert np.allclose(mo_coeff[0][0][10],self.udata.mocoeffs[0][10][0])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request aims to enable the conversion of additional cclib data into PySCF formatted objects.
There are two ways I imagined going about this. The first would be to create the objects from the ground up in cclib. The second would take advantage of the Molden writer in cclib and Molden parser in PySCF. 
I've gone with the latter since the bridge is compact and the Molden parser of PySCF handles AO ordering and normalization requirements ([specifically, the Cartesian orbitals are not normalized in PySCF.](https://sunqm.github.io/pyscf/_modules/pyscf/tools/molden.html)) 

One change that was required  in the Molden writer. The addition of the SYM label of each MO as 'A' was added in the case the they are not present in the cclib data. This was to accommodate PySCF  as they use the SYM label to distinguish between orbitals. 

What are your thoughts?