### PR TITLE
Parse rotational constants and molecular mass for Gaussian logs

### DIFF
--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -75,7 +75,7 @@ class ccData:
         optstatus -- optimization status for each set of atomic coordinates (array[1])
         polarizabilities -- (dipole) polarizabilities, static or dynamic (list of arrays[2])
         pressure -- pressure used for Thermochemistry (float, atm)
-        rotcons -- rotational constants (array[2], GHz)
+        rotconsts -- rotational constants (array[2], GHz)
         scancoords -- geometries of each scan step (array[3], angstroms)
         scanenergies -- energies of potential energy surface (list)
         scannames -- names of variables scanned (list of strings)
@@ -158,7 +158,7 @@ class ccData:
        "optstatus":        Attribute(numpy.ndarray,    'status',                      'optimization'),
        "polarizabilities": Attribute(list,             'polarizabilities',            'N/A'),
        "pressure":         Attribute(float,            'pressure',                    'properties'),
-       "rotcons":          Attribute(numpy.ndarray,    'rotational constants',        'atoms:coords:rotconsts'),
+       "rotconsts":        Attribute(numpy.ndarray,    'rotational constants',        'atoms:coords:rotconsts'),
        "scancoords":       Attribute(numpy.ndarray,    'step geometry',               'optimization:scan'),
        "scanenergies":     Attribute(list,             'PES energies',                'optimization:scan'),
        "scannames":        Attribute(list,             'variable names',              'optimization:scan'),

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -75,6 +75,7 @@ class ccData:
         optstatus -- optimization status for each set of atomic coordinates (array[1])
         polarizabilities -- (dipole) polarizabilities, static or dynamic (list of arrays[2])
         pressure -- pressure used for Thermochemistry (float, atm)
+        rotcons -- rotational constants (array[2], GHz)
         scancoords -- geometries of each scan step (array[3], angstroms)
         scanenergies -- energies of potential energy surface (list)
         scannames -- names of variables scanned (list of strings)
@@ -157,6 +158,7 @@ class ccData:
        "optstatus":        Attribute(numpy.ndarray,    'status',                      'optimization'),
        "polarizabilities": Attribute(list,             'polarizabilities',            'N/A'),
        "pressure":         Attribute(float,            'pressure',                    'properties'),
+       "rotcons":          Attribute(numpy.ndarray,    'rotational constants',        'atoms:coords:rotconsts'),
        "scancoords":       Attribute(numpy.ndarray,    'step geometry',               'optimization:scan'),
        "scanenergies":     Attribute(list,             'PES energies',                'optimization:scan'),
        "scannames":        Attribute(list,             'variable names',              'optimization:scan'),

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2271,5 +2271,12 @@ class Gaussian(logfileparser.Logfile):
             else:
                 self.rotcons.append([utils.float(splits[i])/29.9792458 for i in (-3, -2, -1)])
 
+        # Extract Molecular Mass (in amu)
+        # Example:
+        # Molecular mass:   128.06260 amu.
+        if line[:16] == ' Molecular mass:':
+            splits = line.split()
+            self.molmass = utils.float(splits[2])
+
         if line[:31] == ' Normal termination of Gaussian':
             self.metadata['success'] = True

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2264,12 +2264,7 @@ class Gaussian(logfileparser.Logfile):
         # Note: rotational constant will be converted to wavenumber units (1/cm) to standardize across parsers
         if line[:28] == ' Rotational constants (GHZ):':
             splits = line[28:].split()
-
-            # Determine if the molecule is linear and only has two constants
-            if '*' in line:  # linear molecule
-                self.append_attribute("rotconsts", [0.0]+[float(splits[i]) for i in (-2, -1)])
-            else:
-                self.append_attribute("rotconsts", [float(splits[i]) for i in (-3, -2, -1)])
+            self.append_attribute("rotconsts", [float(splits[i]) for i in (-3, -2, -1)])
 
         # Extract Molecular Mass (in amu)
         # Example:

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2261,15 +2261,15 @@ class Gaussian(logfileparser.Logfile):
         # Rotational constants (GHZ): ************ 12.73690 12.73690
         # Note: rotational constant will be converted to wavenumber units (1/cm) to standardize across parsers
         if line[:27] == ' Rotational constants (GHZ)':
-            if not hasattr(self, "rotcons"):
-                self.rotcons = []
+            if not hasattr(self, "rotconsts"):
+                self.rotconsts = []
             splits = line.split()
 
             # Determine if the molecule is linear and only has two constants
             if '*' in line:  # linear molecule
