### PR TITLE
Add zero-point vibrational energy to most parsers

### DIFF
--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -770,6 +770,34 @@ class ADF(logfileparser.Logfile):
             assert "Temperature" in line
             self.set_attribute("temperature", float(line.split()[1]))
 
+            self.skip_lines(
+                inputfile,
+                [
+                    "b",
+                    "b",
+                    "b",
+                    "Moments of Inertia",
+                    "e",
+                    "b",
+                    "principal moments",
+                    "d",
+                    "MOI tensor Xx",
+                    "MOI tensor Yx",
+                    "MOI tensor Zx",
+                    "b",
+                    "b",
+                ]
+            )
+            while line.split() != ["Temp", "Transl", "Rotat", "Vibrat", "Total"]:
+                line = next(inputfile)
+            self.skip_lines(inputfile, ["d", "s"])
+            line = next(inputfile)
+            assert "Entropy" in line
+            # self.set_attribute("entropy", float(line.split()))
+            line = next(inputfile)
+            assert "Internal Energy" in line
+            self.set_attribute("zpve", utils.convertor(float(line.split()[5]), "kcal/mol", "hartree"))
+
         #******************************************************************************************************************8
         #delete this after new implementation using smat, eigvec print,eprint?
         # Extract the number of basis sets

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -793,7 +793,11 @@ class ADF(logfileparser.Logfile):
             self.skip_lines(inputfile, ["d", "s"])
             line = next(inputfile)
             assert "Entropy" in line
-            # self.set_attribute("entropy", float(line.split()))
+            self.set_attribute(
+                "entropy",
+                utils.convertor(float(line.split()[6]) * self.temperature / 1000,
+                                "kcal/mol", "hartree")
+            )
             line = next(inputfile)
             assert "Internal Energy" in line
             self.set_attribute("zpve", utils.convertor(float(line.split()[5]), "kcal/mol", "hartree"))

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -759,6 +759,17 @@ class ADF(logfileparser.Logfile):
             if hasattr(self, "vibramans"):
                 self.vibramans = numpy.array(self.vibramans, "d")
 
+            self.skip_lines(
+                inputfile,
+                ["b", "b", "e", "Statistical Thermal Analysis", "e", "b"]
+            )
+            line = next(inputfile)
+            assert "Pressure" in line
+            self.set_attribute("pressure", float(line.split()[1]))
+            line = next(inputfile)
+            assert "Temperature" in line
+            self.set_attribute("temperature", float(line.split()[1]))
+
         #******************************************************************************************************************8
         #delete this after new implementation using smat, eigvec print,eprint?
         # Extract the number of basis sets

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1116,6 +1116,15 @@ class DALTON(logfileparser.Logfile):
             # order.
             self.vibramans = vibramans[::-1]
 
+        if line.strip() == "Total Molecular Energy":
+            self.skip_lines(
+                inputfile,
+                ["d", "b", "electronic     vibrational           total    energy", "b"]
+            )
+            tokens = next(inputfile).split()
+            assert tokens[3] == "Hartrees"
+            self.set_attribute("zpve", float(tokens[1]))
+
         # Static polarizability from **PROPERTIES/.POLARI.
         if line.strip() == "Static polarizabilities (au)":
             if not hasattr(self, 'polarizabilities'):

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1526,10 +1526,32 @@ class GAMESS(logfileparser.Logfile):
             match = re.search(r"THERMOCHEMISTRY AT T=(.*)K", line)
             if match:
                 self.set_attribute('temperature', float(match.group(1)))
-        if "PASCAL." in line:
+            self.skip_lines(inputfile, ['d', 'b', 'USING IDEAL GAS, ...'])
+            line = next(inputfile)
+            assert "PASCAL." in line
             match = re.search(r"P=(.*)PASCAL.", line)
             if match:
                 self.set_attribute('pressure', float(match.group(1))/1.01325e5)
