### PR TITLE
Fix decode call that apparently sometimes breaks on Travis for Python 3.7

### DIFF
--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -157,7 +157,7 @@ class Stockholder(Method):
                     gridmax = convertor(float(gridmax), "bohr", "Angstrom")
                     gridn = int(gridn)
                     # Convert byte to string in Python3
-                    if sys.version[0] == "3":
+                    if sys.version[0] == "3" and isinstance(gridtype, bytes):
                         gridtype = gridtype.decode("UTF-8")
 
                     # First verify that it is one of recognized grids


### PR DESCRIPTION
Example failure off of #970: https://travis-ci.com/github/cclib/cclib/jobs/427554026
```
...
                    gridtype, gridmin, gridmax, gridn = (
3718                        proatomdb[keystring_floor].attrs["rtransform"].split()
3719                    )
3720                    gridmin = convertor(float(gridmin), "bohr", "Angstrom")
3721                    gridmax = convertor(float(gridmax), "bohr", "Angstrom")
3722                    gridn = int(gridn)
3723                    # Convert byte to string in Python3
3724                    if sys.version[0] == "3":
3725>                       gridtype = gridtype.decode("UTF-8")
3726E                       AttributeError: 'str' object has no attribute 'decode'
3727
3728cclib/method/stockholder.py:161: AttributeError
3729
...
```

Wasn't able to reproduce this locally, but have seen slight string type variations in the past, so this is not entirely surprising. If the failure is a flake, then this will help as well.