### PR TITLE
Cleanup

### DIFF
--- a/cclib/__init__.py
+++ b/cclib/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/bridge/cclib2ase.py
+++ b/cclib/bridge/cclib2ase.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/bridge/cclib2biopython.py
+++ b/cclib/bridge/cclib2biopython.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2psi4.py
+++ b/cclib/bridge/cclib2psi4.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -35,7 +35,7 @@ def makepyquante(data):
     if missing:
         missing = " ".join(missing)
         raise MissingAttributeError(
-            "Could not create pyquante molecule due to missing attribute: {}".format(missing)
+            f"Could not create pyquante molecule due to missing attribute: {missing}"
         )
 
     # In pyquante2, molecular geometry is specified in a format of:

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/__init__.py
+++ b/cclib/io/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -218,7 +218,7 @@ def ccopen(source, *args, **kwargs):
         if not is_url:
             try:
                 inputfile = logfileparser.openlogfile(source)
-            except IOError as error:
+            except OSError as error:
                 if not kwargs.get('quiet', False):
                     (errno, strerror) = error.args
                 return None
@@ -251,7 +251,7 @@ def ccopen(source, *args, **kwargs):
     if is_stream:
         try:
             inputfile.seek(0, 0)
-        except (AttributeError, IOError):
+        except (AttributeError, OSError):
             contents = inputfile.read()
             try:
                 inputfile = io.StringIO(contents)

--- a/cclib/io/cjsonreader.py
+++ b/cclib/io/cjsonreader.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cjsonreader.py
+++ b/cclib/io/cjsonreader.py
@@ -16,12 +16,12 @@ class CJSON(filereader.Reader):
     """A reader for chemical JSON (CJSON) log files."""
 
     def __init__(self, source, *args, **kwargs):
-        super(CJSON, self).__init__(source, *args, **kwargs)
+        super().__init__(source, *args, **kwargs)
 
         self.representation = dict()
 
     def parse(self):
-        super(CJSON, self).parse()
+        super().parse()
 
         json_data = json.loads(self.filecontents)
 

--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -27,7 +27,7 @@ class CJSON(filewriter.Writer):
           ccdata - An instance of ccData, parsed from a logfile.
         """
 
-        super(CJSON, self).__init__(ccdata, terse=terse, *args, **kwargs)
+        super().__init__(ccdata, terse=terse, *args, **kwargs)
 
     def pathname(self, path):
         """Return filename without extension to be used as name."""
@@ -179,7 +179,7 @@ class NumpyAwareJSONEncoder(json.JSONEncoder):
 class JSONIndentEncoder(json.JSONEncoder):
 
     def __init__(self, *args, **kwargs):
-        super(JSONIndentEncoder, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.current_indent = 0
         self.current_indent_str = ""
 

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -50,9 +50,9 @@ class CML(filewriter.Writer):
                 d = {
                     'id': 'a{}'.format(atomid + 1),
                     'elementType': elements[atomid],
-                    'x3': '{:.10f}'.format(x),
-                    'y3': '{:.10f}'.format(y),
-                    'z3': '{:.10f}'.format(z),
+                    'x3': f'{x:.10f}',
+                    'y3': f'{y:.10f}',
+                    'z3': f'{z:.10f}',
                 }
                 _set_attrs(atom, d)
 

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -25,7 +25,7 @@ class CML(filewriter.Writer):
         """
 
         # Call the __init__ method of the superclass
-        super(CML, self).__init__(ccdata, *args, **kwargs)
+        super().__init__(ccdata, *args, **kwargs)
 
     def generate_repr(self):
         """Generate the CML representation of the logfile data."""

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -128,7 +128,7 @@ class Writer(ABC):
         if not self.indices:
             self.indices = set()
         elif not isinstance(self.indices, Iterable):
-            self.indices = set([self.indices])
+            self.indices = {self.indices}
         # This is the most likely place to get the number of
         # geometries from.
         if hasattr(self.ccdata, 'atomcoords'):

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -105,7 +104,7 @@ class MOLDEN(filewriter.Writer):
         lines = ["scf-first    1 THROUGH   %d" % len(self.ccdata.scfenergies)]
 
         for scfenergy in self.ccdata.scfenergies:
-            lines.append('{:15.6f}'.format(scfenergy))
+            lines.append(f'{scfenergy:15.6f}')
 
         return lines
 

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -170,7 +170,7 @@ class MOLDEN(filewriter.Writer):
             for j in range(len(moenergies[i])):
                 lines.append(' Sym= %s' % syms[i][j])
                 moenergy = utils.convertor(moenergies[i][j], 'eV', 'hartree')
-                lines.append(' Ene= {:10.4f}'.format(moenergy))
+                lines.append(f' Ene= {moenergy:10.4f}')
                 lines.append(' Spin= %s' % spin)
                 if unres and openshell: 
                     if j <= homos[i]:
@@ -180,7 +180,7 @@ class MOLDEN(filewriter.Writer):
                 elif not unres and openshell:
                     occ = numpy.sum(j <= homos)
                     if j <= homos[i]:
-                        lines.append(' Occup= {:10.6f}'.format(occ))
+                        lines.append(f' Occup= {occ:10.6f}')
                     else:
                         lines.append(' Occup= {:10.6f}'.format(0.0))
                 else:

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/xyzreader.py
+++ b/cclib/io/xyzreader.py
@@ -15,12 +15,12 @@ class XYZ(filereader.Reader):
     """A reader for XYZ (Cartesian coordinate) files."""
 
     def __init__(self, source, *args, **kwargs):
-        super(XYZ, self).__init__(source, *args, **kwargs)
+        super().__init__(source, *args, **kwargs)
 
         self.pt = PeriodicTable()
 
     def parse(self):
-        super(XYZ, self).parse()
+        super().parse()
 
         self.generate_repr()
 

--- a/cclib/io/xyzreader.py
+++ b/cclib/io/xyzreader.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -89,15 +89,15 @@ class XYZ(filewriter.Writer):
         else:
             geometry_num = index + 1
         if self.jobfilename is not None:
-            comment = "{}: Geometry {}".format(self.jobfilename, geometry_num)
+            comment = f"{self.jobfilename}: Geometry {geometry_num}"
         else:
-            comment = "Geometry {}".format(geometry_num)
+            comment = f"Geometry {geometry_num}"
         # Wrap the geometry number part of the comment in square brackets,
         # prefixing it with one previously parsed if it existed.
         if existing_comment:
-            comment = "{} [{}]".format(existing_comment, comment)
+            comment = f"{existing_comment} [{comment}]"
         else:
-            comment = "[{}]".format(comment)
+            comment = f"[{comment}]"
 
         atom_template = '{:3s} {:15.10f} {:15.10f} {:15.10f}'
         block = []

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -28,7 +28,7 @@ class XYZ(filewriter.Writer):
         self.required_attrs = ('natom', 'atomcoords', 'atomnos')
 
         # Call the __init__ method of the superclass
