### PR TITLE
Tweaks to docs needed after v1.7.1

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -44,7 +44,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'cclib'
-copyright = u'2014-2018, cclib Development Team'
+copyright = u'2014-2021, cclib Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/sphinx/coverage.py
+++ b/doc/sphinx/coverage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, the cclib development team
+# Copyright (c) 2021, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
@@ -36,7 +36,7 @@ def generate_coverage():
     os.chdir(testpath)
 
     thispath = os.path.dirname(os.path.realpath(__file__))
-    sys.path.insert(1, thispath)
+    sys.path.insert(1, os.path.join(thispath, testpath))
 
     from test.test_data import (all_modules, all_parsers, parser_names, DataSuite)
     import inspect


### PR DESCRIPTION
These changes were needed to build the docs. See cclib/cclib.github.io#40 for the resulting docs upate.