### PR TITLE
Raise ImportError when bridges are not available in unit tests

### DIFF
--- a/test/bridge/testase.py
+++ b/test/bridge/testase.py
@@ -13,6 +13,11 @@ import numpy as np
 
 from cclib import ccopen
 from cclib.bridge import cclib2ase
+from cclib.parser.utils import find_package
+
+
+if not find_package('ase'):
+    raise ImportError('Must install ase to run this test')
 
 from ase import Atoms
 from ase.calculators.emt import EMT
@@ -20,6 +25,9 @@ from ase.calculators.emt import EMT
 
 class ASETest(unittest.TestCase):
     """Tests for the cclib2ase bridge in cclib."""
+
+    def setUp(self):
+        super(ASETest, self).setUp()
 
     def test_makease_allows_optimization(self):
         """Ensure makease works from direct input."""

--- a/test/bridge/testbiopython.py
+++ b/test/bridge/testbiopython.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -10,10 +10,16 @@ import unittest
 import numpy
 
 from cclib.bridge import cclib2biopython
+from cclib.parser.utils import find_package
 
 
 class BiopythonTest(unittest.TestCase):
     """Tests for the cclib2biopython bridge in cclib."""
+
+    def setUp(self):
+        super(BiopythonTest, self).setUp()
+        if not find_package("Bio"):
+            raise ImportError("Must install biopython to run this test")
 
     def test_makebiopython(self):
         from Bio.PDB.Superimposer import Superimposer

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -154,7 +154,8 @@ class Horton3Test(unittest.TestCase):
             datadir, "Gaussian", "basicGaussian16", "dvb_un_sp.fchk"
         )
 
-        self._found_iodata = find_package("iodata")
+        if not find_package("iodata"):
+            raise ImportError("Must install iodata to run this test")
 
         from iodata import IOData
         from iodata.orbitals import MolecularOrbitals

--- a/test/bridge/testpsi4.py
+++ b/test/bridge/testpsi4.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -10,12 +10,16 @@ import unittest
 import numpy as np
 
 from cclib.bridge import cclib2psi4
+from cclib.parser.utils import find_package
 
 
 class Psi4Test(unittest.TestCase):
     """Tests for the cclib2psi4 bridge in cclib."""
 
     def test_makepsi4(self):
+        if not find_package('psi4'):
+            raise ImportError('Must install psi4 to run this test')
+
         import psi4
         from psi4 import energy
 

--- a/test/bridge/testpyquante.py
+++ b/test/bridge/testpyquante.py
@@ -21,11 +21,13 @@ class PyquanteTest(unittest.TestCase):
 
     def setUp(self):
         super(PyquanteTest, self).setUp()
-        self._found_pyquante = find_package("PyQuante")
+        if not find_package("PyQuante"):
+            raise ImportError("Must install PyQuante to run this test")
+
         self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["water_ccsd.log"])
 
     def test_makepyquante(self):
-        # Test older PyQuante bridge
+        """Test older PyQuante bridge."""
         from PyQuante.hartree_fock import hf
         from PyQuante.Molecule import Molecule
 
@@ -47,7 +49,9 @@ class pyquante2Test(unittest.TestCase):
 
     def setUp(self):
         super(pyquante2Test, self).setUp()
-        self._found_pyquante2 = find_package("pyquante2")
+        if not find_package("pyquante2"):
+            raise ImportError("Must install pyquante2 to run this test")
+            
         self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["water_ccsd.log"])
 
     def test_makepyquante(self):

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -10,10 +10,16 @@ import unittest
 import numpy as np
 
 from cclib.bridge import cclib2pyscf
+from cclib.parser.utils import find_package
 
 
 class PyscfTest(unittest.TestCase):
     """Tests for the cclib2pyscf bridge in cclib."""
+
+    def setUp(self):
+        super(PyscfTest, self).setUp()        
+        if not find_package('pyscf'):
+            raise ImportError('Must install pyscf to run this test')
 
     def test_makepyscf(self):
         import pyscf


### PR DESCRIPTION
Doesn't really change much, but exceptions are more consistent, and will make it easier to change the behavior (skip, xfail) of these tests in the future if we want.