-        super(XYZ, self).__init__(ccdata, *args, **kwargs)
+        super().__init__(ccdata, *args, **kwargs)
 
         self.do_firstgeom = firstgeom
         self.do_lastgeom = lastgeom

--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -43,7 +43,7 @@ class Bader(Method):
     required_attrs = ("homos", "mocoeffs", "nbasis", "gbasis")
 
     def __init__(self, data, volume, progress=None, loglevel=logging.INFO, logname="Log"):
-        super(Bader, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.volume = volume
         self.fragresults = None
@@ -64,7 +64,7 @@ class Bader(Method):
         return f"Bader({self.data})"
 
     def _check_required_attributes(self):
-        super(Bader, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def calculate(self, indices=None, fupdate=0.05):
         """Calculate Bader's QTAIM charges using on-grid algorithm proposed by Henkelman group

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -57,11 +57,11 @@ class Bader(Method):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Bader's QTAIM charges of {}".format(self.data)
+        return f"Bader's QTAIM charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Bader({})".format(self.data)
+        return f"Bader({self.data})"
 
     def _check_required_attributes(self):
         super(Bader, self)._check_required_attributes()

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -23,11 +23,11 @@ class Bickelhaupt(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Bickelhaupt charges of {}".format(self.data)
+        return f"Bickelhaupt charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Bickelhaupt({})".format(self.data)
+        return f"Bickelhaupt({self.data})"
 
     def calculate(self, indices=None, fupdate=0.05):
         """Perform a Bickelhaupt population analysis."""

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -19,7 +19,7 @@ class Bickelhaupt(Population):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(Bickelhaupt, self).__init__(logname="Bickelhaupt Population Analysis", *args)
+        super().__init__(logname="Bickelhaupt Population Analysis", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -103,7 +103,7 @@ class Bickelhaupt(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(Bickelhaupt, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -43,7 +43,7 @@ class Method:
         self.loglevel = loglevel
         self.logname = logname
         self._check_required_attributes()
-        self.logger = logging.getLogger('%s %s' % (self.logname, self.data))
+        self.logger = logging.getLogger(f'{self.logname} {self.data}')
         self.logger.setLevel(self.loglevel)
         self.logformat = "[%(name)s %(levelname)s] %(message)s"
         handler = logging.StreamHandler(sys.stdout)

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -37,7 +37,7 @@ class CDA(FragmentAnalysis):
         """
 
 
-        retval = super(CDA, self).calculate(fragments, cupdate)
+        retval = super().calculate(fragments, cupdate)
         if not retval:
             return False
 

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -22,7 +22,7 @@ class CSPA(Population):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(CSPA, self).__init__(logname="CSPA", *args)
+        super().__init__(logname="CSPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -75,7 +75,7 @@ class CSPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(CSPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -297,9 +297,9 @@ class DDEC6(Stockholder):
         stockholder_bigW = numpy.sum(stockholder_w, axis=0)
         localized_bigW = numpy.sum(localized_w, axis=0)
 
-        reference_charges = numpy.zeros((self.data.natom))
-        localizedcharges = numpy.zeros((self.data.natom))
-        stockholdercharges = numpy.zeros((self.data.natom))
+        reference_charges = numpy.zeros(self.data.natom)
+        localizedcharges = numpy.zeros(self.data.natom)
+        stockholdercharges = numpy.zeros(self.data.natom)
 
         for atomi in range(self.data.natom):
             # Equation 52 and 51 in doi: 10.1039/c6ra04656h

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -77,11 +77,11 @@ class DDEC6(Stockholder):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "DDEC6 charges of {}".format(self.data)
+        return f"DDEC6 charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "DDEC6({})".format(self.data)
+        return f"DDEC6({self.data})"
 
     def _check_required_attributes(self):
         super(DDEC6, self)._check_required_attributes()
@@ -196,7 +196,7 @@ class DDEC6(Stockholder):
         steps = 5
         self._update_kappa = False
         while steps < 7:
-            self.logger.info("Optimizing grid weights. (Step {}/7)".format(steps))
+            self.logger.info(f"Optimizing grid weights. (Step {steps}/7)")
             self.N_A.append(self._calculate_w_and_u())
 
             # Determine whether kappa needs to be updated or not based on Figure S4.2

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -66,7 +66,7 @@ class DDEC6(Stockholder):
                 total densities that are partitioned resemble the proatom densities and to prevent
                 the numerical algorithm from failing to converge.
         """
-        super(DDEC6, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
+        super().__init__(data, volume, proatom_path, progress, loglevel, logname)
 
         self.convergence_level = convergence_level
         self.max_iteration = max_iteration
@@ -84,7 +84,7 @@ class DDEC6(Stockholder):
         return f"DDEC6({self.data})"
 
     def _check_required_attributes(self):
-        super(DDEC6, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _cartesian_dist(self, pt1, pt2):
         """ Small utility function that calculates Euclidian distance between two points
@@ -94,7 +94,7 @@ class DDEC6(Stockholder):
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float
     ):
-        return super(DDEC6, self)._read_proatom(directory, atom_num, charge)
+        return super()._read_proatom(directory, atom_num, charge)
 
     def calculate(self, indices=None, fupdate=0.05):
         """
@@ -102,7 +102,7 @@ class DDEC6(Stockholder):
         Cartesian, uniformly spaced grids are assumed for this function.
         """
 
-        super(DDEC6, self).calculate()
+        super().calculate()
 
         # Notify user about the total charge in the density grid
         integrated_density = self.charge_density.integrate()

--- a/cclib/method/density.py
+++ b/cclib/method/density.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/density.py
+++ b/cclib/method/density.py
@@ -20,7 +20,7 @@ class Density(Method):
                  logname="Density"):
 
         # Call the __init__ method of the superclass.
-        super(Density, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -20,7 +20,7 @@ class Electrons(Method):
 
         self.required_attrs = ('atomnos','charge','coreelectrons','homos')
 
-        super(Electrons, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Returns a string representation of the object."""

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -21,7 +21,7 @@ class FragmentAnalysis(Method):
                  logname="FragmentAnalysis of"):
 
         # Call the __init__ method of the superclass.
-        super(FragmentAnalysis, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
         self.parsed = False
 
     def __str__(self):

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -116,7 +116,7 @@ class Hirshfeld(Stockholder):
         # radial distance from center of atom chi.
         stockholder_bigW = numpy.sum(stockholder_w, axis=0)
 
-        self.fragcharges = numpy.zeros((self.data.natom))
+        self.fragcharges = numpy.zeros(self.data.natom)
         self.logger.info("Creating fragcharges: array[1]")
 
         for atomi in range(self.data.natom):

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -55,11 +55,11 @@ class Hirshfeld(Stockholder):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Hirshfeld charges of {}".format(self.data)
+        return f"Hirshfeld charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Hirshfeld({})".format(self.data)
+        return f"Hirshfeld({self.data})"
 
     def _check_required_attributes(self):
         super(Hirshfeld, self)._check_required_attributes()

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -51,7 +51,7 @@ class Hirshfeld(Stockholder):
                 proatom_path -- path to proatom densities
                 (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
         """
-        super(Hirshfeld, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
+        super().__init__(data, volume, proatom_path, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -62,7 +62,7 @@ class Hirshfeld(Stockholder):
         return f"Hirshfeld({self.data})"
 
     def _check_required_attributes(self):
-        super(Hirshfeld, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _cartesian_dist(self, pt1, pt2):
         """Small utility function that calculates Euclidian distance between two points.
@@ -74,11 +74,11 @@ class Hirshfeld(Stockholder):
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float
     ):
-        return super(Hirshfeld, self)._read_proatom(directory, atom_num, charge)
+        return super()._read_proatom(directory, atom_num, charge)
 
     def calculate(self):
         """Calculate Hirshfeld charges."""
-        super(Hirshfeld, self).calculate()
+        super().calculate()
 
         # Generator object to iterate over the grid.
         ngridx, ngridy, ngridz = self.charge_density.data.shape

--- a/cclib/method/lpa.py
+++ b/cclib/method/lpa.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/lpa.py
+++ b/cclib/method/lpa.py
@@ -18,7 +18,7 @@ class LPA(Population):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(LPA, self).__init__(logname="LPA", *args)
+        super().__init__(logname="LPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -89,7 +89,7 @@ class LPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(LPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/mbo.py
+++ b/cclib/method/mbo.py
@@ -19,7 +19,7 @@ class MBO(Density):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(MBO, self).__init__(logname="MBO", *args)
+        super().__init__(logname="MBO", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -32,7 +32,7 @@ class MBO(Density):
     def calculate(self, indices=None, fupdate=0.05):
         """Calculate Mayer's bond orders."""
 
-        retval = super(MBO, self).calculate(fupdate)
+        retval = super().calculate(fupdate)
         if not retval: #making density didn't work
             return False
 

--- a/cclib/method/mbo.py
+++ b/cclib/method/mbo.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -129,7 +129,7 @@ class Moments(Method):
                     raise ValueError(msg, e)
             origin_pos = numpy.average(coords, weights=atommasses, axis=0)
         else:
-            raise ValueError("{} is invalid value for 'origin'".format(origin))
+            raise ValueError(f"{origin} is invalid value for 'origin'")
 
         dipole = self._calculate_dipole(charges, coords, origin_pos)
         quadrupole = self._calculate_quadrupole(charges, coords, origin_pos)

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -25,7 +25,7 @@ class Moments(Method):
         self.required_attrs = ('atomcoords', 'atomcharges')
         self.results = {}
 
-        super(Moments, self).__init__(data)
+        super().__init__(data)
 
     def __str__(self):
         """Returns a string representation of the object."""

--- a/cclib/method/mpa.py
+++ b/cclib/method/mpa.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/mpa.py
+++ b/cclib/method/mpa.py
@@ -19,7 +19,7 @@ class MPA(Population):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(MPA, self).__init__(logname="MPA", *args)
+        super().__init__(logname="MPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -80,7 +80,7 @@ class MPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(MPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -157,7 +157,7 @@ class Nuclear(Method):
         choices = ('amu_bohr_2', 'amu_angstrom_2', 'g_cm_2')
         units = units.lower()
         if units not in choices:
-            raise ValueError("Invalid units, pick one of {}".format(choices))
+            raise ValueError(f"Invalid units, pick one of {choices}")
         moi_tensor = self.moment_of_inertia_tensor()
         principal_moments, principal_axes = np.linalg.eigh(moi_tensor)
         if units == "amu_bohr_2":
@@ -177,7 +177,7 @@ class Nuclear(Method):
         choices = ('invcm', 'ghz')
         units = units.lower()
         if units not in choices:
-            raise ValueError("Invalid units, pick one of {}".format(choices))
+            raise ValueError(f"Invalid units, pick one of {choices}")
         principal_moments = self.principal_moments_of_inertia("amu_angstrom_2")[0]
         _check_scipy(_found_scipy)
         bohr2ang = scipy.constants.value('atomic unit of length') / scipy.constants.angstrom

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -67,7 +67,7 @@ class Nuclear(Method):
 
         self.required_attrs = ('natom','atomcoords','atomnos','charge')
 
-        super(Nuclear, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -27,7 +27,7 @@ class OPA(Population):
     def __init__(self, *args):
 
         # Call the __init__ method of the superclass.
-        super(OPA, self).__init__(logname="OPA", *args)
+        super().__init__(logname="OPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/orbitals.py
+++ b/cclib/method/orbitals.py
@@ -1,14 +1,8 @@
-# -*- coding: utf-8 -*-
 #
-# This file is part of cclib (http://cclib.github.io), a library for parsing
-# and interpreting the results of computational chemistry packages.
+# Copyright (c) 2020, the cclib development team
 #
-# Copyright (C) 2017, the cclib development team
-#
-# The library is free software, distributed under the terms of
-# the GNU Lesser General Public version 2.1 or later. You should have
-# received a copy of the license along with cclib. You can also access
-# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 """Analyses related to orbitals."""
 

--- a/cclib/method/orbitals.py
+++ b/cclib/method/orbitals.py
@@ -21,7 +21,7 @@ class Orbitals(Method):
 
         self.required_attrs = ('mocoeffs','moenergies','homos')
         # Call the __init__ method of the superclass.
-        super(Orbitals, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
         self.fragresults = None
 
     def __str__(self):

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -24,7 +24,7 @@ class Population(Method):
 
     def __init__(self, data, progress=None, \
                  loglevel=logging.INFO, logname="Log"):
-        super(Population, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.fragresults = None
 
@@ -37,7 +37,7 @@ class Population(Method):
         return "Population"
 
     def _check_required_attributes(self):
-        super(Population, self)._check_required_attributes()
+        super()._check_required_attributes()
         
         if self.overlap_attributes and not any(hasattr(self.data, a) for a in self.overlap_attributes):
             raise MissingAttributeError(

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -139,7 +139,7 @@ class Stockholder(Method):
                     density_floor = numpy.array([0])
                     radiusgrid = numpy.array([0])
                 else:
-                    keystring_floor = "Z={}_Q={:+d}".format(atom_num, charge_floor)
+                    keystring_floor = f"Z={atom_num}_Q={charge_floor:+d}"
                     density_floor = numpy.asanyarray(list(proatomdb[keystring_floor]["rho"]))
 
                     # gridspec is specification of integration grid for proatom densities in horton.
@@ -182,7 +182,7 @@ class Stockholder(Method):
                 if atom_num <= charge_ceil:
                     density_ceil = numpy.array([0])
                 else:
-                    keystring_ceil = "Z={}_Q={:+d}".format(atom_num, charge_ceil)
+                    keystring_ceil = f"Z={atom_num}_Q={charge_ceil:+d}"
                     density_ceil = numpy.asanyarray(list(proatomdb[keystring_ceil]["rho"]))
 
                 density = (charge_ceil - charge) * density_floor + (

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -47,7 +47,7 @@ class Stockholder(Method):
                 proatom_path -- path to proatom densities
                 (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
         """
-        super(Stockholder, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.volume = volume
         self.proatom_path = proatom_path
@@ -74,7 +74,7 @@ class Stockholder(Method):
         return "Stockholder"
 
     def _check_required_attributes(self):
-        super(Stockholder, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -180,7 +180,7 @@ class Volume(object):
 
     def __str__(self):
         """Return a string representation."""
-        return "Volume %s to %s (density: %s)" % (
+        return "Volume {} to {} (density: {})".format(
             self.origin,
             self.topcorner,
             self.spacing,
@@ -285,7 +285,7 @@ def scinotation(num):
         sign = "-"
     else:
         sign = "+"
-    return ("%sE%s%s" % (broken[0], sign, broken[1][-2:])).rjust(12)
+    return ("{}E{}{}".format(broken[0], sign, broken[1][-2:])).rjust(12)
 
 
 def getGrid(vol):

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -152,7 +152,7 @@ def _check_pyvtk(found_pyvtk):
         raise ImportError("You must install `pyvtk` to use this function.")
 
 
-class Volume(object):
+class Volume:
     """Represent a volume in space.
 
     Required parameters:

--- a/cclib/parser/__init__.py
+++ b/cclib/parser/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -232,7 +232,7 @@ class ADF(logfileparser.Logfile):
                 info = line.split()
 
                 if len(info) == 7:  # fragment name is listed here
-                    self.fragnames.append("%s_%s" % (info[1], info[0]))
+                    self.fragnames.append("{}_{}".format(info[1], info[0]))
                     self.frags.append([])
                     self.frags[-1].append(int(info[2]) - 1)
 
@@ -610,7 +610,7 @@ class ADF(logfileparser.Logfile):
                     if info[3] != '0.00':
                         homob = len(moenergies[1]) - 1
                 else:
-                    print(("Error reading line: %s" % line))
+                    print(f"Error reading line: {line}")
 
                 line = next(inputfile)
 
@@ -840,7 +840,7 @@ class ADF(logfileparser.Logfile):
                     # At this point, we are either at the start of the next SFO or at
                     # a blank line...the end
 
-                    self.fonames.append("%s_%s" % (frag, orbital))
+                    self.fonames.append(f"{frag}_{orbital}")
                 symoffset += num
 
                 # blankline blankline

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -1,6 +1,5 @@
-## -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -21,7 +21,7 @@ class ADF(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(ADF, self).__init__(logname="ADF", *args, **kwargs)
+        super().__init__(logname="ADF", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -113,7 +113,7 @@ class DALTON(logfileparser.Logfile):
             revision = line.split()[4]
             package_version = self.metadata.get("package_version")
             if package_version:
-                self.metadata["package_version"] = "{}+{}".format(package_version, revision)
+                self.metadata["package_version"] = f"{package_version}+{revision}"
 
         # Is the basis set from a single library file, or is it
         # manually specified? See before_parsing().
@@ -666,7 +666,7 @@ class DALTON(logfileparser.Logfile):
                     continue
 
                 # the first hit of @ n where n is the current iteration
-                strcompare = "@{0:>3d}".format(iteration)
+                strcompare = f"@{iteration:>3d}"
                 if strcompare in line:
                     temp = line.split()
                     error_norm = utils.float(temp[3])

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -21,7 +21,7 @@ class DALTON(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(DALTON, self).__init__(logname="DALTON", *args, **kwargs)
+        super().__init__(logname="DALTON", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -417,11 +417,11 @@ class ccData_optdone_bool(ccData):
 
     def __init__(self, *args, **kwargs):
 
-        super(ccData_optdone_bool, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._attributes["optdone"] = Attribute(bool, 'done', 'optimization')
 
     def setattributes(self, *args, **kwargs):
-        invalid = super(ccData_optdone_bool, self).setattributes(*args, **kwargs)
+        invalid = super().setattributes(*args, **kwargs)
 
         # Reduce optdone to a Boolean, because it will be parsed as a list. If this list has any element,
         # it means that there was an optimized structure and optdone should be True.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -47,7 +47,7 @@ class GAMESS(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(GAMESS, self).__init__(logname="GAMESS", *args, **kwargs)
+        super().__init__(logname="GAMESS", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -88,7 +88,7 @@ class GAMESS(logfileparser.Logfile):
             match = re.search(r"Firefly version\s([\d.]*)\D*(\d*)\s*\*", line)
             if match:
                 base_version, build = match.groups()
-                package_version = "{}+{}".format(base_version, build)
+                package_version = f"{base_version}+{build}"
                 self.metadata["package_version"] = package_version
                 self.metadata["legacy_package_version"] = base_version
         if "GAMESS VERSION =" in line:
@@ -104,8 +104,8 @@ class GAMESS(logfileparser.Logfile):
                 else:
                     # `(R23)` -> 23
                     release = possible_release[2:-1]
-                self.metadata["package_version"] = '{}.r{}'.format(year, release)
-                self.metadata["legacy_package_version"] = "{}R{}".format(year, release)
+                self.metadata["package_version"] = f'{year}.r{release}'
+                self.metadata["legacy_package_version"] = f"{year}R{release}"
 
         if line[1:12] == "INPUT CARD>":
             return
@@ -1118,7 +1118,7 @@ class GAMESS(logfileparser.Logfile):
                             orbno = int(g[0])-1
                         else:  # For F orbitals, as shown above
                             g = [x.strip() for x in line.split()]
-                            aoname = "%s%s_%s" % (g[1].capitalize(), oldatom, g[2])
+                            aoname = "{}{}_{}".format(g[1].capitalize(), oldatom, g[2])
                             atomno = int(oldatom)-1
                             orbno = int(g[0])-1
 

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -504,7 +504,7 @@ class GAMESSUK(logfileparser.Logfile):
                         self.atombasis[atomno].append(orbno)
                     if not self.aonames:
                         pg = p.match(line[:18].strip()).groups()
-                        atomname = "%s%s%s" % (pg[1][0].upper(), pg[1][1:], pg[0])
+                        atomname = "{}{}{}".format(pg[1][0].upper(), pg[1][1:], pg[0])
                         if atomname != oldatomname:
                             aonum = 1
                         oldatomname = atomname

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -22,7 +22,7 @@ class GAMESSUK(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(GAMESSUK, self).__init__(logname="GAMESSUK", *args, **kwargs)
+        super().__init__(logname="GAMESSUK", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -22,7 +22,7 @@ class Gaussian(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(Gaussian, self).__init__(logname="Gaussian", *args, **kwargs)
+        super().__init__(logname="Gaussian", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -285,7 +285,7 @@ class Gaussian(logfileparser.Logfile):
 
             # Necessary for `if line.strip().split()[0:3] == ["Atom", "AN", "X"]:` block
             if not hasattr(self, 'nqmf'):
-                match = re.search('NQMF=\s*(\d+)', line)
+                match = re.search(r'NQMF=\s*(\d+)', line)
                 if match is not None:
                     nqmf = int(match.group(1))
                     if nqmf > 0:
@@ -428,7 +428,7 @@ class Gaussian(logfileparser.Logfile):
                     try:
                         numpy.testing.assert_equal(self.moments[4], hexadecapole)
                     except AssertionError:
-                        self.logger.warning("Attribute hexadecapole changed value (%s -> %s)" % (self.moments[4], hexadecapole))
+                        self.logger.warning("Attribute hexadecapole changed value ({} -> {})".format(self.moments[4], hexadecapole))
                     self.append_attribute("moments", hexadecapole)
 
         # Catch message about completed optimization.
@@ -1694,9 +1694,9 @@ class Gaussian(logfileparser.Logfile):
                             if i > 0:
                                 self.atombasis.append(atombasis)
                             atombasis = []
-                            atomname = "%s%s" % (parts[2], parts[1])
+                            atomname = "{}{}".format(parts[2], parts[1])
                         orbital = line[start_of_basis_fn_name:20].strip()
-                        self.aonames.append("%s_%s" % (atomname, orbital))
+                        self.aonames.append(f"{atomname}_{orbital}")
                         atombasis.append(i)
 
                     part = line[21:].replace("D", "E").rstrip()
@@ -1749,9 +1749,9 @@ class Gaussian(logfileparser.Logfile):
                             if i > 0:
                                 atombasis.append(basisonatom)
                             basisonatom = []
-                            atomname = "%s%s" % (parts[2], parts[1])
+                            atomname = "{}{}".format(parts[2], parts[1])
                         orbital = line[11:20].strip()
-                        aonames.append("%s_%s" % (atomname, orbital))
+                        aonames.append(f"{atomname}_{orbital}")
                         basisonatom.append(i)
                     part = line[21:].replace("D", "E").rstrip()
                     temp = []

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -21,7 +21,7 @@ class Jaguar(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(Jaguar, self).__init__(logname="Jaguar", *args, **kwargs)
+        super().__init__(logname="Jaguar", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -302,7 +302,7 @@ class Jaguar(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(maxdiiserr))
+                    self.logger.warning(f'File terminated before end of last SCF! Last error: {maxdiiserr}')
                     break
             self.scfvalues.append(values)
 

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -154,7 +154,7 @@ def openlogfile(filename, object=None):
         else:
             # Assuming that object is text file encoded in utf-8
             fileobject = io.StringIO(object.decode('utf-8')) if object \
-                    else FileWrapper(io.open(filename, "r", errors='ignore'))
+                    else FileWrapper(open(filename, errors='ignore'))
 
         return fileobject
 

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -74,7 +74,7 @@ class FileWrapper:
             self.size = self.src.tell()
             self.src.seek(pos, 0)
 
-        except (AttributeError, IOError, io.UnsupportedOperation):
+        except (AttributeError, OSError, io.UnsupportedOperation):
             # Stream returned by urllib should have size information.
             if hasattr(self.src, 'headers') and 'content-length' in self.src.headers:
                 self.size = int(self.src.headers['content-length'])

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -216,7 +216,7 @@ class Logfile(ABC):
         #   which means that care needs to be taken not to duplicate handlers.
         self.loglevel = loglevel
         self.logname = logname
-        self.logger = logging.getLogger('%s %s' % (self.logname, self.filename))
+        self.logger = logging.getLogger(f'{self.logname} {self.filename}')
         self.logger.setLevel(self.loglevel)
         if len(self.logger.handlers) == 0:
             handler = logging.StreamHandler(logstream)
@@ -258,7 +258,7 @@ class Logfile(ABC):
                 if type(value) in [numpy.ndarray, list]:
                     self.logger.info("Creating attribute %s[]" % name)
                 else:
-                    self.logger.info("Creating attribute %s: %s" % (name, str(value)))
+                    self.logger.info("Creating attribute {}: {}".format(name, str(value)))
 
         # Set the attribute.
         object.__setattr__(self, name, value)
@@ -427,7 +427,7 @@ class Logfile(ABC):
             try:
                 numpy.testing.assert_equal(getattr(self, name), value)
             except AssertionError:
-                self.logger.warning("Attribute %s changed value (%s -> %s)" % (name, getattr(self, name), value))
+                self.logger.warning("Attribute {} changed value ({} -> {})".format(name, getattr(self, name), value))
 
         setattr(self, name, value)
 

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -21,7 +21,7 @@ class Molcas(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(Molcas, self).__init__(logname="Molcas", *args, **kwargs)
+        super().__init__(logname="Molcas", *args, **kwargs)
 
     def __str__(self):
         """Return a string repeesentation of the object."""

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -53,7 +53,7 @@ class Molpro(logfileparser.Logfile):
 
     def __init__(self, *args, **kwargs):
         # Call the __init__ method of the superclass
-        super(Molpro, self).__init__(logname="Molpro", *args, **kwargs)
+        super().__init__(logname="Molpro", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -486,7 +486,7 @@ class Molpro(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last gradient: {}'.format(grad))
+                    self.logger.warning(f'File terminated before end of last SCF! Last gradient: {grad}')
                     break
             self.scfvalues.append(numpy.array(scfvalues))
 

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -32,7 +32,7 @@ class MOPAC(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(MOPAC, self).__init__(logname="MOPAC", *args, **kwargs)
+        super().__init__(logname="MOPAC", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -382,7 +382,7 @@ class NWChem(logfileparser.Logfile):
                             line = next(inputfile)
                         # Is this the end of the file for some reason?
                         except StopIteration:
-                            self.logger.warning('File terminated before end of last SCF! Last gradient norm: {}'.format(gnorm))
+                            self.logger.warning(f'File terminated before end of last SCF! Last gradient norm: {gnorm}')
                             break
                     if not hasattr(self, 'scfvalues'):
                         self.scfvalues = []
@@ -435,7 +435,7 @@ class NWChem(logfileparser.Logfile):
                     line = next(inputfile)
                 # Is this the end of the file for some reason?
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(diis))
+                    self.logger.warning(f'File terminated before end of last SCF! Last error: {diis}')
                     break
 
             if not hasattr(self, 'scfvalues'):

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -22,7 +22,7 @@ class NWChem(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(NWChem, self).__init__(logname="NWChem", *args, **kwargs)
+        super().__init__(logname="NWChem", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -23,7 +23,7 @@ class ORCA(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(ORCA, self).__init__(logname="ORCA", *args, **kwargs)
+        super().__init__(logname="ORCA", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1782,7 +1782,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             try:
                 line = next(inputfile).split()
             except StopIteration:
-                self.logger.warning('File terminated before end of last SCF! Last Max-DP: {}'.format(maxDP))
+                self.logger.warning(f'File terminated before end of last SCF! Last Max-DP: {maxDP}')
                 break
 
     def parse_scf_expanded_format(self, inputfile, line):

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -18,7 +18,7 @@ class Psi3(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(Psi3, self).__init__(logname="Psi3", *args, **kwargs)
+        super().__init__(logname="Psi3", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -90,13 +90,13 @@ class Psi4(logfileparser.Logfile):
             if "beta" in package_version:
                 self.version_4_beta = True
                 # `beta2+` -> `0!0.beta2`
-                package_version = "0!0.{}".format(package_version)
+                package_version = f"0!0.{package_version}"
                 if package_version[-1] == "+":
                     # There is no good way to keep the bare plus sign around,
                     # but this version is so old...
                     package_version = package_version[:-1]
             else:
-                package_version = "1!{}".format(package_version)
+                package_version = f"1!{package_version}"
             self.skip_line(inputfile, "blank")
             line = next(inputfile)
             if "Git:" in line:
@@ -426,7 +426,7 @@ class Psi4(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last density err: {}'.format(ddensity))
+                    self.logger.warning(f'File terminated before end of last SCF! Last density err: {ddensity}')
                     break
             self.section = "Post-Iterations"
             self.scfvalues.append(scfvals)

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -21,7 +21,7 @@ class Psi4(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(Psi4, self).__init__(logname="Psi4", *args, **kwargs)
+        super().__init__(logname="Psi4", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -73,8 +73,8 @@ class Psi4(logfileparser.Logfile):
                                   '## F-D gradient (Symmetry 0) ##',
                                   ['Irrep num and total size', 'b', '123', 'b']),
     }
-    GRADIENT_HEADERS = set([gradient_type.header
-                            for gradient_type in GRADIENT_TYPES.values()])
+    GRADIENT_HEADERS = {gradient_type.header
+                            for gradient_type in GRADIENT_TYPES.values()}
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -708,7 +708,7 @@ cannot be determined. Rerun without `$molecule read`."""
                 elif 'Bohr' in line:
                     convertor = lambda x: utils.convertor(x, 'bohr', 'Angstrom')
                 else:
-                    raise ValueError("Unknown units in coordinate header: {}".format(line))
+                    raise ValueError(f"Unknown units in coordinate header: {line}")
                 self.skip_lines(inputfile, ['cols', 'dashes'])
                 atomelements = []
                 atomcoords = []
@@ -833,7 +833,7 @@ cannot be determined. Rerun without `$molecule read`."""
                         line = next(inputfile)
                     # Is this the end of the file for some reason?
                     except StopIteration:
-                        self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(error))
+                        self.logger.warning(f'File terminated before end of last SCF! Last error: {error}')
                         break
 
                     # We've converged, but still need the last iteration.

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -22,7 +22,7 @@ class QChem(logfileparser.Logfile):
     def __init__(self, *args, **kwargs):
 
         # Call the __init__ method of the superclass
-        super(QChem, self).__init__(logname="QChem", *args, **kwargs)
+        super().__init__(logname="QChem", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -120,7 +120,7 @@ class Turbomole(logfileparser.Logfile):
             self.metadata["legacy_package_version"] = package_version
             if tokens[1] == "(":
                 revision = tokens[2]
-                self.metadata["package_version"] = "{}.r{}".format(package_version, revision)
+                self.metadata["package_version"] = f"{package_version}.r{revision}"
 
         ## Atomic coordinates in job.last:
         #              +--------------------------------------------------+

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -46,7 +46,7 @@ class Turbomole(logfileparser.Logfile):
     """A Turbomole log file."""
 
     def __init__(self, *args, **kwargs):
-        super(Turbomole, self).__init__(logname="Turbomole", *args, **kwargs)
+        super().__init__(logname="Turbomole", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -136,7 +136,7 @@ def convertor(value, fromunits, tounits):
         "hartree/bohr2_to_mDyne/angstrom": lambda x: x * 8.23872350 / 0.5291772109
     }
 
-    return _convertor["%s_to_%s" % (fromunits, tounits)](value)
+    return _convertor[f"{fromunits}_to_{tounits}"](value)
 
 def _get_rmat_from_vecs(a, b):
     """Get rotation matrix from two 3D vectors, a and b

--- a/cclib/progress/__init__.py
+++ b/cclib/progress/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/progress/qt4progress.py
+++ b/cclib/progress/qt4progress.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/progress/textprogress.py
+++ b/cclib/progress/textprogress.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/__init__.py
+++ b/cclib/scripts/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -66,7 +66,7 @@ def main():
                         help=('overwrite output file in case it already exists'))
     args = parser.parse_args()
     if args.output is not None and not args.force and os.path.exists(args.output):
-        parser.exit(1, 'failure: exiting to avoid overwriting existing file "{}"\n'.format(args.output))
+        parser.exit(1, f'failure: exiting to avoid overwriting existing file "{args.output}"\n')
 
     process_logfiles(args.compchemlogfiles, args.output, args.identifier)
 

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -194,7 +194,7 @@ def ccget():
             for attr in attrnames:
                 if cjsonfile:
                     if attr in data:
-                        print("%s:\n%s" % (attr, data[attr]))
+                        print("{}:\n{}".format(attr, data[attr]))
                         continue
                 else:
                     if hasattr(data, attr):

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccwrite.py
+++ b/cclib/scripts/ccwrite.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccwrite.py
+++ b/cclib/scripts/ccwrite.py
@@ -65,11 +65,11 @@ def main():
         if future:
             ccopen_kwargs['future'] = True
 
-        print("Attempting to parse {}".format(filename))
+        print(f"Attempting to parse {filename}")
         log = ccopen(filename, **ccopen_kwargs)
 
         if not log:
-            print("Cannot figure out what type of computational chemistry output file '{}' is.".format(filename))
+            print(f"Cannot figure out what type of computational chemistry output file '{filename}' is.")
             print("Report this to the cclib development team if you think this is an error.")
             sys.exit()
 
@@ -79,8 +79,8 @@ def main():
             log.logger.setLevel(logging.ERROR)
         data = log.parse()
 
-        print("cclib can parse the following attributes from {}:".format(filename))
-        hasattrs = ['  {}'.format(attr) for attr in ccData._attrlist if hasattr(data, attr)]
+        print(f"cclib can parse the following attributes from {filename}:")
+        hasattrs = [f'  {attr}' for attr in ccData._attrlist if hasattr(data, attr)]
         print('\n'.join(hasattrs))
 
         # Write out to disk.

--- a/cclib/scripts/cda.py
+++ b/cclib/scripts/cda.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/cda.py
+++ b/cclib/scripts/cda.py
@@ -30,7 +30,7 @@ def main():
 
     if retval:
 
-        print("Charge decomposition analysis of {}\n".format(args.file1))
+        print(f"Charge decomposition analysis of {args.file1}\n")
 
         if len(data1.homos) == 2:
             print("ALPHA SPIN:")

--- a/doc/sphinx/attributes.py
+++ b/doc/sphinx/attributes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Generate the attributes.rst and attributes_dev.rst files from the
 ccData docstring that describes attributes."""
 

--- a/doc/sphinx/attributes.py
+++ b/doc/sphinx/attributes.py
@@ -76,7 +76,7 @@ def generate_attributes():
     lines.append("")
 
     for n in names:
-        lines.append(".. _`%s`: data_notes.html#%s" % (n, n))
+        lines.append(f".. _`{n}`: data_notes.html#{n}")
 
     return "\n".join(lines)
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -40,7 +40,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = 'cclib'
-copyright = '2014-2018, cclib Development Team'
+copyright = '2014-2020, cclib Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -182,8 +182,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'cclib.tex', u'cclib Documentation',
-   u'cclib Development Team', 'manual'),
+  ('index', 'cclib.tex', 'cclib Documentation',
+   'cclib Development Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -212,8 +212,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'cclib', u'cclib Documentation',
-     [u'cclib Development Team'], 1)
+    ('index', 'cclib', 'cclib Documentation',
+     ['cclib Development Team'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -226,8 +226,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'cclib', u'cclib Documentation',
-   u'cclib Development Team', 'cclib', 'One line description of project.',
+  ('index', 'cclib', 'cclib Documentation',
+   'cclib Development Team', 'cclib', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # cclib documentation build configuration file, created by
 # sphinx-quickstart on Thu Jan 30 14:44:27 2014.
@@ -40,8 +39,8 @@ source_suffix = '.rst'
 master_doc = 'contents'
 
 # General information about the project.
-project = u'cclib'
-copyright = u'2014-2018, cclib Development Team'
+project = 'cclib'
+copyright = '2014-2018, cclib Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/sphinx/coverage.py
+++ b/doc/sphinx/coverage.py
@@ -110,7 +110,7 @@ def generate_coverage():
     lines.append("")
 
     for attr in attributes:
-        lines.append(".. _`%s`: data_notes.html#%s" % (attr, attr))
+        lines.append(f".. _`{attr}`: data_notes.html#{attr}")
 
     return "\n".join(lines)
 

--- a/doc/sphinx/coverage.py
+++ b/doc/sphinx/coverage.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/doc/sphinx/docs_common.py
+++ b/doc/sphinx/docs_common.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/manifest.py
+++ b/manifest.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testase.py
+++ b/test/bridge/testase.py
@@ -26,7 +26,7 @@ class ASETest(unittest.TestCase):
     """Tests for the cclib2ase bridge in cclib."""
 
     def setUp(self):
-        super(ASETest, self).setUp()
+        super().setUp()
 
     def test_makease_allows_optimization(self):
         """Ensure makease works from direct input."""

--- a/test/bridge/testase.py
+++ b/test/bridge/testase.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testbiopython.py
+++ b/test/bridge/testbiopython.py
@@ -16,7 +16,7 @@ class BiopythonTest(unittest.TestCase):
     """Tests for the cclib2biopython bridge in cclib."""
 
     def setUp(self):
-        super(BiopythonTest, self).setUp()
+        super().setUp()
         if not find_package("Bio"):
             raise ImportError("Must install biopython to run this test")
 

--- a/test/bridge/testbiopython.py
+++ b/test/bridge/testbiopython.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -23,7 +23,7 @@ class Horton2Test(unittest.TestCase):
     # and the attributes that were converted.
 
     def setUp(self):
-        super(Horton2Test, self).setUp()
+        super().setUp()
 
         self.data, self.logfile = getdatafile(
             "Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"]
@@ -141,7 +141,7 @@ class Horton3Test(unittest.TestCase):
     # and the attributes that were converted.
 
     def setUp(self):
-        super(Horton3Test, self).setUp()
+        super().setUp()
 
         self.data, self.logfile = getdatafile(
             "Gaussian", "basicGaussian16", ["dvb_un_sp.fchk"]

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testpsi4.py
+++ b/test/bridge/testpsi4.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testpyquante.py
+++ b/test/bridge/testpyquante.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testpyquante.py
+++ b/test/bridge/testpyquante.py
@@ -19,7 +19,7 @@ class PyquanteTest(unittest.TestCase):
     """Tests for the cclib2pyquante bridge in cclib."""
 
     def setUp(self):
-        super(PyquanteTest, self).setUp()
+        super().setUp()
         if not find_package("PyQuante"):
             raise ImportError("Must install PyQuante to run this test")
 
@@ -47,7 +47,7 @@ class pyquante2Test(unittest.TestCase):
     """Tests for the cclib2pyquante bridge in cclib."""
 
     def setUp(self):
-        super(pyquante2Test, self).setUp()
+        super().setUp()
         if not find_package("pyquante2"):
             raise ImportError("Must install pyquante2 to run this test")
             

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -16,7 +16,7 @@ class PyscfTest(unittest.TestCase):
     """Tests for the cclib2pyscf bridge in cclib."""
 
     def setUp(self):
-        super(PyscfTest, self).setUp()        
+        super().setUp()        
         if not find_package('pyscf'):
             raise ImportError('Must install pyscf to run this test')
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
 """test/conftest.py: dynamic testing configuration for pytest
 
 See the pytest documentation for more details:

--- a/test/data/__init__.py
+++ b/test/data/__init__.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/common.py
+++ b/test/data/common.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/skip.py
+++ b/test/data/skip.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testBOMD.py
+++ b/test/data/testBOMD.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCore.py
+++ b/test/data/testCore.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testPolar.py
+++ b/test/data/testPolar.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -116,7 +116,7 @@ class GenericSPTest(unittest.TestCase):
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass?"""
         mm = 1000*sum(self.data.atommasses)
-        msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
+        msg = f"Molecule mass: {mm:f} not {self.molecularmass:f} +- {self.mass_precision:f}mD"
         self.assertAlmostEqual(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testScan.py
+++ b/test/data/testScan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testTDun.py
+++ b/test/data/testTDun.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testccio.py
+++ b/test/io/testccio.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testcjsonreader.py
+++ b/test/io/testcjsonreader.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testfilewriter.py
+++ b/test/io/testfilewriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testwfxwriter.py
+++ b/test/io/testwfxwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testxyzreader.py
+++ b/test/io/testxyzreader.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testxyzwriter.py
+++ b/test/io/testxyzwriter.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testbader.py
+++ b/test/method/testbader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/method/testbader.py
+++ b/test/method/testbader.py
@@ -25,7 +25,7 @@ class BaderTest(unittest.TestCase):
     """Bader's QTAIM method tests."""
 
     def setUp(self):
-        super(BaderTest, self).setUp()
+        super().setUp()
         self.parse()
 
     def parse(self):

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -45,7 +45,7 @@ def printResults():
 
 
     print("---------------------------")
-    print("T:  %7.3f %7.3f %7.3f" % (fa.donations[0].sum(),
+    print("T:  {:7.3f} {:7.3f} {:7.3f}".format(fa.donations[0].sum(),
                                         fa.bdonations[0].sum(),
                                         fa.repulsions[0].sum()))
     print("\n\n")

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -25,7 +25,7 @@ class DDEC6Test(unittest.TestCase):
     """DDEC6 method tests."""
 
     def setUp(self):
-        super(DDEC6Test, self).setUp()
+        super().setUp()
         self.parse()
 
     def parse(self, molecule_name=None):

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -27,7 +27,7 @@ class HirshfeldTest(unittest.TestCase):
     """Hirshfeld method tests."""
 
     def setUp(self):
-        super(HirshfeldTest, self).setUp()
+        super().setUp()
         self.parse()
 
     def parse(self):

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -1,12 +1,8 @@
-# This file is part of cclib (http://cclib.github.io), a library for parsing
-# and interpreting the results of computational chemistry packages.
 #
-# Copyright (C) 2016 the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
-# The library is free software, distributed under the terms of
-# the GNU Lesser General Public version 2.1 or later. You should have
-# received a copy of the license along with cclib. You can also access
-# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 """Test the various population analyses (MPA, LPA, CSPA) in cclib"""
 

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -127,7 +127,7 @@ class GaussianBickelhauptTest(unittest.TestCase):
     """Bickelhaupt Population Analysis test"""
     
     def setUp(self):
-        super(GaussianBickelhauptTest, self).setUp()
+        super().setUp()
         self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", ["dvb_un_sp.log"])
         self.analysis = Bickelhaupt(self.data)
         self.analysis.logger.setLevel(0)

--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testdata.py
+++ b/test/parser/testdata.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -26,7 +26,7 @@ class FileWrapperTest(unittest.TestCase):
     def test_file_seek(self):
         """Can we seek anywhere in a file object?"""
         fpath = os.path.join(__datadir__,"data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        with open(fpath, 'r') as fobject:
+        with open(fpath) as fobject:
             wrapper = cclib.parser.logfileparser.FileWrapper(fobject)
             wrapper.seek(0, 0)
             self.assertEqual(wrapper.pos, 0)

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -68,7 +68,7 @@ class FileWrapperTest(unittest.TestCase):
         ]
         get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
         for lf in logfiles:
-            path = "%s/%s" % (__datadir__, lf)
+            path = f"{__datadir__}/{lf}"
             expected_attributes = get_attributes(cclib.io.ccread(path))
             with open(path) as handle:
                 contents = handle.read()
@@ -104,7 +104,7 @@ class LogfileTest(unittest.TestCase):
         try:
             parser.logger.error.assert_called_once()
         except AttributeError: # assert_called_once is not availible until python 3.6
-            self.assertEqual(parser.logger.error.call_count, 1, "Expected mock to have been called once. Called {} times.".format(parser.logger.error.call_count))
+            self.assertEqual(parser.logger.error.call_count, 1, f"Expected mock to have been called once. Called {parser.logger.error.call_count} times.")
 
 
 if __name__ == "__main__":

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testutils.py
+++ b/test/parser/testutils.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/regression.py
+++ b/test/regression.py
@@ -3344,7 +3344,7 @@ def test_regressions(which=[], opt_traceback=False, regdir=__regression_dir__, l
     # to any regression file name.
     orphaned_tests = []
     for pn in parser_names:
-        prefix = "test%s_%s" % (pn, pn)
+        prefix = f"test{pn}_{pn}"
         tests = [fn for fn in globals() if fn[:len(prefix)] == prefix]
         normalized = [normalisefilename(fn.replace(__regression_dir__, '')) for fn in filenames[pn]]
         orphaned = [t for t in tests if t[4:] not in normalized]

--- a/test/regression.py
+++ b/test/regression.py
@@ -3315,7 +3315,7 @@ def test_regressions(which=[], opt_traceback=False, regdir=__regression_dir__, l
     # This file should contain the paths to all regresssion test files we have gathered
     # over the years. It is not really necessary, since we can discover them on the disk,
     # but we keep it as a legacy and a way to track the regression tests.
-    regfile = open(os.path.join(regdir, "regressionfiles.txt"), "r")
+    regfile = open(os.path.join(regdir, "regressionfiles.txt"))
     regfilenames = [os.sep.join(x.strip().split("/")) for x in regfile.readlines()]
     regfile.close()
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -1,12 +1,8 @@
-# This file is part of cclib (http://cclib.github.io), a library for parsing
-# and interpreting the results of computational chemistry packages.
 #
-# Copyright (C) 2020, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
-# The library is free software, distributed under the terms of
-# the GNU Lesser General Public version 2.1 or later. You should have
-# received a copy of the license along with cclib. You can also access
-# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 """A regression framework for parsing and testing logfiles.
 

--- a/test/test_bridge.py
+++ b/test/test_bridge.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, the cclib development team
 #

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -171,7 +171,7 @@ class DataSuite:
             description = ''
             if not self.silent:
                 print("", file=stream_test)
-                description = "%s/%s: %s" % (td['subdir'], ",".join(td['files']), test.__doc__)
+                description = "{}/{}: {}".format(td['subdir'], ",".join(td['files']), test.__doc__)
                 print("*** %s ***" % description, file=self.stream)
 
             test.data, test.logfile = getdatafile(
@@ -261,7 +261,7 @@ class DataSuite:
         print("      ", "".join(["%-12s" % pn for pn in parser_names]), file=self.stream)
         print("HOMO", "   ".join(["%+9.4f" % out.moenergies[0][out.homos[0]] for out in output]), file=self.stream)
         print("LUMO", "   ".join(["%+9.4f" % out.moenergies[0][out.homos[0]+1] for out in output]), file=self.stream)
-        print("H-L ", "   ".join(["%9.4f" % (out.moenergies[0][out.homos[0]+1]-out.moenergies[0][out.homos[0]],) for out in output]), file=self.stream)
+        print("H-L ", "   ".join(["{:9.4f}".format(out.moenergies[0][out.homos[0]+1]-out.moenergies[0][out.homos[0]]) for out in output]), file=self.stream)
 
 
 def test_all(parsers, modules, terse, silent, loglevel, summary, visual_tests):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/testall.py
+++ b/test/testall.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017, the cclib development team
+# Copyright (c) 2020, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.


### PR DESCRIPTION
I ran [asottile/pyupgrade](https://github.com/asottile/pyupgrade) on the code base to remove anything we were doing with python 2.
With python 3.6 compatibility: `find . -name "*.py" -exec pyupgrade --py36-plus {} \;`

I understand this might be a lot to look at so I could break it into separate PRs. 

This can go in after we finish some of the more pressing PRs.