### PR TITLE
Fix natural charge parsing

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2037,15 +2037,16 @@ class Gaussian(logfileparser.Logfile):
         if line.strip() == "Natural Population":
             if not hasattr(self, 'atomcharges'):
                 self.atomcharges = {}
-            line1 = next(inputfile)
-            line2 = next(inputfile)
-            if line1.split()[0] == 'Natural' and line2.split()[2] == 'Charge':
-                dashes = next(inputfile)
-                charges = []
-                for i in range(self.natom):
-                    nline = next(inputfile)
-                    charges.append(float(nline.split()[2]))
-                self.atomcharges["natural"] = charges
+            if "natural" not in self.atomcharges:
+                line1 = next(inputfile)
+                line2 = next(inputfile)
+                if line1.split()[0] == 'Natural' and line2.split()[2] == 'Charge':
+                    dashes = next(inputfile)
+                    charges = []
+                    for i in range(self.natom):
+                        nline = next(inputfile)
+                        charges.append(float(nline.split()[2]))
+                    self.atomcharges["natural"] = charges
 
         #Extract Thermochemistry
         #Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.

--- a/test/regression.py
+++ b/test/regression.py
@@ -1161,6 +1161,15 @@ def testGaussian_Gaussian09_benzene_excited_states_optimization_issue889_log(log
     assert len(logfile.data.etsecs) == 20
     assert logfile.data.etveldips.shape == (20,3)
 
+def testGaussian_Gaussian16_H3_natcharge_log(logfile):
+    """A calculation with natural charges calculated. Test issue 1055 where 
+    only the beta set of charges was parsed rather than the spin independent"""
+
+    assert isinstance(logfile.data.atomcharges, dict)
+    assert "mulliken" in logfile.data.atomcharges
+    assert "natural" in logfile.data.atomcharges
+    assert numpy.all(logfile.data.atomcharges["natural"] == [ 0.0721, -0.1442,  0.0721])
+
 def testGaussian_Gaussian16_naturalspinorbitals_parsing_log(logfile):
     """A UHF calculation with natural spin orbitals."""
 


### PR DESCRIPTION
Closes #1055 

The spin independent and spin dependent natural charge blocks have the same header so the final (beta) block was overwriting the attribute.