### PR TITLE
orca multiblock casscf fix

### DIFF
--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -526,7 +526,7 @@ class Logfile(ABC):
 
     skip_line = lambda self, inputfile, expected: self.skip_lines(inputfile, [expected])
 
-    def skip_until_no_match_line(self, inputfile, regex):
+    def skip_until_no_match(self, inputfile, regex):
         """Skip lines that match a regex. First non-matching line is returned.
 
         This method allows to skip a variable number of lines, allowing for example,

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -17,7 +17,6 @@ import os
 import random
 import sys
 import zipfile
-import re
 from abc import ABC, abstractmethod
 
 import numpy
@@ -511,7 +510,7 @@ class Logfile(ABC):
             for character, keys in expected_characters.items():
                 if expected in keys:
                     try:
-                        assert self.str_contains_only(line.strip(), [character, ' '])
+                        assert utils.str_contains_only(line.strip(), [character, ' '])
                     except AssertionError:
                         frame, fname, lno, funcname, funcline, index = inspect.getouterframes(inspect.currentframe())[1]
                         parser = fname.split('/')[-1]
@@ -526,19 +525,3 @@ class Logfile(ABC):
 
     skip_line = lambda self, inputfile, expected: self.skip_lines(inputfile, [expected])
 
-    def skip_until_no_match(self, inputfile, regex):
-        """Skip lines that match a regex. First non-matching line is returned.
-
-        This method allows to skip a variable number of lines, allowing for example,
-        to parse sections that might have different whitespace/spurious lines for
-        different versions of the software.
-        """
-        line = next(inputfile)
-        while re.match(regex, line):
-            line = next(inputfile)
-        return line
-
-    def str_contains_only(self, string, chars):
-        """Checks if string contains only the specified characters.
-        """
-        return all([c in chars for c in string])

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -17,6 +17,7 @@ import os
 import random
 import sys
 import zipfile
+import re
 from abc import ABC, abstractmethod
 
 import numpy
@@ -524,3 +525,15 @@ class Logfile(ABC):
         return lines
 
     skip_line = lambda self, inputfile, expected: self.skip_lines(inputfile, [expected])
+
+    def skip_until_no_match_line(self, inputfile, regex):
+        """Skip lines that match a regex. First non-matching line is returned.
+
+        This method allows to skip a variable number of lines, allowing for example,
+        to parse sections that might have different whitespace/spurious lines for
+        different versions of the software.
+        """
+        line = next(inputfile)
+        while re.match(regex, line):
+            line = next(inputfile)
+        return line

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -511,7 +511,7 @@ class Logfile(ABC):
             for character, keys in expected_characters.items():
                 if expected in keys:
                     try:
-                        assert all([c == character for c in line.strip() if c != ' '])
+                        assert self.str_contains_only(line.strip(), [character, ' '])
                     except AssertionError:
                         frame, fname, lno, funcname, funcline, index = inspect.getouterframes(inspect.currentframe())[1]
                         parser = fname.split('/')[-1]
@@ -537,3 +537,8 @@ class Logfile(ABC):
         while re.match(regex, line):
             line = next(inputfile)
         return line
+
+    def str_contains_only(self, string, chars):
+        """Checks if string contains only the specified characters.
+        """
+        return all([c in chars for c in string])

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -76,14 +76,6 @@ class ORCA(logfileparser.Logfile):
                     break
                 self.scfenergies[i] += dispersionenergy
 
-
-    def skip_until_no_match_line(self, inputfile, regex):
-        line = next(inputfile)
-        while re.match(regex, line):
-            line = next(inputfile)
-        return line
-
-
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1466,15 +1466,16 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             total_el = int(next(inputfile).split()[-1])
             total_orbs = int(next(inputfile).split()[-1])
 
+            line = utils.skip_until_no_match(inputfile, r'^\s*$|^Total number aux.*$|^Determined.*$')
+
             # Determined orbital ranges:
             #    Internal       0 -   -1 (   0 orbitals)
             #    Active         0 -    3 (   4 orbitals)
             #    External       4 -   19 (  16 orbitals)
-            self.skip_lines(inputfile, ['b', 'Determined'])
             orbital_ranges = []
             # Parse the orbital ranges for: Internal, Active, and External orbitals.
             for i in range(3):
-                vals = next(inputfile).split()
+                vals = line.split()
                 start, end, num = int(vals[1]), int(vals[3]), int(vals[5])
                 # Change from inclusive to exclusive in order to match python.
                 end = end + 1

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1485,7 +1485,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             self.skip_line(inputfile, 'CI strategy')
             num_blocks = int(next(inputfile).split()[-1])
             for b in range(1, num_blocks + 1):
-                line = self.skip_until_no_match_line(inputfile, r'^\s*$')
+                line = self.skip_until_no_match(inputfile, r'^\s*$')
                 vals = line.split()
                 block = int(vals[1])
                 weight = float(vals[3])
@@ -1552,7 +1552,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             # ROOT   0:  E=     -14.5950507665 Eh
             #       0.89724 [     0]: 2000
             for b in range(num_blocks):
-                line = self.skip_until_no_match_line(inputfile, r'^\s*$|^-*$')
+                line = self.skip_until_no_match(inputfile, r'^\s*$|^-*$')
                 # Parse the block data.
                 reg = r'BLOCK\s+(\d+) MULT=\s*(\d+) (IRREP=\s*\w+ )?(NROOTS=\s*(\d+))?'
                 groups = re.search(reg, line).groups()
@@ -1605,7 +1605,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 for j, line in zip(range(num_orbs), inputfile):
                     density[j][i:i + 6] = list(map(float, line.split()[1:]))
 
-            line = self.skip_until_no_match_line(inputfile, r'^\s*$|^-*$|^Trace.*$|^Extracting.*$')
+            line = self.skip_until_no_match(inputfile, r'^\s*$|^-*$|^Trace.*$|^Extracting.*$')
             
             # This is only printed for open-shells.
             # -------------------

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1200,7 +1200,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             etrotats = []
             self.skip_lines(inputfile, ["d", "State   Energy Wavelength", "(cm-1)   (nm)", "d"])
             line = next(inputfile)
-            while line.strip() and not self.str_contains_only(line.strip(), ['-']):
+            while line.strip() and not utils.str_contains_only(line.strip(), ['-']):
                 tokens = line.split()
                 if "spin forbidden" in line:
                     etrotat, mx, my, mz = 0.0, 0.0, 0.0, 0.0
@@ -1498,7 +1498,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             self.skip_line(inputfile, 'CI strategy')
             num_blocks = int(next(inputfile).split()[-1])
             for b in range(1, num_blocks + 1):
-                line = self.skip_until_no_match(inputfile, r'^\s*$')
+                line = utils.skip_until_no_match(inputfile, r'^\s*$')
                 vals = line.split()
                 block = int(vals[1])
                 weight = float(vals[3])
@@ -1565,7 +1565,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             # ROOT   0:  E=     -14.5950507665 Eh
             #       0.89724 [     0]: 2000
             for b in range(num_blocks):
-                line = self.skip_until_no_match(inputfile, r'^\s*$|^-*$')
+                line = utils.skip_until_no_match(inputfile, r'^\s*$|^-*$')
                 # Parse the block data.
                 reg = r'BLOCK\s+(\d+) MULT=\s*(\d+) (IRREP=\s*\w+ )?(NROOTS=\s*(\d+))?'
                 groups = re.search(reg, line).groups()
@@ -1618,7 +1618,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 for j, line in zip(range(num_orbs), inputfile):
                     density[j][i:i + 6] = list(map(float, line.split()[1:]))
 
-            line = self.skip_until_no_match(inputfile, r'^\s*$|^-*$|^Trace.*$|^Extracting.*$')
+            line = utils.skip_until_no_match(inputfile, r'^\s*$|^-*$|^Trace.*$|^Extracting.*$')
             
             # This is only printed for open-shells.
             # -------------------

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1183,6 +1183,8 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             #         (cm-1)   (nm)       (1e40*cgs)   (au)      (au)      (au)  
             # -------------------------------------------------------------------
             #    1   43167.6    231.7      0.00000   0.00000  -0.00000   0.00000
+            # ...
+            #    6   25291.1    395.4 spin forbidden
             #
             # OR (from 4.2.0 onwards)
             #------------------------------------------------------------------------------
@@ -1202,9 +1204,10 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 tokens = line.split()
                 if "spin forbidden" in line:
                     etrotat, mx, my, mz = 0.0, 0.0, 0.0, 0.0
+                    etenergies.append(utils.float(tokens[-4]))
                 else:
                     etrotat, mx, my, mz = [utils.float(t) for t in tokens[-4:]]
-                etenergies.append(utils.float(tokens[-6]))
+                    etenergies.append(utils.float(tokens[-6]))
                 etrotats.append(etrotat)
                 line = next(inputfile)
             self.set_attribute("etrotats", etrotats)

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1184,17 +1184,27 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             # -------------------------------------------------------------------
             #    1   43167.6    231.7      0.00000   0.00000  -0.00000   0.00000
             #
+            # OR (from 4.2.0 onwards)
+            #------------------------------------------------------------------------------
+            #                             CD SPECTRUM
+            #------------------------------------------------------------------------------
+            #      States        Energy   Wavelength   R*T        RX        RY        RZ
+            #                    (cm-1)      (nm)   (1e40*sgs)   (au)      (au)      (au)
+            #------------------------------------------------------------------------------
+            #  0( 1)-> 1( 1) 1   37192.8    268.9     0.00000  -0.00000  -0.34085   0.00000
+            # ...
+            #------------------------------------------------------------------------------
             etenergies = []
             etrotats = []
             self.skip_lines(inputfile, ["d", "State   Energy Wavelength", "(cm-1)   (nm)", "d"])
             line = next(inputfile)
-            while line.strip():
+            while line.strip() and not self.str_contains_only(line.strip(), ['-']):
                 tokens = line.split()
                 if "spin forbidden" in line:
                     etrotat, mx, my, mz = 0.0, 0.0, 0.0, 0.0
                 else:
-                    etrotat, mx, my, mz = [utils.float(t) for t in tokens[3:]]
-                etenergies.append(utils.float(tokens[1]))
+                    etrotat, mx, my, mz = [utils.float(t) for t in tokens[-4:]]
+                etenergies.append(utils.float(tokens[-6]))
                 etrotats.append(etrotat)
                 line = next(inputfile)
             self.set_attribute("etrotats", etrotats)

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -8,7 +8,7 @@
 """Utilities often used by cclib parsers and scripts"""
 
 import importlib
-import sys
+import re
 from itertools import accumulate
 
 import numpy
@@ -197,6 +197,23 @@ def get_rotation(a, b):
             rmat = numpy.dot(V, W)
             r = scipy.spatial.transform.Rotation.from_dcm(rmat)
     return r
+
+def skip_until_no_match(inputfile, regex):
+    """Skip lines that match a regex. First non-matching line is returned.
+
+    This method allows to skip a variable number of lines, allowing for example,
+    to parse sections that might have different whitespace/spurious lines for
+    different versions of the software.
+    """
+    line = next(inputfile)
+    while re.match(regex, line):
+        line = next(inputfile)
+    return line
+
+def str_contains_only(string, chars):
+    """Checks if string contains only the specified characters.
+    """
+    return all([c in chars for c in string])
 
 class PeriodicTable:
     """Allows conversion between element name and atomic no."""

--- a/test/regression.py
+++ b/test/regression.py
@@ -1753,6 +1753,11 @@ def testORCA_ORCA4_2_longer_input_out(logfile):
     assert logfile.data.metadata['input_file_contents'][-47:-4] == 'H   1.066878310   1.542378768  -0.602599044'
 
 
+def testORCA_ORCA4_2_casscf_out(logfile):
+    """ORCA casscf input file (#1044)."""
+    assert numpy.isclose(logfile.data.etenergies[0], 28271.0)
+
+
 # PSI 3 #
 
 


### PR DESCRIPTION
Hi, this should fix #1043

As i want to also support the old output format, I didn't want to hardcode these newlines, so I couldn't use the already defined `skip_lines`. Therefore I made a new method `skip_until_no_match_line`, that skips all continuous lines not matching a regex, which enables to skip variable variable number of lines & support both the old and new output file format.

Additionally, my output had the following section:

~~~
--------------
DENSITY MATRIX
--------------

                   0          1          2          3
      0       1.945508  -0.000000   0.000000   0.000000
      1      -0.000000   1.100650  -0.000000  -0.000000
      2       0.000000  -0.000000   0.899343   0.000000
      3       0.000000  -0.000000   0.000000   0.054499
Trace of the electron density:  4.000000
Extracting Spin-Density from 2-RDM (MULT=3) ... done
Extracting Spin-Density from 2-RDM (MULT=1) ... done

-------------------
SPIN-DENSITY MATRIX
-------------------
~~~

which contains the lines starting with `Extracting` that were not handled previously.

Again, log file for reference: [log.txt](https://github.com/cclib/cclib/files/6618229/log.txt)

