### PR TITLE
Add cpu/wall time to QChem metadata

### DIFF
--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -114,6 +114,9 @@ class QChem(logfileparser.Logfile):
             'CCD', 'CCSD', 'CCSD(T)',
             'QCISD', 'QCISD(T)'
         ]
+        # create empty list for the computing time to be stored in. 
+        self.metadata['wall_time'] =[]
+        self.metadata['cpu_time'] =[]
 
     def after_parsing(self):
 
@@ -1586,6 +1589,9 @@ cannot be determined. Rerun without `$molecule read`."""
 
         if line[:16] == ' Total job time:':
             self.metadata['success'] = True
+            a = line.split()
+            self.metadata['wall_time'].append(a[-2].split('s')[0])
+            self.metadata['cpu_time'].append(a[-1].split('s')[0])
 
         # TODO:
         # 'enthalpy' (incorrect)

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -10,7 +10,7 @@
 import itertools
 import math
 import re
-
+import datetime
 import numpy
 
 from cclib.parser import logfileparser
@@ -1589,9 +1589,17 @@ cannot be determined. Rerun without `$molecule read`."""
 
         if line[:16] == ' Total job time:':
             self.metadata['success'] = True
+            # the line format is " Total job time:  120.37s(wall), 2251.02s(cpu)" at the end of each job ran. 
+            # first split the line by white space
             a = line.split()
-            self.metadata['wall_time'].append(a[-2].split('s')[0])
-            self.metadata['cpu_time'].append(a[-1].split('s')[0])
+            # next split the second to last entry at the 's' to pull wall time
+            # cast as a float for use in timedelta data structure
+            wall_td = datetime.timedelta(seconds=float(a[-2].split('s')[0]))
+            # next split the last entry at the 's' to pull cpu time
+            # cast as a float for use in timedelta data structure
+            cpu_td = datetime.timedelta(seconds=float(a[-1].split('s')[0]))
+            self.metadata['wall_time'].append(wall_td)
+            self.metadata['cpu_time'].append(cpu_td)
 
         # TODO:
         # 'enthalpy' (incorrect)

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1591,15 +1591,18 @@ cannot be determined. Rerun without `$molecule read`."""
             self.metadata['success'] = True
             # the line format is " Total job time:  120.37s(wall), 2251.02s(cpu)" at the end of each job ran. 
             # first split the line by white space
-            a = line.split()
-            # next split the second to last entry at the 's' to pull wall time
-            # cast as a float for use in timedelta data structure
-            wall_td = datetime.timedelta(seconds=float(a[-2].split('s')[0]))
-            # next split the last entry at the 's' to pull cpu time
-            # cast as a float for use in timedelta data structure
-            cpu_td = datetime.timedelta(seconds=float(a[-1].split('s')[0]))
-            self.metadata['wall_time'].append(wall_td)
-            self.metadata['cpu_time'].append(cpu_td)
+            try:
+                a = line.split()
+                # next split the second to last entry at the 's' to pull wall time
+                # cast as a float for use in timedelta data structure
+                wall_td = datetime.timedelta(seconds=float(a[-2].split('s')[0]))
+                # next split the last entry at the 's' to pull cpu time
+                # cast as a float for use in timedelta data structure
+                cpu_td = datetime.timedelta(seconds=float(a[-1].split('s')[0]))
+                self.metadata['wall_time'].append(wall_td)
+                self.metadata['cpu_time'].append(cpu_td)
+            except:
+                pass
 
         # TODO:
         # 'enthalpy' (incorrect)

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -318,6 +318,7 @@ A dictionary containing metadata_ (data about data) for the calculation. Current
 * ``basis_set``: A string with the name of the basis set, if it is printed anywhere as a standard name.
 * ``coord_type``: For the ``coords`` field, a string for the representation of stored coordinates. Currently, it is one of ``xyz``, ``int``/``internal``, or ``gzmat``.
 * ``coords``: A list of lists with shape ``[natoms, 4]`` which contains the input coordinates (those found in the input file). The first column is the atomic symbol as a string, and the next three columns are floats. This is useful as many programs reorient coordinates for symmetry reasons.
+* ``cpu_time``: A list of datetime.timedeltas containing the CPU time of each calculation in the output.  
 * ``functional``: A string with the name of the density functional used.
 * ``info``: A list of strings, each of which is an information or log message produced during a calculation.
 * ``input_file_contents``: A string containing the entire input file, if it is echoed back during the calculation.
@@ -328,6 +329,7 @@ A dictionary containing metadata_ (data about data) for the calculation. Current
 * ``package_version``: A string representation of the package version. It is formatted to allow comparison using relational operators.
 * ``success``: A boolean for whether or not the calculation completed properly.
 * ``unrestricted``: A boolean for whether or not the calculation was performed with a unrestricted wavefunction.
+* ``wall_time``: A list of datetime.timedeltas containing the wall time of each calculation in the output.  
 * ``warnings``: A list of strings, each of which is a warning produced during a calculation.
 
 The implementation and coverage of metadata is currently inconsistent. In the future, metadata may receive its own page similar to `extracted data`_.

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -347,6 +347,25 @@ class GenericSPTest(unittest.TestCase):
             packaging.version.parse(self.data.metadata["package_version"]),
             packaging.version.Version
         )
+    @skipForParser('ADF', 'reading cpu/wall time is not implemented for this parser')
+    @skipForParser('DALTON', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('FChk', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('GAMESS', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('GAMESSUK', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('GAMESSUS', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Gaussian', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Jaguar', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Molcas', ' reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Molpro', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('NWChem', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('ORCA', 'reading cpu not implemented for this parser, wall time not available') 
+    @skipForParser('Psi3', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Psi4', 'reading cpu/wall time is not implemented for this parser') 
+    @skipForParser('Turbomole', 'reading cpu/wall time is not implemented for this parser') 
+    def testmetadata_times(self):
+        """Does metadata have expected keys and values?"""
+        self.assertIn("cpu_time", self.data.metadata)
+        self.assertIn("wall_time", self.data.metadata)
 
 
 class ADFSPTest(GenericSPTest):


### PR DESCRIPTION
Extending the parser to parse the CPU/wall time from QChem output files. 

I needed to pull this out for my own research, though maybe it could be useful for others as well. Would parsing this information fall within cclib scope? Additionally,  if this is something you would parse, is metadata the place this should reside?

I could extend this to other parsers as well. 