### PR TITLE
FChk: fix units for parsing MO energies

### DIFF
--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -149,7 +149,7 @@ class FChk(logfileparser.Logfile):
             assert count == self.nmo
 
             energies = numpy.array(self._parse_block(inputfile, count, float, 'Alpha MO Energies'))
-            self.set_attribute('moenergies', [energies])
+            self.set_attribute('moenergies', [utils.convertor(energies, 'hartree', 'eV')])
 
         if line[0:20] == 'Beta MO coefficients':
             count = int(line.split()[-1])
@@ -164,7 +164,7 @@ class FChk(logfileparser.Logfile):
             assert count == self.nmo
 
             energies = numpy.array(self._parse_block(inputfile, count, float, 'Alpha MO Energies'))
-            self.append_attribute('moenergies', energies)
+            self.append_attribute('moenergies', utils.convertor(energies, 'hartree', 'eV'))
 
         if line[0:11] == 'Shell types':
             self.parse_aonames(line, inputfile)

--- a/test/regression.py
+++ b/test/regression.py
@@ -2843,6 +2843,10 @@ class ADFSPTest_nosyms_valence_noscfvalues(ADFSPTest_nosyms_valence):
     def testscfvaluetype(self):
         """SCF cycles were not printed here."""
 
+    @unittest.skip('Cannot parse moenergies from this file.')
+    def testfirstmoenergy(self):
+        """MO energies were not printed here."""
+
     @unittest.skip('Cannot parse aooverlaps from this file.')
     def testaooverlaps(self):
         """AO overlaps were not printed here."""
@@ -2880,6 +2884,10 @@ class DALTONSPTest_nosymmetry(GenericSPTest):
     def testmetadata_symmetry_used(self):
         """Does metadata have expected keys and values?"""
         self.assertEqual(self.data.metadata["symmetry_used"], "c1")
+
+
+class DALTONHFSPTest_nosymmetry(DALTONSPTest_nosymmetry, GenericHFSPTest):
+    pass
 
 
 class DALTONTDTest_noetsecs(DALTONTDTest):
@@ -2960,6 +2968,7 @@ class JaguarSPTest_6_31gss(JaguarSPTest):
     """AO counts and some values are different in 6-31G** compared to STO-3G."""
     nbasisdict = {1: 5, 6: 15}
     b3lyp_energy = -10530
+    b3lyp_moenergy = -277.610006052399
     overlap01 = 0.22
 
     def testmetadata_basis_set(self):
@@ -3088,9 +3097,10 @@ class MolproBigBasisTest_cart(MolproBigBasisTest):
 # ORCA #
 
 
-class OrcaSPTest_3_21g(OrcaSPTest, GenericSPTest):
+class OrcaSPTest_3_21g(OrcaSPTest):
     nbasisdict = {1: 2, 6: 9}
     b3lyp_energy = -10460
+    b3lyp_moenergy = -276.1556935784018
     overlap01 = 0.19
     molecularmass = 130190
     @unittest.skip('This calculation has no symmetry.')
@@ -3193,6 +3203,13 @@ class PsiSPTest_noatommasses(PsiSPTest):
         """These values are not present in this output file."""
 
 
