### PR TITLE
introducing carryforward flags

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,14 +13,6 @@ coverage:
         flags:
           - unit
 
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false  
-  require_base: yes
-  require_head: yes       
-  branches: null
-
 flags:
   method:
     paths:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,34 @@
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+      method:
+        target: auto
+        flags:
+          - method
+      unit:
+        target: auto
+        flags:
+          - unit
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  
+  require_base: yes
+  require_head: yes       
+  branches: null
+
+flags:
+  method:
+    paths:
+      - cclib/method/
+    carryforward: true
+  unit:
+    paths:
+      - cclib/io/
+      - cclib/parser/
+      - cclib/bridge/
+    carryforward: true

--- a/.github/scripts/run_pytest_methods.bash
+++ b/.github/scripts/run_pytest_methods.bash
@@ -5,4 +5,4 @@
 
 set -euxo pipefail
 
-python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-unit.xml --terse test -k "test_method"
+python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-method.xml --terse test -k "test_method"

--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
-          files: ./coverage-unit.xml,./coverage-regression.xml
+          files: ./coverage-unit.xml,./coverage-regression.xml,./coverage-method.xml
           name: codecov-cclib
           fail_ci_if_error: true
           verbose: false

--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           env | sort
           bash .github/scripts/run_pytest.bash
-      - name: Test method code with pytest
-        if: steps.filter.outputs.method == 'true' 
+      - name: Test methods with pytest
+        if: steps.filter.outputs.methods == 'false'
         run: |
           bash .github/scripts/run_pytest_methods.bash
       - name: Upload coverage to Codecov


### PR DESCRIPTION
This will introduce carry forward flags to allow conditional testing work well with codecov.  

Since we can create a separate reports methods,  the carry forward flags will let us pull an old report if a new report isn't generated.  More documentation can be found here: https://docs.codecov.com/docs/carryforward-flags

This commit isn't incorporating the filtering yet, but just the flags to enable it. One more commit will be needed in which `.github/workflows/cclib_pytest.yml` will change what reports are uploaded.