### PR TITLE
Orca: fix for oscillator strength

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1117,7 +1117,7 @@ Dispersion correction           -0.016199959
             self.extend_attribute('etsyms', etsyms)
 
         # Parse the various absorption spectra for TDDFT and ROCIS.
-        if 'ABSORPTION SPECTRUM' in line or 'ELECTRIC DIPOLE' in line:
+        if ('ABSORPTION SPECTRUM' in line and 'ELECTRIC DIPOLE' in line) and not 'SOC' in line:
             # CASSCF has an anomalous printing of ABSORPTION SPECTRUM.
             if line[:-1] == 'ABSORPTION SPECTRUM':
                 return

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -214,7 +214,8 @@ class OrcaROCIS40Test(OrcaROCISTest):
     # In ORCA 4.0, an additional spectrum ("COMBINED ELECTRIC DIPOLE +
     # MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM (Origin Independent,
     # Length Representation)") was present that is not in ORCA 4.1.
-    n_spectra = 9
+    # Changed via 1085. Only the Electric Dipole are parsed
+    n_spectra = 2
 
 
 class TurbomoleTDTest(GenericTDTest):

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -179,7 +179,8 @@ class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
     expected_l_max = 2316970.8
-    n_spectra = 2
+    # per 1085, no VELOCITY DIPOLE MOMENTS are parsed
+    n_spectra = 7
 
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""
@@ -214,8 +215,8 @@ class OrcaROCIS40Test(OrcaROCISTest):
     # In ORCA 4.0, an additional spectrum ("COMBINED ELECTRIC DIPOLE +
     # MAGNETIC DIPOLE + ELECTRIC QUADRUPOLE SPECTRUM (Origin Independent,
     # Length Representation)") was present that is not in ORCA 4.1.
-    # Changed via 1085. Only the Electric Dipole are parsed
-    n_spectra = 2
+    # Changed via 1085. VELOCITY DIPOLE MOMENTS are not parsed.
+    n_spectra = 8
 
 
 class TurbomoleTDTest(GenericTDTest):

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -148,7 +148,7 @@ class OrcaTDDFTTest(GenericTDTest):
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""
         self.assertEqual(len(self.data.etoscs), self.number)
-        self.assertAlmostEqual(max(self.data.etoscs), .09, delta=0.01)
+        self.assertAlmostEqual(max(self.data.etoscs), 1.17, delta=0.01)
 
 
 class QChemTDDFTTest(GenericTDTest):
@@ -179,7 +179,7 @@ class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
     expected_l_max = 2316970.8
-    n_spectra = 8
+    n_spectra = 2
 
     def testoscs(self):
         """Is the maximum of etoscs in the right range?"""

--- a/test/regression.py
+++ b/test/regression.py
@@ -3140,6 +3140,13 @@ class OrcaTDDFTTest_error(OrcaTDDFTTest):
         self.assertAlmostEqual(max(self.data.etoscs), 1.0, delta=0.2)
 
 
+class OrcaTDDFTTest_pre1085(OrcaTDDFTTest):
+    def testoscs(self):
+        """These values changed in the electric dipole osc strengths prior to Orca 4.0. See PR1085"""
+        self.assertEqual(len(self.data.etoscs), self.number)
+        self.assertAlmostEqual(max(self.data.etoscs), 0.94, delta=0.2)
+
+
 class OrcaIRTest_old_coordsOK(OrcaIRTest):
 
     zpve = 0.1986
@@ -3364,7 +3371,7 @@ old_unittests = {
     "ORCA/ORCA2.8/dvb_sp.out":      GenericBasisTest,
     "ORCA/ORCA2.8/dvb_sp.out":      OrcaSPTest,
     "ORCA/ORCA2.8/dvb_sp_un.out":   OrcaSPunTest_charge0,
-    "ORCA/ORCA2.8/dvb_td.out":      OrcaTDDFTTest,
+    "ORCA/ORCA2.8/dvb_td.out":      OrcaTDDFTTest_pre1085,
     "ORCA/ORCA2.8/dvb_ir.out":      OrcaIRTest_old,
 
     "ORCA/ORCA2.9/dvb_gopt.out":    OrcaGeoOptTest,
@@ -3374,7 +3381,7 @@ old_unittests = {
     "ORCA/ORCA2.9/dvb_sp.out":      GenericBasisTest,
     "ORCA/ORCA2.9/dvb_sp.out":      OrcaSPTest,
     "ORCA/ORCA2.9/dvb_sp_un.out":   GenericSPunTest,
-    "ORCA/ORCA2.9/dvb_td.out":      OrcaTDDFTTest,
+    "ORCA/ORCA2.9/dvb_td.out":      OrcaTDDFTTest_pre1085,
 
     "ORCA/ORCA3.0/dvb_bomd.out":          GenericBOMDTest,
     "ORCA/ORCA3.0/dvb_gopt.out":          OrcaGeoOptTest,
@@ -3384,7 +3391,7 @@ old_unittests = {
     "ORCA/ORCA3.0/dvb_sp_un.out":         GenericSPunTest,
     "ORCA/ORCA3.0/dvb_sp.out":            GenericBasisTest,
     "ORCA/ORCA3.0/dvb_sp.out":            OrcaSPTest,
-    "ORCA/ORCA3.0/dvb_td.out":            OrcaTDDFTTest,
+    "ORCA/ORCA3.0/dvb_td.out":            OrcaTDDFTTest_pre1085,
     "ORCA/ORCA3.0/Trp_polar.out":         ReferencePolarTest,
     "ORCA/ORCA3.0/trithiolane_polar.out": GaussianPolarTest,
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -3362,11 +3362,6 @@ old_unittests = {
 
     "NWChem/NWChem6.6/trithiolane_polar.out": GaussianPolarTest,
 
-    "ORCA/ORCA2.6/dvb_gopt.out":    OrcaGeoOptTest_3_21g,
-    "ORCA/ORCA2.6/dvb_sp.out":      OrcaSPTest_3_21g,
-    "ORCA/ORCA2.6/dvb_td.out":      OrcaTDDFTTest_error,
-    "ORCA/ORCA2.6/dvb_ir.out":      OrcaIRTest_old_coordsOK,
-
     "ORCA/ORCA2.8/dvb_gopt.out":    OrcaGeoOptTest,
     "ORCA/ORCA2.8/dvb_sp.out":      GenericBasisTest,
     "ORCA/ORCA2.8/dvb_sp.out":      OrcaSPTest,


### PR DESCRIPTION
Orca prints two values for the oscillator strengths, the `ELECTRIC DIPOLE MOMENTS` and `VELOCITY DIPOLE MOMENTS`.

At the moment, the `VELOCITY DIPOLE MOMENTS` are parsed by cclib. But, actually, the `ELECTRIC DIPOLE MOMENTS`, i.e. the length representation, are the thing one usually talks about. Also the comment on line 1102 suggests that cclib wants to actually parse the `ELECTRIC DIPOLE MOMENTS`. So, I would suggest changing this line in the parser to make sure that the `ELECTRIC DIPOLE MOMENTS` are read in. Is that ok?

In addition, I am including a small fix for calculations including SOC.