### PR TITLE
Pytest filter through GitHub actions

### DIFF
--- a/.github/scripts/run_pytest.bash
+++ b/.github/scripts/run_pytest.bash
@@ -5,7 +5,7 @@
 
 set -euxo pipefail
 
-python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-unit.xml --terse test
+python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-unit.xml --terse test -k "not test_method"
 pushd data
 bash ./regression_download.sh
 popd

--- a/.github/scripts/run_pytest_methods.bash
+++ b/.github/scripts/run_pytest_methods.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# run_pytest.bash: Run pytest on cclib with coverage checking. Requires
+# `pytest` and `pytest-cov`.
+
+set -euxo pipefail
+
+python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-unit.xml --terse test -k "test_method"

--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -25,10 +25,21 @@ jobs:
       - name: Install cclib
         run: |
           python -m pip install .
-      - name: Test with pytest
+      - name: Filter code
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            methods:
+              - 'cclib/cclib/method/**'
+      - name: Test core code with pytest
         run: |
           env | sort
           bash .github/scripts/run_pytest.bash
+      - name: Test method code with pytest
+        if: steps.filter.outputs.method == 'true' 
+        run: |
+          bash .github/scripts/run_pytest_methods.bash
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Introduces filtering for tests. 

The core set of tests for parsers run for every pull request, while the method related tests will only run when there is a change within the methods folder. 