### PR TITLE
Use stable version rather than git for iodata

### DIFF
--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -31,7 +31,7 @@ jobs:
           conda info -a
           conda install ci-psi4 psi4 openbabel pytest-cov pytest-shutil h5py
           python -m pip install pyscf
-          python -m pip install git+https://github.com/theochem/iodata.git
+          python -m pip install qc-iodata
           conda list
           conda env export
       - name: Install core dependencies


### PR DESCRIPTION
Commit [95e1642d5df88cf086593dd688ad6f7739c09c2d](https://github.com/theochem/iodata/commit/95e1642d5df88cf086593dd688ad6f7739c09c2d?branch=95e1642d5df88cf086593dd688ad6f7739c09c2d&diff=unified) in theochem/iodata introduced a bug it seems like:

```
Python 3.9.2 (default, Feb 20 2021, 18:40:11) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import iodata
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/shiv/.local/lib/python3.9/site-packages/iodata/__init__.py", line 23, in <module>
    from .api import *
  File "/home/shiv/.local/lib/python3.9/site-packages/iodata/api.py", line 47, in <module>
    FORMAT_MODULES = _find_format_modules()
  File "/home/shiv/.local/lib/python3.9/site-packages/iodata/api.py", line 41, in _find_format_modules
    format_module = import_module('iodata.formats.' + module_info.name)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/shiv/.local/lib/python3.9/site-packages/iodata/formats/json.py", line 45, in <module>
    from ..version import __version__
ModuleNotFoundError: No module named 'iodata.version'
```
We should use the stable pip version rather than the git version.