-                self.rotcons.append([0.0]+[float(splits[i]) for i in (-2, -1)])
+                self.rotconsts.append([0.0]+[float(splits[i]) for i in (-2, -1)])
             else:
-                self.rotcons.append([float(splits[i]) for i in (-3, -2, -1)])
+                self.rotconsts.append([float(splits[i]) for i in (-3, -2, -1)])
 
         # Extract Molecular Mass (in amu)
         # Example:

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2262,8 +2262,8 @@ class Gaussian(logfileparser.Logfile):
         # OR for linear molecules:
         # Rotational constants (GHZ): ************ 12.73690 12.73690
         # Note: rotational constant will be converted to wavenumber units (1/cm) to standardize across parsers
-        if line[:27] == ' Rotational constants (GHZ)':
-            splits = line.split()
+        if line[:28] == ' Rotational constants (GHZ):':
+            splits = line[28:].split()
 
             # Determine if the molecule is linear and only has two constants
             if '*' in line:  # linear molecule

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2267,9 +2267,9 @@ class Gaussian(logfileparser.Logfile):
 
             # Determine if the molecule is linear and only has two constants
             if '*' in line:  # linear molecule
-                self.rotcons.append([0.0]+[utils.float(splits[i])/29.9792458 for i in (-2, -1)])
+                self.rotcons.append([0.0]+[float(splits[i]) for i in (-2, -1)])
             else:
-                self.rotcons.append([utils.float(splits[i])/29.9792458 for i in (-3, -2, -1)])
+                self.rotcons.append([float(splits[i]) for i in (-3, -2, -1)])
 
         # Extract Molecular Mass (in amu)
         # Example:

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2254,5 +2254,22 @@ class Gaussian(logfileparser.Logfile):
             except:
                 pass
 
+        # Extract Rotational Constants
+        # Example:
+        # Rotational constants (GHZ):           3.13081     1.24272     0.88960
+        # OR for linear molecules:
+        # Rotational constants (GHZ): ************ 12.73690 12.73690
+        # Note: rotational constant will be converted to wavenumber units (1/cm) to standardize across parsers
+        if line[:27] == ' Rotational constants (GHZ)':
+            if not hasattr(self, "rotcons"):
+                self.rotcons = []
+            splits = line.split()
+
+            # Determine if the molecule is linear and only has two constants
+            if '*' in line:  # linear molecule
+                self.rotcons.append([0.0]+[utils.float(splits[i])/29.9792458 for i in (-2, -1)])
+            else:
+                self.rotcons.append([utils.float(splits[i])/29.9792458 for i in (-3, -2, -1)])
+
         if line[:31] == ' Normal termination of Gaussian':
             self.metadata['success'] = True

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -139,6 +139,8 @@ class Gaussian(logfileparser.Logfile):
                 self.atomcoords = self.atomcoords[:last_point + 1]
             if hasattr(self, 'inputcoords'):
                 self.inputcoords = self.inputcoords[:last_point + 1]
+            if hasattr(self, "rotconsts"):
+                self.rotconsts = self.rotconsts[:last_point + 1]
 
         # If we parsed high-precision vibrational displacements, overwrite
         # lower-precision displacements in self.vibdisps

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2263,15 +2263,13 @@ class Gaussian(logfileparser.Logfile):
         # Rotational constants (GHZ): ************ 12.73690 12.73690
         # Note: rotational constant will be converted to wavenumber units (1/cm) to standardize across parsers
         if line[:27] == ' Rotational constants (GHZ)':
-            if not hasattr(self, "rotconsts"):
-                self.rotconsts = []
             splits = line.split()
 
             # Determine if the molecule is linear and only has two constants
             if '*' in line:  # linear molecule
-                self.rotconsts.append([0.0]+[float(splits[i]) for i in (-2, -1)])
+                self.append_attribute("rotconsts", [0.0]+[float(splits[i]) for i in (-2, -1)])
             else:
-                self.rotconsts.append([float(splits[i]) for i in (-3, -2, -1)])
+                self.append_attribute("rotconsts", [float(splits[i]) for i in (-3, -2, -1)])
 
         # Extract Molecular Mass (in amu)
         # Example:

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -172,14 +172,14 @@ class MOPAC(logfileparser.Logfile):
         if line[0:40] == '          ROTATIONAL CONSTANTS IN CM(-1)':
             blankline = inputfile.next()
             rotinfo = inputfile.next()