+            self.skip_lines(
+                inputfile,
+                [
+                    "ALL FREQUENCIES ARE SCALED",
+                    "THE MOMENTS OF INERTIA ARE (IN AMU*BOHR**2)",
+                    "moments of inertia",
+                    "THE ROTATIONAL SYMMETRY NUMBER IS",
+                    "THE ROTATIONAL CONSTANTS ARE (IN GHZ)",
+                    "rotational constants",
+                ]
+            )
+            line = next(inputfile)
+            if "IMAGINARY FREQUENCY VIBRATION(S)" in line:
+                line = next(inputfile)
+                line = next(inputfile)
+            if "VIBRATIONAL MODES ARE USED IN THERMOCHEMISTRY." in line:
+                line = next(inputfile)
+            line = next(inputfile)
+            assert "HARTREE/MOLECULE" in line
+            self.set_attribute('zpve', float(line.split()[0]))
 
         if "KCAL/MOL  KCAL/MOL  KCAL/MOL CAL/MOL-K CAL/MOL-K CAL/MOL-K" in line:
             self.skip_lines(inputfile,["ELEC","TRANS","ROT","VIB"])

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -303,6 +303,37 @@ class GAMESSUK(logfileparser.Logfile):
 
                 freqnum = next(inputfile)
 
+        if line[40:63] == "thermochemical analysis":
+            self.skip_lines(inputfile, ["s", "b", "b"])
+            line = next(inputfile)
+            assert "temperature" in line
+            self.set_attribute("temperature", float(line.split()[1]))
+            line = next(inputfile)
+            assert "pressure" in line
+            self.set_attribute("pressure", float(line.split()[1]))
+            self.skip_lines(
+                inputfile,
+                [
+                    "b",
+                    "molecular mass",
+                    "b",
+                    "principal moments of inertia header",
+                    "principal moment values",
+                    "b",
+                    "rotational symmetry number",
+                    "b",
+                    "rotational temperatures",
+                    "b"
+                 ]
+            )
+            line = next(inputfile)
+            assert "zero point vibrational energy" in line
+            line = next(inputfile)
+            assert "kcal/mol" in line
+            line = next(inputfile)
+            assert "hartree/particle" in line
+            self.set_attribute("zpve", float(line.split()[0]))
+
         if line[26:36] == "raman data":
             self.vibramans = []
 

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -682,6 +682,35 @@ class Jaguar(logfileparser.Logfile):
             if hasattr(self, "vibfconsts"):
                 self.vibfconsts = numpy.array(self.vibfconsts, "d")
 
+            line = freqs
+
+            # Jaguar 4.2:
+            #
+            # Thermochemical Properties:
+            #   pressure:        1.0000 atm
+            #   rotational symmetry number:    2
+            #   zero point energy:    111.455 kcal/mol
+            #
+            # Jaguar >= 7.0:
+            #
+            #   Thermochemical properties at    1.0000 atm
+            #   ...
+            #   The zero point energy (ZPE):    111.155 kcal/mol
+            while "thermochemical properties" not in line.lower():
+                line = next(inputfile)
+            tokens = line.split()
+            if len(tokens) == 5:
+                self.set_attribute("pressure", float(line.split()[3]))
+            line = next(inputfile)
+            if "pressure" in line:
+                self.set_attribute("pressure", float(line.split()[1]))
+            while "zero point energy" not in line:
+                line = next(inputfile)
+            self.set_attribute(
+                "zpve",
+                utils.convertor(float(line.split()[-2]), "kcal/mol", "hartree")
+            )
+
         # Parse excited state output (for CIS calculations).
         # Jaguar calculates only singlet states.
         if line[2:15] == "Excited State":

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -470,6 +470,10 @@ class Molcas(logfileparser.Logfile):
         #  ++    Isotopic shifts:
         if line[4:19] == 'THERMOCHEMISTRY':
 
+            while "ZPVE" not in line:
+                line = next(inputfile)
+            self.set_attribute("zpve", float(line.split()[3]))
+
             temperature_values = []
             pressure_values = []
             entropy_values = []

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -876,6 +876,9 @@ class Molpro(logfileparser.Logfile):
                 line = next(inputfile)
                 self.amass += list(map(float, line.strip().split()[2:]))
 
+        if line[1:18] == "Zero point energy":
+            self.set_attribute("zpve", float(line.split()[3]))
+
         #1PROGRAM * POP (Mulliken population analysis)
         #
         #

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -916,7 +916,7 @@ Dispersion correction           -0.016199959
             while line[:17] != 'Electronic energy':
                 line = next(inputfile)
             self.electronic_energy = float(line.split()[3])
-            self.zpe = float(next(inputfile).split()[4])
+            self.set_attribute("zpve", float(next(inputfile).split()[4]))
             thermal_vibrational_correction = float(next(inputfile).split()[4])
             thermal_rotional_correction = float(next(inputfile).split()[4])
             thermal_translational_correction = float(next(inputfile).split()[4])

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -1059,6 +1059,27 @@ class Psi4(logfileparser.Logfile):
             if len(vibdisps) == n_modes:
                 self.set_attribute('vibfconsts', vibfconsts)
 
