### PR TITLE
Fix Long (10,000+ Lines) ORCA Input Parsing

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -150,7 +150,7 @@ class ORCA(logfileparser.Logfile):
             for line in inputfile:
                 if line[0] != '|':
                     break
-                lines.append(line[6:])
+                lines.append(line[line.find('> ')+2:])
 
             self.metadata['input_file_contents'] = ''.join(lines[:-1])
             lines_iter = iter(lines[:-1])


### PR DESCRIPTION
When parsing input lines within an ORCA output file, [cclib slices the first six characters of the line](https://github.com/cclib/cclib/blob/937fdbf036b5002c47021e613077bc64902138fa/cclib/parser/orcaparser.py#L153) to remove the line number (i.e. `|  1> `). This works for the vast majority of output files. Sometimes there is a leftover space (once you reach 1,000+ lines), but this gets [corrected by a line strip later on](https://github.com/cclib/cclib/blob/937fdbf036b5002c47021e613077bc64902138fa/cclib/parser/orcaparser.py#L162).

However, once you get to 10,000+ lines, a `>` is leftover and not corrected with the line strip and not parsed correctly. Instead of having a hard slice, I think having a flexible slice by using `line.find('> ')` is more robust. This corrects any metadata parsing issues like [recognizing keywords](https://github.com/cclib/cclib/blob/937fdbf036b5002c47021e613077bc64902138fa/cclib/parser/orcaparser.py#L167) from lines that start with `!`.

[Here](https://github.com/cclib/cclib/files/6286511/longer-input.txt) is an example output file where the metadata is not parsed correctly (without this fix). I can add a regression test for this, but I am unsure if it is necessary.