-            if not hasattr(self, "rotcons"):
-                self.rotcons = []
+            if not hasattr(self, "rotconsts"):
+                self.rotconsts = []
             broken = rotinfo.split()
             # leave the rotational constants in Hz
             a = float(broken[2])
             b = float(broken[5])
             c = float(broken[8])
-            self.rotcons.append([a, b, c])
+            self.rotconsts.append([a, b, c])
 
         # Start of the IR/Raman frequency section.
         # Example:

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -14,7 +14,7 @@ import numpy
 
 from common import get_minimum_carbon_separation
 
-from skip import skipForParser
+from skip import skipForLogfile, skipForParser
 
 __filedir__ = os.path.realpath(os.path.dirname(__file__))
 
@@ -179,6 +179,24 @@ class GenericGeoOptTest(unittest.TestCase):
         for i in range(1, len(self.data.optstatus)-1):
             self.assertEqual(self.data.optstatus[i], self.data.OPT_UNKNOWN)
         self.assertEqual(self.data.optstatus[-1], self.data.OPT_DONE)
+
+    @skipForParser('ADF', 'Not implemented yet')
+    @skipForParser('DALTON', 'Not implemented yet')
+    @skipForParser('FChk', 'Rotational constants are never written to fchk files')
+    @skipForParser('GAMESS', 'Not implemented yet')
+    @skipForParser('GAMESSUK', 'Not implemented yet')
+    @skipForParser('Jaguar', 'Not implemented yet')
+    @skipForParser('Molcas', 'Not implemented yet')
+    @skipForParser('Molpro', 'Not implemented yet')
+    @skipForLogfile('MOPAC/basicMOPAC2016', 'Not present in this file')
+    @skipForParser('NWChem', 'Not implemented yet')
+    @skipForParser('ORCA', 'Not implemented yet')
+    @skipForParser('Psi4', 'Not implemented yet')
+    @skipForParser('QChem', 'Not implemented yet')
+    @skipForParser('Turbomole', 'Not implemented yet')
+    def testrotconsts(self):
+        """Each geometry leads to a row in the rotational constants entry."""
+        self.assertEqual(self.data.rotconsts.shape, (len(self.data.atomcoords), 3))
 
     @skipForParser('Molcas', 'The parser is still being developed so we skip this test')
     def testmoenergies(self):

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -251,6 +251,26 @@ class GenericSPTest(unittest.TestCase):
         """There should be no optdone attribute set."""
         self.assertFalse(hasattr(self.data, 'optdone'))
 
+    @skipForParser('ADF', 'Not implemented yes')
+    @skipForParser('DALTON', 'Not implemented yes')
+    @skipForParser('FChk', 'Rotational constants are never written to fchk files')
+    @skipForParser('GAMESS', 'Not implemented yes')
+    @skipForParser('GAMESSUK', 'Not implemented yet')
+    @skipForParser('Jaguar', 'Not implemented yet')
+    @skipForParser('Molcas', 'Not implemented yes')
+    @skipForParser('Molpro', 'Not implemented yes')
+    @skipForParser('NWChem', 'Not implemented yes')
+    @skipForParser('ORCA', 'Not implemented yes')
+    @skipForParser('Psi4', 'Not implemented yes')
+    @skipForParser('QChem', 'Not implemented yes')
+    @skipForParser('Turbomole', 'Not implemented yes')
+    def testrotconsts(self):
+        """A single geometry leads to single set of rotational constants."""
+        self.assertEqual(self.data.rotconsts.shape, (1, 3))
+        # taken from Gaussian16/dvb_sp.out
+        ref = [4.6266363, 0.6849065, 0.5965900]
+        numpy.testing.assert_allclose(self.data.rotconsts[0], ref, rtol=0, atol=1.0e-3)
+
     @skipForParser('FChk', 'The parser is still being developed so we skip this test')
     @skipForParser('Gaussian', 'Logfile needs to be updated')
     @skipForParser('Jaguar', 'No dipole moments in the logfile')


### PR DESCRIPTION
# Purpose
Currently, cclib has the ability to parse rotational constants and molecular mass from MOPAC log files (I think this functionality was added to cclib long ago by RMG developer Greg Magoon to support his work on QMTP in RMG). This PR extends this ability to Gaussian log files, which is something we use cclib for in RMG. 

# Testing
I have tested locally that the added code works by testing it on Gaussian log files for various semi-empirical calculations. It is the same suite of tests that we use to test the MOPAC parsing ability already implemented in cclib

# Other considerations
This is my first time contributing to cclib, so let me know if I missed any steps in your usual development workflow. I tried to follow the guidelines outlined in your online documentation.