+        # Second one is 1.0, first one is 1.2 and newer
+        if (self.section == "Thermochemistry Energy Analysis" and "Thermochemistry Energy Analysis" in line) \
+           or (self.section == "Energy Analysis" and "Energy Analysis" in line):
+
+            self.skip_lines(
+                inputfile,
+                [
+                    "b",
+                    "Raw electronic energy",
+                    "Total E0",
+                    "b",
+                    "Zero-point energy, ZPE_vib = Sum_i nu_i / 2",
+                    "Electronic ZPE",
+                    "Translational ZPE",
+                    "Rotational ZPE"
+                ]
+            )
+            line = next(inputfile)
+            assert "Vibrational ZPE" in line
+            self.set_attribute("zpve", float(line.split()[6]))
+
         # If finite difference is used to compute forces (i.e. by displacing
         # slightly all the atoms), a series of additional scf calculations is
         # performed. Orbitals, geometries, energies, etc. for these shouln't be

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1554,8 +1554,8 @@ cannot be determined. Rerun without `$molecule read`."""
                     assert 'Zero point vibrational energy' in line
                     if not hasattr(self, 'zpe'):
                         # Convert from kcal/mol to Hartree/particle.
-                        self.zpe = utils.convertor(float(line.split()[4]),
-                                                   'kcal/mol', 'hartree')
+                        self.zpve = utils.convertor(float(line.split()[4]),
+                                                    'kcal/mol', 'hartree')
                     atommasses = []
                     while 'Translational Enthalpy' not in line:
                         if 'Has Mass' in line:

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -236,6 +236,9 @@ class Turbomole(logfileparser.Logfile):
                     rmasses = [utils.float(f) for f in line.split()[2:]]
                     vibrmasses.extend(rmasses)
 
+                if "zero point VIBRATIONAL energy" in line:
+                    self.set_attribute("zpve", float(line.split()[6]))
+
                 line = next(inputfile)
 
             self.set_attribute('vibfreqs', vibfreqs)

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -86,6 +86,23 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
+    @skipForParser('ADF', 'not implemented yet')
+    @skipForParser('DALTON', 'not implemented yet')
+    @skipForParser('GAMESS', 'not implemented yet')
+    @skipForParser('GAMESSUK', 'not implemented yet')
+    @skipForParser('Jaguar', 'not implemented yet')
+    @skipForParser('Molcas', 'not implemented yet')
+    @skipForParser('Molpro', 'not implemented yet')
+    @skipForParser('ORCA', 'not implemented yet')
+    @skipForParser('Psi3', 'not implemented yet')
+    @skipForParser('Psi4', 'not implemented yet')
+    @skipForParser('Turbomole', 'not implemented yet')
+    def testzeropointcorrection(self):
+        # reference zero-point correction from dvb_ir.out
+        zpve = 0.1771
+        """Is the zero-point correction correct?"""
+        self.assertAlmostEqual(self.data.zpve, zpve, delta=0.001)
+
 
 class FireflyIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
@@ -99,12 +116,6 @@ class GaussianIRTest(GenericIRTest):
     def testvibsyms(self):
         """Is the length of vibsyms correct?"""
         self.assertEqual(len(self.data.vibsyms), self.numvib)
-
-    def testzeropointcorrection(self):
-        # reference zero-point correction from dvb_ir.out
-        zpve = 0.1771
-        """Is the zero-point correction correct?"""
-        self.assertAlmostEqual(self.data.zpve, zpve, delta=0.001)
 
 
 class JaguarIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -26,6 +26,9 @@ class GenericIRTest(unittest.TestCase):
     max_force_constant = 10.0
     max_reduced_mass = 6.9
 
+    # reference zero-point correction from Gaussian 16 dvb_ir.out
+    zpve = 0.1771
+
     def setUp(self):
         """Initialize the number of vibrational frequencies on a per molecule basis"""
         self.numvib = 3*len(self.data.atomnos) - 6
@@ -96,16 +99,16 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('Psi3', 'not implemented yet')
     @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):
-        # reference zero-point correction from Gaussian 16 dvb_ir.out
-        zpve = 0.1771
         """Is the zero-point correction correct?"""
-        self.assertAlmostEqual(self.data.zpve, zpve, delta=0.001)
+        self.assertAlmostEqual(self.data.zpve, self.zpve, delta=0.001)
 
 
 class FireflyIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
     max_IR_intensity = 135
+    # ???
+    zpve = 0.1935
 
 
 class GaussianIRTest(GenericIRTest):
@@ -259,6 +262,7 @@ class Psi4IRTest(GenericIRTest):
 
     # RHF is used for Psi4 IR test data instead of B3LYP
     max_force_constant = 9.37
+    zpve = 0.1917
 
 
 class GenericIRimgTest(unittest.TestCase):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -89,7 +89,6 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
-    @skipForParser('ADF', 'not implemented yet')
     @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')
@@ -97,7 +96,16 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):
         """Is the zero-point correction correct?"""
-        self.assertAlmostEqual(self.data.zpve, self.zpve, delta=0.001)
+        self.assertAlmostEqual(self.data.zpve, self.zpve, delta=1.0e-3)
+
+
+class ADFIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    # ???
+    def testzeropointcorrection(self):
+        """Is the zero-point correction correct?"""
+        self.assertAlmostEqual(self.data.zpve, self.zpve, delta=1.0e-2)
 
 
 class FireflyIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -89,7 +89,6 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
-    @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')
     @skipForParser('Psi3', 'not implemented yet')
     @skipForParser('Turbomole', 'not implemented yet')
@@ -139,6 +138,7 @@ class MolcasIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
     max_IR_intensity = 65
+    zpve = 0.1783
 
     entropy_places = 3
     enthalpy_places = 3

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -88,7 +88,6 @@ class GenericIRTest(unittest.TestCase):
 
     @skipForParser('ADF', 'not implemented yet')
     @skipForParser('DALTON', 'not implemented yet')
-    @skipForParser('GAMESS', 'not implemented yet')
     @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Jaguar', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -94,7 +94,6 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')
-    @skipForParser('ORCA', 'not implemented yet')
     @skipForParser('Psi3', 'not implemented yet')
     @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):
@@ -165,6 +164,7 @@ class OrcaIRTest(GenericIRTest):
 
     # ORCA has a bug in the intensities for version < 4.0
     max_IR_intensity = 215
+    zpve = 0.1921
 
     enthalpy_places = 3
     entropy_places = 3

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -94,10 +94,9 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('Molpro', 'not implemented yet')
     @skipForParser('ORCA', 'not implemented yet')
     @skipForParser('Psi3', 'not implemented yet')
-    @skipForParser('Psi4', 'not implemented yet')
     @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):
-        # reference zero-point correction from dvb_ir.out
+        # reference zero-point correction from Gaussian 16 dvb_ir.out
         zpve = 0.1771
         """Is the zero-point correction correct?"""
         self.assertAlmostEqual(self.data.zpve, zpve, delta=0.001)

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -89,7 +89,6 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
-    @skipForParser('Molpro', 'not implemented yet')
     @skipForParser('Psi3', 'not implemented yet')
     @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -89,7 +89,6 @@ class GenericIRTest(unittest.TestCase):
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
-    @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')
     @skipForParser('Psi3', 'not implemented yet')

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -92,7 +92,6 @@ class GenericIRTest(unittest.TestCase):
     @skipForParser('ADF', 'not implemented yet')
     @skipForParser('DALTON', 'not implemented yet')
     @skipForParser('GAMESSUK', 'not implemented yet')
-    @skipForParser('Jaguar', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')
     @skipForParser('ORCA', 'not implemented yet')

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -90,7 +90,6 @@ class GenericIRTest(unittest.TestCase):
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
     @skipForParser('Psi3', 'not implemented yet')
-    @skipForParser('Turbomole', 'not implemented yet')
     def testzeropointcorrection(self):
         """Is the zero-point correction correct?"""
         self.assertAlmostEqual(self.data.zpve, self.zpve, delta=1.0e-3)
@@ -267,6 +266,13 @@ class Psi4IRTest(GenericIRTest):
     # RHF is used for Psi4 IR test data instead of B3LYP
     max_force_constant = 9.37
     zpve = 0.1917
+
+
+class TurbomoleIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    # ???
+    zpve = 0.1725
 
 
 class GenericIRimgTest(unittest.TestCase):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -90,7 +90,6 @@ class GenericIRTest(unittest.TestCase):
         self.assertAlmostEqual(max(self.data.vibrmasses), self.max_reduced_mass, delta=0.1)
 
     @skipForParser('ADF', 'not implemented yet')
-    @skipForParser('DALTON', 'not implemented yet')
     @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Molcas', 'not implemented yet')
     @skipForParser('Molpro', 'not implemented yet')

--- a/test/regression.py
+++ b/test/regression.py
@@ -3082,7 +3082,7 @@ old_unittests = {
     "ADF/ADF2004.01/dvb_sp_d.adfout":       ADFSPTest_nosyms_noscfvalues,
     "ADF/ADF2004.01/dvb_un_sp.adfout":      GenericSPunTest,
     "ADF/ADF2004.01/dvb_un_sp_c.adfout":    GenericSPunTest,
-    "ADF/ADF2004.01/dvb_ir.adfout":         GenericIRTest,
+    "ADF/ADF2004.01/dvb_ir.adfout":         ADFIRTest,
 
     "ADF/ADF2006.01/dvb_gopt.adfout":              ADFGeoOptTest_noscfvalues,
     "ADF/ADF2013.01/dvb_gopt_b_fullscf.adfout":    ADFGeoOptTest,

--- a/test/regression.py
+++ b/test/regression.py
@@ -3010,12 +3010,19 @@ class OrcaTDDFTTest_error(OrcaTDDFTTest):
 
 class OrcaIRTest_old_coordsOK(OrcaIRTest):
 
+    zpve = 0.1986
+
     enthalpy_places = -1
     entropy_places = 2
     freeenergy_places = -1
 
 
 class OrcaIRTest_old(OrcaIRTest):
+    """The frequency part of this calculation didn't finish, but went ahead and
+    printed incomplete and incorrect results anyway.
+    """
+
+    zpve = 0.0200
 
     enthalpy_places = -1
     entropy_places = 2

--- a/test/regression.py
+++ b/test/regression.py
@@ -3257,7 +3257,7 @@ old_unittests = {
     "Psi4/Psi4-1.0/C_bigbasis.out":     Psi4BigBasisTest,
     "Psi4/Psi4-1.0/dvb_gopt_rhf.out":   Psi4GeoOptTest,
     "Psi4/Psi4-1.0/dvb_gopt_rks.out":   Psi4GeoOptTest,
-    "Psi4/Psi4-1.0/dvb_ir_rhf.out":     GenericIRTest,
+    "Psi4/Psi4-1.0/dvb_ir_rhf.out":     Psi4IRTest,
     "Psi4/Psi4-1.0/dvb_sp_rhf.out":     PsiSPTest_noatommasses,
     "Psi4/Psi4-1.0/dvb_sp_rks.out":     PsiSPTest_noatommasses,
     "Psi4/Psi4-1.0/dvb_sp_rohf.out":    GenericROSPTest,

--- a/test/testdata
+++ b/test/testdata
@@ -355,7 +355,7 @@ vib       Psi4        Psi4IRTest            basicPsi4-1.2.1       dvb_ir_rhf.out
 vib       Psi4        Psi4IRTest            basicPsi4-1.3.1       dvb_ir_rhf.out
 vib       QChem       QChemIRTest           basicQChem4.2         dvb_ir.out
 vib       QChem       QChemIRTest           basicQChem5.1         dvb_ir.out
-vib       Turbomole   GenericIRTest         basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out
+vib       Turbomole   TurbomoleIRTest       basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out
 
 vib       GAMESS      GenericIRimgTest      basicGAMESS-US2017    nh3_ts_ir.out
 vib       GAMESS      GenericIRimgTest      basicGAMESS-US2018    nh3_ts_ir.out

--- a/test/testdata
+++ b/test/testdata
@@ -333,8 +333,8 @@ TD        QChem       QChemTDDFTTest        basicQChem5.1         dvb_td.out
 TDun      Gaussian    GenericTDunTest       basicGaussian09       CO_TD_delta.log
 TDun      Gaussian    GenericTDunTest       basicGaussian16       CO_TD_delta.log
 
-vib       ADF         GenericIRTest         basicADF2007.01       dvb_ir.adfout
-vib       ADF         GenericIRTest         basicADF2013.01       dvb_ir.adfout
+vib       ADF         ADFIRTest             basicADF2007.01       dvb_ir.adfout
+vib       ADF         ADFIRTest             basicADF2013.01       dvb_ir.adfout
 vib       DALTON      GenericIRTest         basicDALTON-2013      dvb_ir.out
 vib       DALTON      GenericIRTest         basicDALTON-2015      dvb_ir.out
 vib       GAMESSUK    GenericIRTest         basicGAMESS-UK7.0     dvb_ir.out


### PR DESCRIPTION
In at least one case entropy/pressure/temperature has been added too, since they appear before the ZPVE in the output.