### PR TITLE
Fix deprecation warning on getargspec

### DIFF
--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -273,7 +273,7 @@ class Logfile(ABC):
             raise AttributeError("Class %s has no extract() method." % self.__class__.__name__)
         if not callable(self.extract):
             raise AttributeError("Method %s._extract not callable." % self.__class__.__name__)
-        if len(inspect.getargspec(self.extract)[0]) != 3:
+        if len(inspect.getfullargspec(self.extract)[0]) != 3:
             raise AttributeError("Method %s._extract takes wrong number of arguments." % self.__class__.__name__)
 
         # Save the current list of attributes to keep after parsing.


### PR DESCRIPTION
I have a vendetta against `DeprecationWarning`'s, so here is a quick fix for the `inspect.getargspec()` command used in `cclib.parser.logfileparser.`:
```
...\cclib\parser\logfileparser.py:276: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
    if len(inspect.getargspec(self.extract)[0]) != 3:

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```