### PR TITLE
super calls don't require arguments in Python 3

### DIFF
--- a/cclib/io/cjsonreader.py
+++ b/cclib/io/cjsonreader.py
@@ -17,12 +17,12 @@ class CJSON(filereader.Reader):
     """A reader for chemical JSON (CJSON) log files."""
 
     def __init__(self, source, *args, **kwargs):
-        super(CJSON, self).__init__(source, *args, **kwargs)
+        super().__init__(source, *args, **kwargs)
 
         self.representation = dict()
 
     def parse(self):
-        super(CJSON, self).parse()
+        super().parse()
 
         json_data = json.loads(self.filecontents)
 

--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -27,8 +27,7 @@ class CJSON(filewriter.Writer):
         Inputs:
           ccdata - An instance of ccData, parsed from a logfile.
         """
-
-        super(CJSON, self).__init__(ccdata, terse=terse, *args, **kwargs)
+        super().__init__(ccdata, terse=terse, *args, **kwargs)
 
     def pathname(self, path):
         """Return filename without extension to be used as name."""
@@ -180,7 +179,7 @@ class NumpyAwareJSONEncoder(json.JSONEncoder):
 class JSONIndentEncoder(json.JSONEncoder):
 
     def __init__(self, *args, **kwargs):
-        super(JSONIndentEncoder, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.current_indent = 0
         self.current_indent_str = ""
 

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -24,9 +24,7 @@ class CML(filewriter.Writer):
         Inputs:
           ccdata - An instance of ccData, parsed from a logfile.
         """
-
-        # Call the __init__ method of the superclass
-        super(CML, self).__init__(ccdata, *args, **kwargs)
+        super().__init__(ccdata, *args, **kwargs)
 
     def generate_repr(self):
         """Generate the CML representation of the logfile data."""

--- a/cclib/io/xyzreader.py
+++ b/cclib/io/xyzreader.py
@@ -16,12 +16,12 @@ class XYZ(filereader.Reader):
     """A reader for XYZ (Cartesian coordinate) files."""
 
     def __init__(self, source, *args, **kwargs):
-        super(XYZ, self).__init__(source, *args, **kwargs)
+        super().__init__(source, *args, **kwargs)
 
         self.pt = PeriodicTable()
 
     def parse(self):
