### PR TITLE
Fix GAMESS parser when there are >100 scf iterations

### DIFF
--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -693,13 +693,13 @@ class GAMESS(logfileparser.Logfile):
                     # will look like 10099, 101100, 102101, etc., with no spaces between
                     # the numbers. We can check if this is the case by seeing if the first
                     # number on the line exceeds 10000.
-                    gt_100_its = int(line.split()[0]) > 10000
+                    base_split = line.split()
+                    gt_100_its = int(base_split[0]) > 10000
                     if gt_100_its:
-                        base_split = line.split()
                         first_two = [base_split[0][:3], base_split[0][3:]]
                         split = [*first_two, *base_split[1:]]
                     else:
-                        split = line.split()
+                        split = base_split
                     values.append([float(split[self.scf_valcol])])
                 try:
                     line = next(inputfile)

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -689,13 +689,25 @@ class GAMESS(logfileparser.Logfile):
                 except ValueError:
                     pass
                 else:
-                    values.append([float(line.split()[self.scf_valcol])])
+                    # if there were 100 iterations or more, the first part of the line
+                    # will look like 10099, 101100, 102101, etc., with no spaces between
+                    # the numbers. We can check if this is the case by seeing if the first
+                    # number on the line exceeds 10000.
+                    gt_100_its = int(line.split()[0]) > 10000
+                    if gt_100_its:
+                        base_split = line.split()
+                        first_two = [base_split[0][:3], base_split[0][3:]]
+                        split = [*first_two, *base_split[1:]]
+                    else:
+                        split = line.split()
+                    values.append([float(split[self.scf_valcol])])
                 try:
                     line = next(inputfile)
                 except StopIteration:
                     self.logger.warning('File terminated before end of last SCF!')
                     break
             self.scfvalues.append(values)
+
 
         # Sometimes, only the first SCF cycle has the banner parsed for above,
         # so we must identify them from the header before the SCF iterations.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -693,14 +693,8 @@ class GAMESS(logfileparser.Logfile):
                     # will look like 10099, 101100, 102101, etc., with no spaces between
                     # the numbers. We can check if this is the case by seeing if the first
                     # number on the line exceeds 10000.
-                    base_split = line.split()
-                    gt_100_its = int(base_split[0]) > 10000
-                    if gt_100_its:
-                        first_two = [base_split[0][:3], base_split[0][3:]]
-                        split = [*first_two, *base_split[1:]]
-                    else:
-                        split = base_split
-                    values.append([float(split[self.scf_valcol])])
+                    split_line = [line[0:4], line[4:7]] + line[7:].split()
+                    values.append([float(split_line[self.scf_valcol])])
                 try:
                     line = next(inputfile)
                 except StopIteration:

--- a/test/regression.py
+++ b/test/regression.py
@@ -647,7 +647,7 @@ def testGAMESS_GAMESS_US2018_exam45_log(logfile):
 
 def testGAMESS_GAMESS_US2018_exam46_log(logfile):
     """
-    This logfile needs >100 scf iterations for convergence, which used to cause
+    This logfile has >100 scf iterations, which used to cause
     a parsing error.
     """
     assert len(logfile.data.scfvalues[0]) == 113

--- a/test/regression.py
+++ b/test/regression.py
@@ -645,6 +645,18 @@ def testGAMESS_GAMESS_US2018_exam45_log(logfile):
         parse_version(logfile.data.metadata["package_version"]), Version
     )
 
+def testGAMESS_GAMESS_US2018_exam46_log(logfile):
+    """
+    This logfile needs >100 scf iterations for convergence, which used to cause
+    a parsing error.
+    """
+    assert len(logfile.data.scfvalues[0]) == 113
+    assert logfile.data.metadata["legacy_package_version"] == "2018R3"
+    assert logfile.data.metadata["package_version"] == "2018.r3"
+    assert isinstance(
+        parse_version(logfile.data.metadata["package_version"]), Version
+    )
+
 
 def testGAMESS_WinGAMESS_dvb_td_trplet_2007_03_24_r1_out(logfile):
     """Do some basic checks for this old unit test that was failing.


### PR DESCRIPTION
Hi there,
I noticed a bug when there are more than 100 scf iterations in GAMESS. Please let me know how my fix looks.
Thanks,
Simon