### PR TITLE
pin h5py to fix CI

### DIFF
--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           conda config --set always_yes true --set changeps1 false --set channel_priority flexible --set quiet true
           conda info -a
-          conda install ci-psi4 psi4 openbabel pytest-cov pytest-shutil h5py
+          conda install ci-psi4 psi4 openbabel pytest-cov pytest-shutil h5py=2.10.0
           python -m pip install pyscf
           python -m pip install qc-iodata
           conda list


### PR DESCRIPTION
PySCF wheels require an older version of h5py. This is necessary for now.