-        super(XYZ, self).parse()
+        super().parse()
 
         self.generate_repr()
 

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -25,11 +25,9 @@ class XYZ(filewriter.Writer):
           lastgeom - Boolean to write the last available geometry from the logfile.
           allgeom - Boolean to write all available geometries from the logfile.
         """
+        super().__init__(ccdata, *args, **kwargs)
 
         self.required_attrs = ('natom', 'atomcoords', 'atomnos')
-
-        # Call the __init__ method of the superclass
-        super(XYZ, self).__init__(ccdata, *args, **kwargs)
 
         self.do_firstgeom = firstgeom
         self.do_lastgeom = lastgeom

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -44,7 +44,7 @@ class Bader(Method):
     required_attrs = ("homos", "mocoeffs", "nbasis", "gbasis")
 
     def __init__(self, data, volume, progress=None, loglevel=logging.INFO, logname="Log"):
-        super(Bader, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.volume = volume
         self.fragresults = None
@@ -65,7 +65,7 @@ class Bader(Method):
         return "Bader({})".format(self.data)
 
     def _check_required_attributes(self):
-        super(Bader, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def calculate(self, indices=None, fupdate=0.05):
         """Calculate Bader's QTAIM charges using on-grid algorithm proposed by Henkelman group

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -18,9 +18,7 @@ class Bickelhaupt(Population):
     """Bickelhaupt population analysis."""
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(Bickelhaupt, self).__init__(logname="Bickelhaupt Population Analysis", *args)
+        super().__init__(logname="Bickelhaupt Population Analysis", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -104,7 +102,7 @@ class Bickelhaupt(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(Bickelhaupt, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -18,9 +18,7 @@ class CDA(FragmentAnalysis):
     """Charge Decomposition Analysis (CDA)"""
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(FragmentAnalysis, self).__init__(logname="CDA", *args)
+        super().__init__(logname="CDA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -38,7 +36,7 @@ class CDA(FragmentAnalysis):
         """
 
 
-        retval = super(CDA, self).calculate(fragments, cupdate)
+        retval = super().calculate(fragments, cupdate)
         if not retval:
             return False
 

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -21,9 +21,7 @@ class CSPA(Population):
     overlap_attributes = ()
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(CSPA, self).__init__(logname="CSPA", *args)
+        super().__init__(logname="CSPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -76,7 +74,7 @@ class CSPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(CSPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -67,7 +67,7 @@ class DDEC6(Stockholder):
                 total densities that are partitioned resemble the proatom densities and to prevent
                 the numerical algorithm from failing to converge.
         """
-        super(DDEC6, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
+        super().__init__(data, volume, proatom_path, progress, loglevel, logname)
 
         self.convergence_level = convergence_level
         self.max_iteration = max_iteration
@@ -85,7 +85,7 @@ class DDEC6(Stockholder):
         return "DDEC6({})".format(self.data)
 
     def _check_required_attributes(self):
-        super(DDEC6, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _cartesian_dist(self, pt1, pt2):
         """ Small utility function that calculates Euclidian distance between two points
@@ -95,15 +95,14 @@ class DDEC6(Stockholder):
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float
     ):
-        return super(DDEC6, self)._read_proatom(directory, atom_num, charge)
+        return super()._read_proatom(directory, atom_num, charge)
 
     def calculate(self, indices=None, fupdate=0.05):
         """
         Calculate DDEC6 charges based on doi: 10.1039/c6ra04656h paper.
         Cartesian, uniformly spaced grids are assumed for this function.
         """
-
-        super(DDEC6, self).calculate()
+        super().calculate()
 
         # Notify user about the total charge in the density grid
         integrated_density = self.charge_density.integrate()

--- a/cclib/method/density.py
+++ b/cclib/method/density.py
@@ -19,9 +19,7 @@ class Density(Method):
     """Calculate the density matrix"""
     def __init__(self, data, progress=None, loglevel=logging.INFO,
                  logname="Density"):
-
-        # Call the __init__ method of the superclass.
-        super(Density, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -18,10 +18,8 @@ class Electrons(Method):
     """A container for methods pertaining to electrons."""
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
-
+        super().__init__(data, progress, loglevel, logname)
         self.required_attrs = ('atomnos','charge','coreelectrons','homos')
-
-        super(Electrons, self).__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Returns a string representation of the object."""

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -20,9 +20,7 @@ class FragmentAnalysis(Method):
     """Convert a molecule's basis functions from atomic-based to fragment MO-based"""
     def __init__(self, data, progress=None, loglevel=logging.INFO,
                  logname="FragmentAnalysis of"):
-
-        # Call the __init__ method of the superclass.
-        super(FragmentAnalysis, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
         self.parsed = False
 
     def __str__(self):

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -52,7 +52,7 @@ class Hirshfeld(Stockholder):
                 proatom_path -- path to proatom densities
                 (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
         """
-        super(Hirshfeld, self).__init__(data, volume, proatom_path, progress, loglevel, logname)
+        super().__init__(data, volume, proatom_path, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -63,7 +63,7 @@ class Hirshfeld(Stockholder):
         return "Hirshfeld({})".format(self.data)
 
     def _check_required_attributes(self):
-        super(Hirshfeld, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _cartesian_dist(self, pt1, pt2):
         """Small utility function that calculates Euclidian distance between two points.
@@ -75,11 +75,11 @@ class Hirshfeld(Stockholder):
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float
     ):
-        return super(Hirshfeld, self)._read_proatom(directory, atom_num, charge)
+        return super()._read_proatom(directory, atom_num, charge)
 
     def calculate(self):
         """Calculate Hirshfeld charges."""
-        super(Hirshfeld, self).calculate()
+        super().calculate()
 
         # Generator object to iterate over the grid.
         ngridx, ngridy, ngridz = self.charge_density.data.shape

--- a/cclib/method/lpa.py
+++ b/cclib/method/lpa.py
@@ -17,9 +17,7 @@ from cclib.method.population import Population
 class LPA(Population):
     """The Löwdin population analysis"""
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(LPA, self).__init__(logname="LPA", *args)
+        super().__init__(logname="LPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -90,7 +88,7 @@ class LPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(LPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/mbo.py
+++ b/cclib/method/mbo.py
@@ -18,9 +18,7 @@ class MBO(Density):
     """Mayer's bond orders"""
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(MBO, self).__init__(logname="MBO", *args)
+        super().__init__(logname="MBO", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -33,7 +31,7 @@ class MBO(Density):
     def calculate(self, indices=None, fupdate=0.05):
         """Calculate Mayer's bond orders."""
 
-        retval = super(MBO, self).calculate(fupdate)
+        retval = super().calculate(fupdate)
         if not retval: #making density didn't work
             return False
 

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -23,10 +23,9 @@ class Moments(Method):
     dictionary whose keys denote the used charge population scheme.
     """
     def __init__(self, data):
+        super().__init__(data)
         self.required_attrs = ('atomcoords', 'atomcharges')
         self.results = {}
-
-        super(Moments, self).__init__(data)
 
     def __str__(self):
         """Returns a string representation of the object."""

--- a/cclib/method/mpa.py
+++ b/cclib/method/mpa.py
@@ -18,9 +18,7 @@ class MPA(Population):
     """Mulliken population analysis."""
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(MPA, self).__init__(logname="MPA", *args)
+        super().__init__(logname="MPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""
@@ -81,7 +79,7 @@ class MPA(Population):
         if self.progress:
             self.progress.update(nstep, "Done")
 
-        retval = super(MPA, self).partition(indices)
+        retval = super().partition(indices)
 
         if not retval:
             self.logger.error("Error in partitioning results")

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -65,10 +65,8 @@ class Nuclear(Method):
     """A container for methods pertaining to atomic nuclei."""
 
     def __init__(self, data, progress=None, loglevel=logging.INFO, logname="Log"):
-
+        super().__init__(data, progress, loglevel, logname)
         self.required_attrs = ('natom','atomcoords','atomnos','charge')
-
-        super(Nuclear, self).__init__(data, progress, loglevel, logname)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -26,9 +26,7 @@ class OPA(Population):
     """Overlap population analysis."""
 
     def __init__(self, *args):
-
-        # Call the __init__ method of the superclass.
-        super(OPA, self).__init__(logname="OPA", *args)
+        super().__init__(logname="OPA", *args)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/method/orbitals.py
+++ b/cclib/method/orbitals.py
@@ -24,10 +24,8 @@ class Orbitals(Method):
 
     def __init__(self, data, progress=None, \
                  loglevel=logging.INFO, logname="Log"):
-
+        super().__init__(data, progress, loglevel, logname)
         self.required_attrs = ('mocoeffs','moenergies','homos')
-        # Call the __init__ method of the superclass.
-        super(Orbitals, self).__init__(data, progress, loglevel, logname)
         self.fragresults = None
 
     def __str__(self):

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -25,7 +25,7 @@ class Population(Method):
 
     def __init__(self, data, progress=None, \
                  loglevel=logging.INFO, logname="Log"):
-        super(Population, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.fragresults = None
 
@@ -38,7 +38,7 @@ class Population(Method):
         return "Population"
 
     def _check_required_attributes(self):
-        super(Population, self)._check_required_attributes()
+        super()._check_required_attributes()
         
         if self.overlap_attributes and not any(hasattr(self.data, a) for a in self.overlap_attributes):
             raise MissingAttributeError(

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -48,7 +48,7 @@ class Stockholder(Method):
                 proatom_path -- path to proatom densities
                 (directory containing atoms.h5 in horton or c2_001_001_000_400_075.txt in chargemol)
         """
-        super(Stockholder, self).__init__(data, progress, loglevel, logname)
+        super().__init__(data, progress, loglevel, logname)
 
         self.volume = volume
         self.proatom_path = proatom_path
@@ -75,7 +75,7 @@ class Stockholder(Method):
         return "Stockholder"
 
     def _check_required_attributes(self):
-        super(Stockholder, self)._check_required_attributes()
+        super()._check_required_attributes()
 
     def _read_proatom(
         self, directory, atom_num, charge  # type = str  # type = int  # type = float

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -20,9 +20,7 @@ class ADF(logfileparser.Logfile):
     """An ADF log file"""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(ADF, self).__init__(logname="ADF", *args, **kwargs)
+        super().__init__(logname="ADF", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -20,9 +20,7 @@ class DALTON(logfileparser.Logfile):
     """A DALTON log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(DALTON, self).__init__(logname="DALTON", *args, **kwargs)
+        super().__init__(logname="DALTON", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -419,12 +419,11 @@ class ccData_optdone_bool(ccData):
     """This is the version of ccData where optdone is a Boolean."""
 
     def __init__(self, *args, **kwargs):
-
-        super(ccData_optdone_bool, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._attributes["optdone"] = Attribute(bool, 'done', 'optimization')
 
     def setattributes(self, *args, **kwargs):
-        invalid = super(ccData_optdone_bool, self).setattributes(*args, **kwargs)
+        invalid = super().setattributes(*args, **kwargs)
 
         # Reduce optdone to a Boolean, because it will be parsed as a list. If this list has any element,
         # it means that there was an optimized structure and optdone should be True.

--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -60,9 +60,7 @@ class FChk(logfileparser.Logfile):
     """
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(FChk, self).__init__(logname="FChk", *args, **kwargs)
+        super().__init__(logname="FChk", *args, **kwargs)
         self.start = True
 
     def __str__(self):

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -46,9 +46,7 @@ class GAMESS(logfileparser.Logfile):
             'ACC6C': 'aug-cc-pCV6Z'}
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(GAMESS, self).__init__(logname="GAMESS", *args, **kwargs)
+        super().__init__(logname="GAMESS", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -21,9 +21,7 @@ class GAMESSUK(logfileparser.Logfile):
     SCFRMS, SCFMAX, SCFENERGY = list(range(3))  # Used to index self.scftargets[]
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(GAMESSUK, self).__init__(logname="GAMESSUK", *args, **kwargs)
+        super().__init__(logname="GAMESSUK", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -21,9 +21,7 @@ class Gaussian(logfileparser.Logfile):
     """A Gaussian 98/03 log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(Gaussian, self).__init__(logname="Gaussian", *args, **kwargs)
+        super().__init__(logname="Gaussian", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -20,9 +20,7 @@ class Jaguar(logfileparser.Logfile):
     """A Jaguar output file"""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(Jaguar, self).__init__(logname="Jaguar", *args, **kwargs)
+        super().__init__(logname="Jaguar", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -20,9 +20,7 @@ class Molcas(logfileparser.Logfile):
     """A Molcas log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(Molcas, self).__init__(logname="Molcas", *args, **kwargs)
+        super().__init__(logname="Molcas", *args, **kwargs)
 
     def __str__(self):
         """Return a string repeesentation of the object."""

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -53,8 +53,7 @@ class Molpro(logfileparser.Logfile):
     atomic_orbital_names = create_atomic_orbital_names(['D', 'F', 'G'])
 
     def __init__(self, *args, **kwargs):
-        # Call the __init__ method of the superclass
-        super(Molpro, self).__init__(logname="Molpro", *args, **kwargs)
+        super().__init__(logname="Molpro", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -31,9 +31,7 @@ class MOPAC(logfileparser.Logfile):
     """A MOPAC20XX output file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(MOPAC, self).__init__(logname="MOPAC", *args, **kwargs)
+        super().__init__(logname="MOPAC", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -21,9 +21,7 @@ class NWChem(logfileparser.Logfile):
     """An NWChem log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(NWChem, self).__init__(logname="NWChem", *args, **kwargs)
+        super().__init__(logname="NWChem", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -22,9 +22,7 @@ class ORCA(logfileparser.Logfile):
     """An ORCA log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(ORCA, self).__init__(logname="ORCA", *args, **kwargs)
+        super().__init__(logname="ORCA", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -17,9 +17,7 @@ class Psi3(logfileparser.Logfile):
     """A Psi3 log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(Psi3, self).__init__(logname="Psi3", *args, **kwargs)
+        super().__init__(logname="Psi3", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -20,9 +20,7 @@ class Psi4(logfileparser.Logfile):
     """A Psi4 log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(Psi4, self).__init__(logname="Psi4", *args, **kwargs)
+        super().__init__(logname="Psi4", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -23,9 +23,7 @@ class QChem(logfileparser.Logfile):
     """A Q-Chem log file."""
 
     def __init__(self, *args, **kwargs):
-
-        # Call the __init__ method of the superclass
-        super(QChem, self).__init__(logname="QChem", *args, **kwargs)
+        super().__init__(logname="QChem", *args, **kwargs)
 
     def __str__(self):
         """Return a string representation of the object."""

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -49,7 +49,7 @@ class Turbomole(logfileparser.Logfile):
     """A Turbomole log file."""
 
     def __init__(self, *args, **kwargs):
-        super(Turbomole, self).__init__(logname="Turbomole", *args, **kwargs)
+        super().__init__(logname="Turbomole", *args, **kwargs)
         
         # Flag for whether this calc is DFT.
         self.is_DFT = False
@@ -1311,8 +1311,7 @@ class OldTurbomole(logfileparser.Logfile):
     """A Turbomole output file. Code is outdated and is not being used."""
 
     def __init__(self, *args):
-        # Call the __init__ method of the superclass
-        super(Turbomole, self).__init__(logname="Turbomole", *args)
+        super().__init__(logname="Turbomole", *args)
         
     def __str__(self):
         """Return a string representation of the object."""


### PR DESCRIPTION
https://docs.python.org/3/library/functions.html#super

This makes things look a little cleaner.

There are two `super(...)` calls in `logfileparser.py` for the bz2 and gzip wrappers that are slightly different, and I'm not sure how the inheritance works in those cases, so if they can also be modified, I'll do them in another PR.