### PR TITLE
Parsing Gaussian ONIOM files

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -601,12 +601,12 @@ class Gaussian(logfileparser.Logfile):
             if not "full" in line:
                 inputfile.seek(0, 2)
 
-        # Another hack for regression Gaussian03/ortho_prod_prod_freq.log, which is an ONIOM job.
-        # Basically for now we stop parsing after the output for the real system, because
+        # For ONIOM jobs, we skip parsing for the output for the model systems, because
         # currently we don't support changes in system size or fragments in cclib. When we do,
         # we will want to parse the model systems, too, and that is what nmodels could track.
         if "ONIOM: generating point" in line and line.strip()[-13:] == 'model system.' and getattr(self, 'nmodels', 0) > 0:
-            inputfile.seek(0, 2)
+            while not line[1:30] == 'ONIOM: Integrating ONIOM file':
+                line = inputfile.next()
 
         # With the gfinput keyword, the atomic basis set functios are:
         #

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -264,7 +264,7 @@ class Gaussian(logfileparser.Logfile):
 
             self.updateprogress(inputfile, "Charge and Multiplicity", self.fupdate)
 
-            if line.split()[-1] == "supermolecule" or not "fragment" in line:
+            if line.split()[-1] == "supermolecule" or (not "fragment" in line and not "model system" in line):
 
                 regex = r".*=(.*)Mul.*=\s*-?(\d+).*"
                 match = re.match(regex, line)
@@ -275,6 +275,9 @@ class Gaussian(logfileparser.Logfile):
 
             if line.split()[-2] == "fragment":
                 self.nfragments = int(line.split()[-1].strip('.'))
+
+            if line.strip()[-13:] == "model system.":
+                self.nmodels = getattr(self, 'nmodels', 0) + 1
 
         # Number of atoms is also explicitely printed after the above.
         if line[1:8] == "NAtoms=":

--- a/test/regression.py
+++ b/test/regression.py
@@ -1071,12 +1071,13 @@ def testGaussian_Gaussian09_OPT_oniom_log(logfile):
     assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
-def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
-    """Problem parsing IR intensity from mode 192"""
-    assert hasattr(logfile.data, 'vibirs')
-    assert len(logfile.data.vibirs) == 216
-
-    assert logfile.data.metadata["package_version"] == "2009+C.01"
+#def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
+#    """Problem parsing IR intensity from mode 192"""
+#    assert hasattr(logfile.data, 'vibirs')
+#    assert len(logfile.data.vibirs) == 216
+#
+#    assert logfile.data.metadata["package_version"] == "2009+C.01"
+# commented out for now as changes to oniom parsing mean vibirs not parsed for this file
 
 
 def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):

--- a/test/regression.py
+++ b/test/regression.py
@@ -1071,13 +1071,12 @@ def testGaussian_Gaussian09_OPT_oniom_log(logfile):
     assert logfile.data.metadata["package_version"] == "2009+D.01"
 
 
-#def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
-#    """Problem parsing IR intensity from mode 192"""
-#    assert hasattr(logfile.data, 'vibirs')
-#    assert len(logfile.data.vibirs) == 216
-#
-#    assert logfile.data.metadata["package_version"] == "2009+C.01"
-# commented out for now as changes to oniom parsing mean vibirs not parsed for this file
+def testGaussian_Gaussian09_oniom_IR_intensity_log(logfile):
+    """Problem parsing IR intensity from mode 192"""
+    assert hasattr(logfile.data, 'vibirs')
+    assert len(logfile.data.vibirs) == 216
+
+    assert logfile.data.metadata["package_version"] == "2009+C.01"
 
 
 def testGaussian_Gaussian09_Ru2bpyen2_H2_freq3_log(logfile):


### PR DESCRIPTION
I think I spotted two issues in gaussianparser.py that are causing some oniom files to be parsed incorrectly.

1.

The real and model systems are tracked in oniom output files via the nmodels attribute, in a similar way to nfragments. Currently this is only parsed via the symbolic Z-matrix, as in ortho_prod_freq.log, however, some files do not have a symbolic Z-matrix, e.g. oniom_IR_intensity.log. 

Parsing via symbolic Z-matrix:

https://github.com/cclib/cclib/blob/8833b3e1003ac4d42841608bb05ebb32a698a1fc/cclib/parser/gaussianparser.py#L229-L233
 
Parsing via charge / multiplicity:

https://github.com/cclib/cclib/blob/8833b3e1003ac4d42841608bb05ebb32a698a1fc/cclib/parser/gaussianparser.py#L269-L271
 
The code at L589-590 uses the self.nmodels attribute to ensure that parsing finishes after the real system is parsed:
 
https://github.com/cclib/cclib/blob/8833b3e1003ac4d42841608bb05ebb32a698a1fc/cclib/parser/gaussianparser.py#L589-L590

However, because nmodels is not updated unless the file has a symbolic Z-matrix, parsing is not stopped for files such as oniom_IR_intensity.log. Instead, parsing continues for the model systems, and some data given by cclib, such as the Mulliken atom charges, is for the last model system and not the real system.

I believe the nmodels attribute should also be tracked via the charge and multiplicity section. This is the case for the nfragments attribute, which is tracked either via the symbolic Z-matrix or via the charge/multiplicity.

Copying lines 232-233 to follow after 269-270 resulted in the correct Mulliken charges being parsed.

2.

L260 originally locates the charge and multiplicity lines:

https://github.com/cclib/cclib/blob/8833b3e1003ac4d42841608bb05ebb32a698a1fc/cclib/parser/gaussianparser.py#L260

Currently, for oniom_IR_intensity.log, all three of the following lines are read:

`Charge = 0 Multiplicity = 1 for low level calculation on real system.`
`Charge = 0 Multiplicity = 1 for high level calculation on model system.`
`Charge = 0 Multiplicity = 1 for low level calculation on model system.`

The charge and mulitplicity are updated from the last line, which means overall the charge and multiplicity for the second model system are being parsed, rather than for the real system (although, in this case, the values are the same).
 
I propose updating L260 as follows:

`if line.split()[-1] == "supermolecule" or (not "fragment" in line and not "model system" in line):`

This would parse the charge/multiplicity for the real system from the first line only:

`Charge = 0 Multiplicity = 1 for low level calculation on real system.`






Following both of these changes the exact same set of data is extracted for ortho_prod_freq.log, as expected. However, for oniom_IR_intensity.log some attributes, such as the atomcharges, change (to those for the real system) whilst many others are no longer parsed at all, e.g. enthalpy, entropy, freeenergy, vibdisps, vibfreqs, and more. This is because parsing is now correctly ended by L589-590, and these attributes appear later in the outfile. Accordingly, none of these attributes are parsed for ortho_prod_freq.log.

On a side note, whilst these changes would bring a consistency to the parsing of the different oniom files, I believe at least some of these attributes actually are for the real system - they just appear later in the outfile. Maybe a possibility would be to replace the `inputfile.seek(0, 2)` with something that skips until a particular line (afterwhich data for the real system appears again), rather than skipping the rest of the file? Although this would rely on data for the model systems not reappearing after a particular point. If not, this might fall under #132 






