### PR TITLE
coverage actions v2

### DIFF
--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -30,7 +30,7 @@ jobs:
           env | sort
           bash .github/scripts/run_pytest.bash
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           files: ./coverage-unit.xml,./coverage-regression.xml
           name: codecov-cclib


### PR DESCRIPTION
As described [here](https://github.com/codecov/codecov-action) version 1 of coverage-action is being sunset and we should switch to v2. 

I'm not familiar enough with cclib codecov set up yet, so I am not sure if the TOKEN is uploaded as described in the note on their page:
"Note: This assumes that you've set your Codecov token inside Settings > Secrets as CODECOV_TOKEN"
