### PR TITLE
extending pyscf bridge to basis

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,3 +8,5 @@
 """Unit tests and parser data tests for cclib."""
 
 from .data import *
+from .data import *
+from test import test_data


### PR DESCRIPTION
Extending the PySCF bridge to instantiate a basis set if it is available in cclib data. 

The test checks the energy of RHF in the case the basis is provided and checks in the case of no basis being provided that the PySCF default is initialized. 