+class PsiHFSPTest_noatommasses(PsiHFSPTest):
+
+    @unittest.skip('atommasses were not printed in this file.')
+    def testatommasses(self):
+        """These values are not present in this output file."""
+
+
 old_unittests = {
 
     "ADF/ADF2004.01/MoOCl4-sp.adfout":      ADFCoreTest,
@@ -3212,7 +3229,7 @@ old_unittests = {
 
     "DALTON/DALTON-2013/C_bigbasis.aug-cc-pCVQZ.out":       DALTONBigBasisTest_aug_cc_pCVQZ,
     "DALTON/DALTON-2013/b3lyp_energy_dvb_sp_nosym.out":     DALTONSPTest_nosymmetry,
-    "DALTON/DALTON-2013/dvb_sp_hf_nosym.out":               DALTONSPTest_nosymmetry,
+    "DALTON/DALTON-2013/dvb_sp_hf_nosym.out":               DALTONHFSPTest_nosymmetry,
     "DALTON/DALTON-2013/dvb_td_normalprint.out":            DALTONTDTest_noetsecs,
     "DALTON/DALTON-2013/sp_b3lyp_dvb.out":                  GenericSPTest,
     "DALTON/DALTON-2015/dvb_td_normalprint.out":            DALTONTDTest_noetsecs,
@@ -3267,7 +3284,7 @@ old_unittests = {
     "GAMESS/PCGAMESS/dvb_gopt_b.out":       GenericGeoOptTest,
     "GAMESS/PCGAMESS/dvb_ir.out":           FireflyIRTest,
     "GAMESS/PCGAMESS/dvb_raman.out":        GenericRamanTest,
-    "GAMESS/PCGAMESS/dvb_sp.out":           GenericSPTest,
+    "GAMESS/PCGAMESS/dvb_sp.out":           GenericHFSPTest,
     "GAMESS/PCGAMESS/dvb_td.out":           GenericTDTest,
     "GAMESS/PCGAMESS/dvb_td_trplet.out":    GenericTDDFTtrpTest,
     "GAMESS/PCGAMESS/dvb_un_sp.out":        GenericSPunTest,
@@ -3387,7 +3404,7 @@ old_unittests = {
     "Psi4/Psi4-1.0/dvb_gopt_rhf.out":   Psi4GeoOptTest,
     "Psi4/Psi4-1.0/dvb_gopt_rks.out":   Psi4GeoOptTest,
     "Psi4/Psi4-1.0/dvb_ir_rhf.out":     Psi4IRTest,
-    "Psi4/Psi4-1.0/dvb_sp_rhf.out":     PsiSPTest_noatommasses,
+    "Psi4/Psi4-1.0/dvb_sp_rhf.out":     PsiHFSPTest_noatommasses,
     "Psi4/Psi4-1.0/dvb_sp_rks.out":     PsiSPTest_noatommasses,
     "Psi4/Psi4-1.0/dvb_sp_rohf.out":    GenericROSPTest,
     "Psi4/Psi4-1.0/dvb_sp_uhf.out":     GenericSPunTest,
@@ -3398,7 +3415,7 @@ old_unittests = {
     "Psi4/Psi4-beta5/C_bigbasis.out":   GenericBigBasisTest,
     "Psi4/Psi4-beta5/dvb_gopt_hf.out":  Psi4GeoOptTest,
     "Psi4/Psi4-beta5/dvb_sp_hf.out":    GenericBasisTest,
-    "Psi4/Psi4-beta5/dvb_sp_hf.out":    PsiSPTest_noatommasses,
+    "Psi4/Psi4-beta5/dvb_sp_hf.out":    PsiHFSPTest_noatommasses,
     "Psi4/Psi4-beta5/dvb_sp_ks.out":    GenericBasisTest,
     "Psi4/Psi4-beta5/dvb_sp_ks.out":    PsiSPTest_noatommasses,
     "Psi4/Psi4-beta5/water_ccsd.out":   GenericCCTest,

--- a/test/testdata
+++ b/test/testdata
@@ -252,42 +252,42 @@ Scan      ORCA         GenericUnrelaxedScanTest              basicORCA5.0       
 
 SP        ADF         ADFSPTest             basicADF2007.01             dvb_sp_b.adfout
 SP        ADF         ADFSPTest             basicADF2013.01             dvb_sp_b.adfout
-SP        DALTON      GenericSPTest         basicDALTON-2013            dvb_sp_hf.out
+SP        DALTON      GenericHFSPTest       basicDALTON-2013            dvb_sp_hf.out
 SP        DALTON      GenericSPTest         basicDALTON-2013            dvb_sp_ks.out
-SP        DALTON      GenericSPTest         basicDALTON-2015            dvb_sp_hf.out
+SP        DALTON      GenericHFSPTest       basicDALTON-2015            dvb_sp_hf.out
 SP        DALTON      GenericSPTest         basicDALTON-2015            dvb_sp_ks.out
 SP        FChk        GenericSPTest         basicQChem5.2               dvb_sp_modified.FChk
 SP        GAMESSUK    GenericSPTest         basicGAMESS-UK7.0           dvb_sp_b.out
-SP        GAMESSUK    GenericSPTest         basicGAMESS-UK8.0           dvb_sp_hf.out
+SP        GAMESSUK    GenericHFSPTest       basicGAMESS-UK8.0           dvb_sp_hf.out
 SP        GAMESSUK    GenericSPTest         basicGAMESS-UK8.0           dvb_sp_ks.out
-SP        GAMESS      GenericSPTest         basicFirefly8.0             dvb_sp.out
+SP        GAMESS      GenericHFSPTest       basicFirefly8.0             dvb_sp.out
 SP        GAMESS      GenericSPTest         basicGAMESS-US2017          dvb_sp.out
 SP        GAMESS      GenericSPTest         basicGAMESS-US2018          dvb_sp.out
 SP        Gaussian    GaussianSPTest        basicGaussian09             dvb_sp.out
 SP        Gaussian    GaussianSPTest        basicGaussian16             dvb_sp.out
 SP        Gaussian    GaussianSPTest        basicGaussian16             dvb_sp_no.out
 SP        Jaguar      Jaguar7SPTest         basicJaguar7.0              dvb_sp.out
-SP        Jaguar      JaguarSPTest          basicJaguar8.3              dvb_sp_hf.out
+SP        Jaguar      JaguarHFSPTest        basicJaguar8.3              dvb_sp_hf.out
 SP        Jaguar      JaguarSPTest          basicJaguar8.3              dvb_sp_ks.out
 SP        Molcas      MolcasSPTest          basicOpenMolcas18.0         dvb_sp.out
 SP        Molpro      MolproSPTest          basicMolpro2006             dvb_sphf.out
 SP        Molpro      MolproSPTest          basicMolpro2012             dvb_sphf.out
-SP        NWChem      GenericSPTest         basicNWChem6.0              dvb_sp_hf.out
+SP        NWChem      GenericHFSPTest       basicNWChem6.0              dvb_sp_hf.out
 SP        NWChem      NWChemKSSPTest        basicNWChem6.0              dvb_sp_ks.out
-SP        NWChem      GenericSPTest         basicNWChem6.5              dvb_sp_hf.out
+SP        NWChem      GenericHFSPTest       basicNWChem6.5              dvb_sp_hf.out
 SP        NWChem      NWChemKSSPTest        basicNWChem6.5              dvb_sp_ks.out
 SP        ORCA        OrcaSPTest            basicORCA4.1                dvb_sp.out
 SP        ORCA        OrcaSPTest            basicORCA4.2                dvb_sp.out
 SP        ORCA        OrcaSPTest            basicORCA5.0                dvb_sp.out
 SP        Psi3        Psi3SPTest            basicPsi3                   dvb_sp_hf.out
-SP        Psi4        PsiSPTest             basicPsi4-1.2.1             dvb_sp_rhf.out
+SP        Psi4        PsiHFSPTest           basicPsi4-1.2.1             dvb_sp_rhf.out
 SP        Psi4        PsiSPTest             basicPsi4-1.2.1             dvb_sp_rks.out
-SP        Psi4        PsiSPTest             basicPsi4-1.3.1             dvb_sp_rhf.out
+SP        Psi4        PsiHFSPTest           basicPsi4-1.3.1             dvb_sp_rhf.out
 SP        Psi4        PsiSPTest             basicPsi4-1.3.1             dvb_sp_rks.out
 SP        QChem       GenericSPTest         basicQChem5.1               dvb_sp.out
 SP        QChem       GenericSPTest         basicQChem5.4               dvb_sp.out
 SP        Turbomole   TurbomoleSPTest       basicTurbomole5.9           dvb_sp_symm/mos       dvb_sp_symm/basis      dvb_sp_symm/control      dvb_sp_symm/dscf.out      dvb_sp_symm/coord
-SP        Turbomole   TurbomoleSPTest       basicTurbomole7.5           dvb_sp/basis      dvb_sp/control      dvb_sp/mos      dvb_sp/dscf.out      dvb_sp/coord
+SP        Turbomole   TurbomoleHFSPTest     basicTurbomole7.5           dvb_sp/basis      dvb_sp/control      dvb_sp/mos      dvb_sp/dscf.out      dvb_sp/coord
 SP        DALTON      GenericDispersionTest basicDALTON-2018            dvb_dispersion_bp86_d3zero.out
 SP        GAMESS      FireflyDispersionTest basicFirefly8.1             dvb_dispersion_bp86_d3zero.out
 SP        GAMESS      GenericDispersionTest basicGAMESS-US2018          dvb_dispersion_bp86_d3zero.out


### PR DESCRIPTION
Closes #1068. This also tests for the energy of the first molecular orbital, which would have caught this.