### PR TITLE
Multiple jobs in one output file

### DIFF
--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1588,7 +1588,6 @@ class GAMESS(logfileparser.Logfile):
             self.set_attribute('entropy', utils.convertor(float(thermoValues[6])/1000.0,"kcal/mol","hartree"))
 
 
-        if line[:30] == ' ddikick.x: exited gracefully.'\
-                or line[:41] == ' EXECUTION OF FIREFLY TERMINATED NORMALLY'\
+        if line[:41] == ' EXECUTION OF FIREFLY TERMINATED NORMALLY'\
                 or line[:40] == ' EXECUTION OF GAMESS TERMINATED NORMALLY':
             self.metadata['success'] = True

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -282,10 +282,6 @@ class Logfile(ABC):
                 f"Method {self.__class__.__name__}._extract takes wrong number of arguments."
             )
 
-        # Save the current list of attributes to keep after parsing.
-        # The dict of self should be the same after parsing.
-        _nodelete = list(set(self.__dict__.keys()))
-
         # Initiate the FileInput object for the input files.
         # Remember that self.filename can be a list of files.
         if not self.isstream:
@@ -307,6 +303,10 @@ class Logfile(ABC):
 
         # Maybe the sub-class has something to do before parsing.
         self.before_parsing()
+
+        # Save the current list of attributes to keep after parsing.
+        # The dict of self should be the same after parsing.
+        _nodelete = list(set(self.__dict__.keys()))
 
         # Loop over lines in the file object and call extract().
         # This is where the actual parsing is done.

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -175,46 +175,53 @@ def ccget():
             kwargs['cjson'] = True
 
         print(f"Attempting to read {name}")
-        data = ccread(filename, **kwargs)
+        parsed_data = ccread(filename, **kwargs)
 
-        if data is None:
+        if parsed_data is None:
             print(f"Cannot figure out the format of '{name}'")
             print("Report this to the cclib development team if you think it is an error.")
             print(f"\n{parser.format_usage()}")
             parser.exit(1)
 
-        if showattr:
-            print(f"cclib can parse the following attributes from {name}:")
-            if cjsonfile:
-                for key in data:
-                    print(key)
-                break
-            for attr in data._attrlist:
-                if hasattr(data, attr):
-                    print(f"  {attr}")
+        if type(parsed_data) == list:
+            print(f"Found multiple jobs in {name}")
         else:
-            invalid = False
-            for attr in attrnames:
-                if cjsonfile:
-                    if attr in data:
-                        print(f"{attr}:\n{data[attr]}")
-                        continue
-                else:
-                    if hasattr(data, attr):
-                        print(attr)
-                        attr_val = getattr(data, attr)
-                        # List of attributes to be printed with new lines
-                        if attr in data._listsofarrays and full:
-                            for val in attr_val:
-                                pprint(val)
-                        else:
-                            pprint(attr_val)
-                        continue
+            parsed_data = [parsed_data]
 
-                print(f"Could not parse {attr} from this file.")
-                invalid = True
-            if invalid:
-                parser.print_help()
+        for job_num, data in enumerate(parsed_data):
+            print("{name} job {job_num}")
+            if showattr:
+                print(f"cclib can parse the following attributes from {name} job {job_num}:")
+                if cjsonfile:
+                    for key in data:
+                        print(key)
+                    break
+                for attr in data._attrlist:
+                    if hasattr(data, attr):
+                        print("  %s" % attr)
+            else:
+                invalid = False
+                for attr in attrnames:
+                    if cjsonfile:
+                        if attr in data:
+                            print("%s:\n%s" % (attr, data[attr]))
+                            continue
+                    else:
+                        if hasattr(data, attr):
+                            print(attr)
+                            attr_val = getattr(data, attr)
+                            # List of attributes to be printed with new lines
+                            if attr in data._listsofarrays and full:
+                                for val in attr_val:
+                                    pprint(val)
+                            else:
+                                pprint(attr_val)
+                            continue
+
+                    print("Could not parse %s from this file." % attr)
+                    invalid = True
+                if invalid:
+                    parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a (?proposal) WIP PR to allow for the parsing of multiple jobs in a single file. 

For a simple example:
```
# to form temp:
# cat dvb_sp_hf.out &>> temp
# cat dvb_sp_hf.out &>> temp

import cclib
print("Single Job Single File")
a = cclib.ccopen("dvb_sp_hf.out")
print(a.parse())

print("Multiple Jobs Single File")
b = cclib.ccopen("temp")
print(b.parse())
```
The single job still creates a single ccData object and the multiple job file creates a list of ccData objects:
```
Single Job Single File
<cclib.parser.data.ccData_optdone_bool object at 0x7f61d99cb6a0>
Multiple Jobs Single File
[<cclib.parser.data.ccData_optdone_bool object at 0x7f61db8f85e0>, <cclib.parser.data.ccData_optdone_bool object at 0x7f61db8f8610>]
```

Things that I know still need to be fixed:

- [ ] ccframe
- [ ] ccwrite
- [ ] False positives? (BOMD, Geometry scans, others)  



Closes #657 