### PR TITLE
Turbomole: Base bug fixes

### DIFF
--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -459,7 +459,7 @@ def sort_turbomole_outputs(filelist):
         'gradient' : 7,
         'aoforce' : 8,
     }
-
+    
     known_files = []
     unknown_files = []
     sorted_list = []
@@ -467,6 +467,12 @@ def sort_turbomole_outputs(filelist):
         filename = path_leaf(fname)
         if filename in sorting_order:
             known_files.append([fname, sorting_order[filename]])
+        elif "job." in filename:
+            # Calling 'jobex -keep' will also write job.n files, where n ranges from 0 to inf.
+            # Numbered job files are inserted before job.last.
+            job_number = int(filename[4:]) +1
+            job_order = float("{}.{}".format(sorting_order['job.last'] -1, job_number))
+            known_files.append([fname, job_order])
         else:
             unknown_files.append(fname)
     for i in sorted(known_files, key=lambda x: x[1]):

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -467,7 +467,7 @@ def sort_turbomole_outputs(filelist):
         filename = path_leaf(fname)
         if filename in sorting_order:
             known_files.append([fname, sorting_order[filename]])
-        elif "job." in filename:
+        elif re.match(r"^job\.[0-9]+$", filename):
             # Calling 'jobex -keep' will also write job.n files, where n ranges from 0 to inf.
             # Numbered job files are inserted before job.last.
             job_number = int(filename[4:]) +1

--- a/test/data/skip.py
+++ b/test/data/skip.py
@@ -24,7 +24,8 @@ def skipForLogfile(fragment, msg):
     """Return a decorator that skips the test for logfiles containing fragment."""
     def testdecorator(testfunc):
         def testwrapper(self, *args, **kwargs):
-            if fragment in self.logfile.filename:
+            # self.logfile.filename may be a string or list of strings.
+            if fragment in self.logfile.filename or any(fragment in filename for filename in self.logfile.filename):
                 self.skipTest(msg)
             else:
                 testfunc(self, *args, **kwargs)


### PR DESCRIPTION
Bug fixes required for further Turbomole related updates:

- sort_turbomole_outputs(): Now correctly handles job.n files from intermediate optimisation steps
- skipForLogfile() decorator: Now correctly handles lists of log files as well as single log files