### PR TITLE
Use f-strings instead of format

### DIFF
--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -77,7 +77,7 @@ def readfile(fname, format):
         obc.ReadFile(mol, fname)
         return makecclib(mol)
     else:
-        print("Unable to load the %s reader from OpenBabel." % format)
+        print(f"Unable to load the {format} reader from OpenBabel.")
         return {}
 
 

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -36,7 +36,7 @@ def makepyquante(data):
     if missing:
         missing = " ".join(missing)
         raise MissingAttributeError(
-            "Could not create pyquante molecule due to missing attribute: {}".format(missing)
+            f"Could not create pyquante molecule due to missing attribute: {missing}"
         )
 
     # In pyquante2, molecular geometry is specified in a format of:

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -35,12 +35,11 @@ def makepyscf(data, charge=0, mult=1):
     if missing:
         missing = " ".join(missing)
         raise MissingAttributeError(
-            "Could not create pyscf molecule due to missing attribute: {}".format(missing)
+            f"Could not create pyscf molecule due to missing attribute: {missing}"
         )
     mol = gto.Mole(
         atom=[
-            ["{}".format(data.atomnos[i]), data.atomcoords[-1][i]]
-            for i in range(data.natom)
+            [f"{data.atomnos[i]}", data.atomcoords[-1][i]] for i in range(data.natom)
         ],
         unit="Angstrom",
         charge=charge,
@@ -58,12 +57,12 @@ def makepyscf(data, charge=0, mult=1):
             for jdx, j in enumerate(curr_atom_basis):
                 curr_l = j[0]
                 curr_e_prim = j[1]
-                new_list = [l_sym2num["{}".format(curr_l)]]
+                new_list = [l_sym2num[f"{curr_l}"]]
                 new_list += curr_e_prim
-                if not "{}".format(pt.element[uatoms[idx]]) in basis:
-                    basis["{}".format(pt.element[uatoms[idx]])] = [new_list]
+                if not f"{pt.element[uatoms[idx]]}" in basis:
+                    basis[f"{pt.element[uatoms[idx]]}"] = [new_list]
                 else:
-                    basis["{}".format(pt.element[uatoms[idx]])].append(new_list)
+                    basis[f"{pt.element[uatoms[idx]]}"].append(new_list)
         mol.basis = basis
         mol.cart = True
     return mol

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -160,8 +160,8 @@ def ccread(source, *args, **kwargs):
 
     log = ccopen(source, *args, **kwargs)
     if log:
-        if kwargs.get('verbose', None):
-            print('Identified logfile to be in %s format' % log.logname)
+        if kwargs.get("verbose", None):
+            print(f"Identified logfile to be in {log.logname} format")
         # If the input file is a CJSON file and not a standard compchemlog file
         cjson_as_input = kwargs.get("cjson", False)
         if cjson_as_input:
@@ -477,7 +477,7 @@ def sort_turbomole_outputs(filelist):
             # Calling 'jobex -keep' will also write job.n files, where n ranges from 0 to inf.
             # Numbered job files are inserted before job.last.
             job_number = int(filename[4:]) +1
-            job_order = float("{}.{}".format(sorting_order['job.last'] -1, job_number))
+            job_order = float(f"{sorting_order['job.last'] - 1}.{job_number}")
             known_files.append([fname, job_order])
         else:
             unknown_files.append(fname)

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -47,11 +47,11 @@ class CML(filewriter.Writer):
                 atom = ET.SubElement(atomArray, 'atom')
                 x, y, z = self.ccdata.atomcoords[-1][atomid].tolist()
                 d = {
-                    'id': 'a{}'.format(atomid + 1),
-                    'elementType': elements[atomid],
-                    'x3': '{:.10f}'.format(x),
-                    'y3': '{:.10f}'.format(y),
-                    'z3': '{:.10f}'.format(z),
+                    "id": f"a{atomid + 1}",
+                    "elementType": elements[atomid],
+                    "x3": f"{x:.10f}",
+                    "y3": f"{y:.10f}",
+                    "z3": f"{z:.10f}",
                 }
                 _set_attrs(atom, d)
 
@@ -59,11 +59,8 @@ class CML(filewriter.Writer):
         bondArray = ET.SubElement(molecule, 'bondArray')
         if _has_openbabel:
             for bc in self.bond_connectivities:
-                bond = ET.SubElement(bondArray, 'bond')
-                d = {
-                    'atomRefs2': 'a{} a{}'.format(bc[0] + 1, bc[1] + 1),
-                    'order': str(bc[2]),
-                }
+                bond = ET.SubElement(bondArray, "bond")
+                d = {"atomRefs2": f"a{bc[0] + 1} a{bc[1] + 1}", "order": str(bc[2])}
                 _set_attrs(bond, d)
 
         _indent(molecule)
@@ -82,10 +79,10 @@ def _set_attrs(element, d):
 
 def _indent(elem, level=0):
     """An in-place pretty-print indenter for XML."""
-    i = "\n" + (level * "  ")
+    i = f"\n{level * '  '}"
     if len(elem):
         if not elem.text or not elem.text.strip():
-            elem.text = i + "  "
+            elem.text = f"{i}  "
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for elem in elem:

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -86,7 +86,7 @@ class Writer(ABC):
         if missing:
             missing = ' '.join(missing)
             raise MissingAttributeError(
-                'Could not parse required attributes to write file: ' + missing)
+                f"Could not parse required attributes to write file: {missing}")
 
     def _make_openbabel_from_ccdata(self):
         """Create Open Babel and Pybel molecules from ccData."""

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -47,21 +47,20 @@ class MOLDEN(filewriter.Writer):
         if self.ghost is not None:
             elements = [self.ghost if e is None else e for e in elements]
         elif None in elements:
-            raise ValueError('It seems that there is at least one ghost atom ' +
-                             'in these elements. Please use the ghost flag to'+
-                             ' specify a label for the ghost atoms.')
+            raise ValueError(
+                f"It seems that there is at least one ghost atom in these elements. Please use the ghost flag to specify a label for the ghost atoms."
+            )
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos
         nos = range(self.ccdata.natom)
 
         # element_name number atomic_number x y z
-        atom_template = '{:2s} {:5d} {:2d} {:12.6f} {:12.6f} {:12.6f}'
+        atom_template = "{:2s} {:5d} {:2d} {:12.6f} {:12.6f} {:12.6f}"
         lines = []
         for element, no, atomno, coord in zip(elements, nos, atomnos,
                                               atomcoords):
             x, y, z = map(round_molden, coord)
-            lines.append(atom_template.format(element, no + 1, atomno,
-                                              x, y, z))
+            lines.append(atom_template.format(element, no + 1, atomno, x, y, z))
 
         return lines
 
@@ -77,12 +76,12 @@ class MOLDEN(filewriter.Writer):
         """
 
         gbasis = self.ccdata.gbasis
-        label_template = '{:s} {:5d} 1.00'
-        basis_template = '{:15.9e} {:15.9e}'
+        label_template = "{:s} {:5d} 1.00"
+        basis_template = "{:15.9e} {:15.9e}"
         lines = []
 
         for no, basis in enumerate(gbasis):
-            lines.append('{:3d} 0'.format(no + 1))
+            lines.append(f"{no + 1:3d} 0")
             for prims in basis:
                 lines.append(label_template.format(prims[0].lower(),
                                                    len(prims[1])))
@@ -102,10 +101,10 @@ class MOLDEN(filewriter.Writer):
            -673.590571
         """
 
-        lines = ["scf-first    1 THROUGH   %d" % len(self.ccdata.scfenergies)]
+        lines = [f"scf-first    1 THROUGH   {len(self.ccdata.scfenergies)}"]
 
         for scfenergy in self.ccdata.scfenergies:
-            lines.append('{:15.6f}'.format(scfenergy))
+            lines.append(f"{scfenergy:15.6f}")
 
         return lines
 
@@ -169,30 +168,30 @@ class MOLDEN(filewriter.Writer):
         spin = 'Alpha'
         for i in range(len(moenergies)):
             for j in range(len(moenergies[i])):
-                lines.append(' Sym= %s' % syms[i][j])
-                moenergy = utils.convertor(moenergies[i][j], 'eV', 'hartree')
-                lines.append(' Ene= {:10.4f}'.format(moenergy))
-                lines.append(' Spin= %s' % spin)
-                if unres and openshell: 
+                lines.append(f" Sym= {syms[i][j]}")
+                moenergy = utils.convertor(moenergies[i][j], "eV", "hartree")
+                lines.append(f" Ene= {moenergy:10.4f}")
+                lines.append(f" Spin= {spin}")
+                if unres and openshell:
                     if j <= homos[i]:
-                        lines.append(' Occup= {:10.6f}'.format(1.0))
+                        lines.append(f" Occup= {1.0:10.6f}")
                     else:
-                        lines.append(' Occup= {:10.6f}'.format(0.0))
+                        lines.append(f" Occup= {0.0:10.6f}")
                 elif not unres and openshell:
                     occ = numpy.sum(j <= homos)
                     if j <= homos[i]:
-                        lines.append(' Occup= {:10.6f}'.format(occ))
+                        lines.append(f" Occup= {occ:10.6f}")
                     else:
-                        lines.append(' Occup= {:10.6f}'.format(0.0))
+                        lines.append(f" Occup= {0.0:10.6f}")
                 else:
                     if j <= homos[i]:
-                        lines.append(' Occup= {:10.6f}'.format(2.0))
+                        lines.append(f" Occup= {2.0:10.6f}")
                     else:
-                        lines.append(' Occup= {:10.6f}'.format(0.0))
+                        lines.append(f" Occup= {0.0:10.6f}")
                 # Rearrange mocoeffs according to Molden's lexicographical order.
                 mocoeffs[i][j] = self._rearrange_mocoeffs(mocoeffs[i][j])
                 for k, mocoeff in enumerate(mocoeffs[i][j]):
-                    lines.append('{:4d}  {:10.6f}'.format(k + 1, mocoeff))
+                    lines.append(f"{k + 1:4d}  {mocoeff:10.6f}")
 
             spin = 'Beta'
 
@@ -211,7 +210,7 @@ class MOLDEN(filewriter.Writer):
         # Coordinates for the Electron Density/Molecular orbitals.
         # [Atoms] (Angs|AU)
         unit = "Angs"
-        molden_lines.append('[Atoms] %s' % unit)
+        molden_lines.append(f"[Atoms] {unit}")
         # Last set of coordinates for geometry optimization runs.
         index = -1
         molden_lines.extend(self._coords_from_ccdata(index))
@@ -248,8 +247,8 @@ class MoldenReformatter:
         """Convert Molden style number formatting to scientific notation.
         0.9910616900D+02 --> 9.910617e+01
         """
-        num = num.replace('D', 'e')
-        return str('%.9e' % decimal.Decimal(num))
+        num = num.replace("D", "e")
+        return str(f"{decimal.Decimal(num):.9e}")
 
     def reformat(self):
         """Reformat Molden output file to:
@@ -289,15 +288,17 @@ class MoldenReformatter:
             # Convert sp to s and p orbitals.
             elif 'sp' in line:
                 n_prim = int(line.split()[1])
-                new_s = ['s ' + str(n_prim) + ' 1.00']
-                new_p = ['p ' + str(n_prim) + ' 1.00']
+                new_s = [f"s {str(n_prim)} 1.00"]
+                new_p = [f"p {str(n_prim)} 1.00"]
                 while n_prim > 0:
                     n_prim -= 1
                     line = next(filelines).split()
-                    new_s.append(self.scinotation(line[0]) + ' '
-                                 + self.scinotation(line[1]))
-                    new_p.append(self.scinotation(line[0]) + ' '
-                                 + self.scinotation(line[2]))
+                    new_s.append(
+                        f"{self.scinotation(line[0])} {self.scinotation(line[1])}"
+                    )
+                    new_p.append(
+                        f"{self.scinotation(line[0])} {self.scinotation(line[2])}"
+                    )
                 lines.extend(new_s)
                 lines.extend(new_p)
             else:

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -88,15 +88,15 @@ class XYZ(filewriter.Writer):
         else:
             geometry_num = index + 1
         if self.jobfilename is not None:
-            comment = "{}: Geometry {}".format(self.jobfilename, geometry_num)
+            comment = f"{self.jobfilename}: Geometry {geometry_num}"
         else:
-            comment = "Geometry {}".format(geometry_num)
+            comment = f"Geometry {geometry_num}"
         # Wrap the geometry number part of the comment in square brackets,
         # prefixing it with one previously parsed if it existed.
         if existing_comment:
-            comment = "{} [{}]".format(existing_comment, comment)
+            comment = f"{existing_comment} [{comment}]"
         else:
-            comment = "[{}]".format(comment)
+            comment = f"[{comment}]"
 
         atom_template = '{:3s} {:15.10f} {:15.10f} {:15.10f}'
         block = []

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -58,11 +58,11 @@ class Bader(Method):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Bader's QTAIM charges of {}".format(self.data)
+        return f"Bader's QTAIM charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Bader({})".format(self.data)
+        return f"Bader({self.data})"
 
     def _check_required_attributes(self):
         super()._check_required_attributes()
@@ -201,9 +201,7 @@ class Bader(Method):
 
         assert (
             0 not in self.matches
-        ), "Failed to assign Bader regions to atoms. Try with a finer grid. Content of Bader area matches: {}".format(
-            self.matches
-        )
+        ), f"Failed to assign Bader regions to atoms. Try with a finer grid. Content of Bader area matches: {self.matches}"
         assert len(
             numpy.unique(self.matches) != len(self.data.atomnos)
         ), "Failed to assign unique Bader regions to each atom. Try with a finer grid."

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -22,11 +22,11 @@ class Bickelhaupt(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Bickelhaupt charges of {}".format(self.data)
+        return f"Bickelhaupt charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Bickelhaupt({})".format(self.data)
+        return f"Bickelhaupt({self.data})"
 
     def calculate(self, indices=None, fupdate=0.05):
         """Perform a Bickelhaupt population analysis."""

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -44,7 +44,7 @@ class Method:
         self.loglevel = loglevel
         self.logname = logname
         self._check_required_attributes()
-        self.logger = logging.getLogger('%s %s' % (self.logname, self.data))
+        self.logger = logging.getLogger(f"{self.logname} {self.data}")
         self.logger.setLevel(self.loglevel)
         self.logformat = "[%(name)s %(levelname)s] %(message)s"
         handler = logging.StreamHandler(sys.stdout)
@@ -58,4 +58,5 @@ class Method:
         if missing:
             missing = ' '.join(missing)
             raise MissingAttributeError(
-                'Could not parse required attributes to use method: ' + missing)
+                f"Could not parse required attributes to use method: {missing}"
+            )

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -22,11 +22,11 @@ class CDA(FragmentAnalysis):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "CDA of %s" % (self.data)
+        return f"CDA of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'CDA("%s")' % (self.data)
+        return f'CDA("{self.data}")'
 
     def calculate(self, fragments, cupdate=0.05):
         """Perform the charge decomposition analysis.

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -25,11 +25,11 @@ class CSPA(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "CSPA of %s" % (self.data)
+        return f"CSPA of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'CSPA("%s")' % (self.data)
+        return f'CSPA("{self.data}")'
 
     def calculate(self, indices=None, fupdate=0.05):
         """Perform the C squared population analysis.

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -78,11 +78,11 @@ class DDEC6(Stockholder):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "DDEC6 charges of {}".format(self.data)
+        return f"DDEC6 charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "DDEC6({})".format(self.data)
+        return f"DDEC6({self.data})"
 
     def _check_required_attributes(self):
         super()._check_required_attributes()
@@ -107,9 +107,7 @@ class DDEC6(Stockholder):
         # Notify user about the total charge in the density grid
         integrated_density = self.charge_density.integrate()
         self.logger.info(
-            "Total charge density in the grid is {}. If this does not match what is expected, using a finer grid may help.".format(
-                integrated_density
-            )
+            f"Total charge density in the grid is {integrated_density}. If this does not match what is expected, using a finer grid may help."
         )
 
 
@@ -196,7 +194,7 @@ class DDEC6(Stockholder):
         steps = 5
         self._update_kappa = False
         while steps < 7:
-            self.logger.info("Optimizing grid weights. (Step {}/7)".format(steps))
+            self.logger.info(f"Optimizing grid weights. (Step {steps}/7)")
             self.N_A.append(self._calculate_w_and_u())
 
             # Determine whether kappa needs to be updated or not based on Figure S4.2

--- a/cclib/method/density.py
+++ b/cclib/method/density.py
@@ -23,11 +23,11 @@ class Density(Method):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Density matrix of %s" % (self.data)
+        return f"Density matrix of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Density matrix("%s")' % (self.data)
+        return f'Density matrix("{self.data}")'
 
     def calculate(self, fupdate=0.05):
         """Calculate the density matrix."""

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -25,11 +25,11 @@ class FragmentAnalysis(Method):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Fragment molecule basis of %s" % (self.data)
+        return f"Fragment molecule basis of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Fragment molecular basis("%s")' % (self.data)
+        return f'Fragment molecular basis("{self.data}")'
 
     def calculate(self, fragments, cupdate=0.05):
 
@@ -54,9 +54,9 @@ class FragmentAnalysis(Method):
             #assign fonames based on fragment name and MO number
             for i in range(fragments[j].nbasis):
                 if hasattr(fragments[j],"name"):
-                    self.fonames.append("%s_%i"%(fragments[j].name,i+1))
+                    self.fonames.append(f"{fragments[j].name}_{int(i + 1)}")
                 else:
-                    self.fonames.append("noname%i_%i"%(j,i+1))
+                    self.fonames.append(f"noname{int(j)}_{int(i + 1)}")
 
         nBasis = self.data.nbasis
         nAlpha = self.data.homos[0] + 1

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -56,11 +56,11 @@ class Hirshfeld(Stockholder):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Hirshfeld charges of {}".format(self.data)
+        return f"Hirshfeld charges of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return "Hirshfeld({})".format(self.data)
+        return f"Hirshfeld({self.data})"
 
     def _check_required_attributes(self):
         super()._check_required_attributes()

--- a/cclib/method/lpa.py
+++ b/cclib/method/lpa.py
@@ -21,11 +21,11 @@ class LPA(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "LPA of %s" % (self.data)
+        return f"LPA of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'LPA("%s")' % (self.data)
+        return f'LPA("{self.data}")'
 
     def calculate(self, indices=None, x=0.5, fupdate=0.05):
         """Perform a calculation of Löwdin population analysis.

--- a/cclib/method/mbo.py
+++ b/cclib/method/mbo.py
@@ -22,11 +22,11 @@ class MBO(Density):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Mayer's bond order of %s" % (self.data)
+        return f"Mayer's bond order of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Mayer\'s bond order("%s")' % (self.data)
+        return f'Mayer\'s bond order("{self.data}")'
 
     def calculate(self, indices=None, fupdate=0.05):
         """Calculate Mayer's bond orders."""

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -29,11 +29,11 @@ class Moments(Method):
 
     def __str__(self):
         """Returns a string representation of the object."""
-        return "Multipole moments of %s" % (self.data)
+        return f"Multipole moments of {self.data}"
 
     def __repr__(self):
         """Returns a representation of the object."""
-        return 'Moments("%s")' % (self.data)
+        return f'Moments("{self.data}")'
 
     def _calculate_dipole(self, charges, coords, origin):
         """Calculate the dipole moment from the given atomic charges
@@ -129,7 +129,7 @@ class Moments(Method):
                     raise ValueError(msg, e)
             origin_pos = numpy.average(coords, weights=atommasses, axis=0)
         else:
-            raise ValueError("{} is invalid value for 'origin'".format(origin))
+            raise ValueError(f"{origin} is invalid value for 'origin'")
 
         dipole = self._calculate_dipole(charges, coords, origin_pos)
         quadrupole = self._calculate_quadrupole(charges, coords, origin_pos)

--- a/cclib/method/mpa.py
+++ b/cclib/method/mpa.py
@@ -22,11 +22,11 @@ class MPA(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "MPA of %s" % (self.data)
+        return f"MPA of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'MPA("%s")' % (self.data)
+        return f'MPA("{self.data}")'
 
     def calculate(self, indices=None, fupdate=0.05):
         """Perform a Mulliken population analysis."""

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -83,7 +83,7 @@ class Nuclear(Method):
         counts = {el: elements.count(el) for el in set(elements)}
 
         formula = ""
-        elcount = lambda el, c: "%s%i" % (el, c) if c > 1 else el
+        elcount = lambda el, c: f"{el}{int(c)}" if c > 1 else el
         if 'C' in elements:
             formula += elcount('C', counts['C'])
             counts.pop('C')
@@ -96,7 +96,7 @@ class Nuclear(Method):
         if getattr(self.data, 'charge', 0):
             magnitude = abs(self.data.charge)
             sign = "+" if self.data.charge > 0 else "-"
-            formula += "(%s%i)" % (sign, magnitude)
+            formula += f"({sign}{int(magnitude)})"
         return formula
 
     def repulsion_energy(self, atomcoords_index=-1):
@@ -156,7 +156,7 @@ class Nuclear(Method):
         choices = ('amu_bohr_2', 'amu_angstrom_2', 'g_cm_2')
         units = units.lower()
         if units not in choices:
-            raise ValueError("Invalid units, pick one of {}".format(choices))
+            raise ValueError(f"Invalid units, pick one of {choices}")
         moi_tensor = self.moment_of_inertia_tensor()
         principal_moments, principal_axes = np.linalg.eigh(moi_tensor)
         if units == "amu_bohr_2":
@@ -176,7 +176,7 @@ class Nuclear(Method):
         choices = ('invcm', 'ghz')
         units = units.lower()
         if units not in choices:
-            raise ValueError("Invalid units, pick one of {}".format(choices))
+            raise ValueError(f"Invalid units, pick one of {choices}")
         principal_moments = self.principal_moments_of_inertia("amu_angstrom_2")[0]
         _check_scipy(_found_scipy)
         bohr2ang = scipy.constants.value('atomic unit of length') / scipy.constants.angstrom

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -30,11 +30,11 @@ class OPA(Population):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "OPA of %s" % (self.data)
+        return f"OPA of {self.data}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'OPA("%s")' % (self.data)
+        return f'OPA("{self.data}")'
 
     def calculate(self, indices=None, fupdate=0.05):
         """Perform an overlap population analysis given the results of a parser"""

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -99,15 +99,11 @@ class Stockholder(Method):
 
         chargemol_path_floor = os.path.join(
             directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
-                atom_num, atom_num, atom_num - charge_floor
-            ),
+            f"c2_{atom_num:03d}_{atom_num:03d}_{atom_num - charge_floor:03d}_500_100.txt",
         )
         chargemol_path_ceil = os.path.join(
             directory,
-            "c2_{:03d}_{:03d}_{:03d}_500_100.txt".format(
-                atom_num, atom_num, atom_num - charge_ceil
-            ),
+            f"c2_{atom_num:03d}_{atom_num:03d}_{atom_num - charge_ceil:03d}_500_100.txt",
         )
         horton_path = os.path.join(directory, "atoms.h5")
 
@@ -140,7 +136,7 @@ class Stockholder(Method):
                     density_floor = numpy.array([0])
                     radiusgrid = numpy.array([0])
                 else:
-                    keystring_floor = "Z={}_Q={:+d}".format(atom_num, charge_floor)
+                    keystring_floor = f"Z={atom_num}_Q={charge_floor:+d}"
                     density_floor = numpy.asanyarray(list(proatomdb[keystring_floor]["rho"]))
 
                     # gridspec is specification of integration grid for proatom densities in horton.
@@ -183,7 +179,7 @@ class Stockholder(Method):
                 if atom_num <= charge_ceil:
                     density_ceil = numpy.array([0])
                 else:
-                    keystring_ceil = "Z={}_Q={:+d}".format(atom_num, charge_ceil)
+                    keystring_ceil = f"Z={atom_num}_Q={charge_ceil:+d}"
                     density_ceil = numpy.asanyarray(list(proatomdb[keystring_ceil]["rho"]))
 
                 density = (charge_ceil - charge) * density_floor + (

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -181,11 +181,7 @@ class Volume(object):
 
     def __str__(self):
         """Return a string representation."""
-        return "Volume %s to %s (density: %s)" % (
-            self.origin,
-            self.topcorner,
-            self.spacing,
-        )
+        return f"Volume {self.origin} to {self.topcorner} (density: {self.spacing})"
 
     def write(self, filename, fformat="Cube"):
         """Write the volume to a file."""
@@ -277,7 +273,7 @@ class Volume(object):
 
 def scinotation(num):
     """Write in scientific notation."""
-    ans = "%10.5E" % num
+    ans = f"{num:10.5E}"
     broken = ans.split("E")
     exponent = int(broken[1])
     if exponent < -99:
@@ -286,7 +282,7 @@ def scinotation(num):
         sign = "-"
     else:
         sign = "+"
-    return ("%sE%s%s" % (broken[0], sign, broken[1][-2:])).rjust(12)
+    return (f"{broken[0]}E{sign}{broken[1][-2:]}").rjust(12)
 
 
 def getGrid(vol):

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -24,11 +24,11 @@ class ADF(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "ADF log file %s" % (self.filename)
+        return f"ADF log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'ADF("%s")' % (self.filename)
+        return f'ADF("{self.filename}")'
 
     def normalisesym(self, label):
         """Use standard symmetry labels instead of ADF labels.
@@ -47,15 +47,15 @@ class ADF(logfileparser.Logfile):
 
         ans = label.replace(".", "")
         if ans[1:3] == "''":
-            temp = ans[0] + '"'
+            temp = f"{ans[0]}\""
             ans = temp
 
         l = len(ans)
         if l > 1 and ans[0] == ans[1]:  # Python only tests the second condition if the first is true
             if l > 2 and ans[1] == ans[2]:
-                ans = ans.replace(ans[0]*3, ans[0]) + '"'
+                ans = f"{ans.replace(ans[0] * 3, ans[0])}\""
             else:
-                ans = ans.replace(ans[0]*2, ans[0]) + "'"
+                ans = f"{ans.replace(ans[0] * 2, ans[0])}'"
         return ans
 
     def normalisedegenerates(self, label, num, ndict=None):
@@ -76,9 +76,9 @@ class ADF(logfileparser.Logfile):
             if num in ndict[label]:
                 return ndict[label][num]
             else:
-                return "%s:%i" % (label, num+1)
+                return f"{label}:{int(num + 1)}"
         else:
-            return "%s:%i" % (label, num+1)
+            return f"{label}:{int(num + 1)}"
 
     def before_parsing(self):
 
@@ -144,18 +144,18 @@ class ADF(logfileparser.Logfile):
             tokens = line.split()[1:-1]
             assert len(tokens) >= 1
             if tokens[0] == "Build":
-                package_version += "+{}".format(tokens[1])
+                package_version += f"+{tokens[1]}"
             else:
                 assert tokens[0][0] == "r"
                 # If a year-type version has already been parsed (YYYY(.nn)),
                 # it should take precedence, otherwise use the more detailed
                 # version first.
                 if match:
-                    package_version = '{}dev{}'.format(package_version, tokens[0][1:])
+                    package_version = f"{package_version}dev{tokens[0][1:]}"
                 else:
                     year = tokens[1].split("-")[0]
                     self.metadata["package_version_description"] = package_version
-                    package_version = '{}dev{}'.format(year, tokens[0][1:])
+                    package_version = f"{year}dev{tokens[0][1:]}"
                     self.metadata["legacy_package_version"] = year
                 self.metadata["package_version_date"] = tokens[1]
             self.metadata["package_version"] = package_version
@@ -241,7 +241,7 @@ class ADF(logfileparser.Logfile):
                 info = line.split()
 
                 if len(info) == 7:  # fragment name is listed here
-                    self.fragnames.append("%s_%s" % (info[1], info[0]))
+                    self.fragnames.append(f"{info[1]}_{info[0]}")
                     self.frags.append([])
                     self.frags[-1].append(int(info[2]) - 1)
 
@@ -574,7 +574,7 @@ class ADF(logfileparser.Logfile):
             info = line.split()
 
             if not info[0] == '1':
-                self.logger.warning("MO info up to #%s is missing" % info[0])
+                self.logger.warning(f"MO info up to #{info[0]} is missing")
 
             #handle case where MO information up to a certain orbital are missing
             while int(info[0]) - 1 != len(self.moenergies[0]):
@@ -619,7 +619,7 @@ class ADF(logfileparser.Logfile):
                     if info[3] != '0.00':
                         homob = len(moenergies[1]) - 1
                 else:
-                    print(("Error reading line: %s" % line))
+                    print(f"Error reading line: {line}")
 
                 line = next(inputfile)
 
@@ -882,17 +882,17 @@ class ADF(logfileparser.Logfile):
                         # i.e. while not completely blank, but blank at the start
                         info = line[43:].split()
                         if len(info) > 0:  # len(info)==0 for the second line of dvb_ir.adfout
-                            frag += "+" + fragname + info[-1]
+                            frag += f"+{fragname}{info[-1]}"
                             coeff = float(info[-4])
                             if coeff < 0:
-                                orbital += '-' + info[-3] + info[-2].replace(":", "")
+                                orbital += f"-{info[-3]}{info[-2].replace(':', '')}"
                             else:
-                                orbital += '+' + info[-3] + info[-2].replace(":", "")
+                                orbital += f"+{info[-3]}{info[-2].replace(':', '')}"
                         line = next(inputfile)
                     # At this point, we are either at the start of the next SFO or at
                     # a blank line...the end
 
-                    self.fonames.append("%s_%s" % (frag, orbital))
+                    self.fonames.append(f"{frag}_{orbital}")
                 symoffset += num
 
                 # blankline blankline

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -24,11 +24,11 @@ class DALTON(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "DALTON log file %s" % (self.filename)
+        return f"DALTON log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'DALTON("%s")' % (self.filename)
+        return f'DALTON("{self.filename}")'
 
     def normalisesym(self, label):
         """DALTON does not require normalizing symmetry labels."""
@@ -108,7 +108,7 @@ class DALTON(logfileparser.Logfile):
             revision = line.split()[4]
             package_version = self.metadata.get("package_version")
             if package_version:
-                self.metadata["package_version"] = "{}+{}".format(package_version, revision)
+                self.metadata["package_version"] = f"{package_version}+{revision}"
 
         # Is the basis set from a single library file, or is it
         # manually specified? See before_parsing().
@@ -489,7 +489,7 @@ class DALTON(logfileparser.Logfile):
 
                 # We want to count the number of contractiong already parsed for each orbital,
                 # but need to make sure to differentiate between atoms and symmetry atoms.
-                orblabel = str(iatom) + '.' + orbital + (sym or "")
+                orblabel = f"{str(iatom)}.{orbital}{sym or ''}"
                 orbitalcount[orblabel] = orbitalcount.get(orblabel, 0) + 1
 
                 # Here construct the actual primitives for gbasis, which should be a list
@@ -685,7 +685,7 @@ class DALTON(logfileparser.Logfile):
                     continue
 
                 # the first hit of @ n where n is the current iteration
-                strcompare = "@{0:>3d}".format(iteration)
+                strcompare = f"@{iteration:>3d}"
                 if strcompare in line:
                     temp = line.split()
                     error_norm = utils.float(temp[3])
@@ -1248,7 +1248,7 @@ class DALTON(logfileparser.Logfile):
                     etosc_key = (sym_num, excited_state_num_in_sym)
                     etoscs_keys.add(etosc_key)
                     etsym = tokens[9]
-                    etsyms.append(symmap[do_triplet] + "-" + etsym)
+                    etsyms.append(f"{symmap[do_triplet]}-{etsym}")
                     self.skip_lines(inputfile, ["d", "b", "Excitation energy in a.u."])
                     line = next(inputfile)
                     etenergies.append(utils.float(line.split()[3]))

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -305,15 +305,15 @@ class ccData:
                 val = self._attributes[attr].type(val)
             except ValueError:
                 args = (attr, type(val), self._attributes[attr].type)
-                raise TypeError("attribute %s is %s instead of %s and could not be converted" % args)
+                raise TypeError(
+                    f"attribute {args[0]} is {args[1]} instead of {args[2]} and could not be converted"
+                )
 
     def check_values(self, logger=logging):
         """Perform custom checks on the values of attributes."""
         if hasattr(self, "etenergies") and any(e < 0 for e in self.etenergies):
             negative_values = [e for e in self.etenergies if e < 0]
-            msg = ("At least one excitation energy is negative. "
-                   "\nNegative values: %s\nFull etenergies: %s"
-                   % (negative_values, self.etenergies))
+            msg = f"At least one excitation energy is negative. \nNegative values: {negative_values}\nFull etenergies: {self.etenergies}"
             logger.error(msg)
 
     def write(self, filename=None, indices=None, *args, **kwargs):

--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -50,7 +50,7 @@ def _shell_to_orbitals(type, offset):
     `['4D1', '4D2', '4D3', '4D4', '4D5']`.
     """
 
-    return ['{}{}'.format(SHELL_START[type] + offset, x) for x in SHELL_ORBITALS[type]]
+    return [f"{SHELL_START[type] + offset}{x}" for x in SHELL_ORBITALS[type]]
 
 
 class FChk(logfileparser.Logfile):
@@ -65,11 +65,11 @@ class FChk(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Formatted checkpoint file %s" % self.filename
+        return f"Formatted checkpoint file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'FCHK("%s")' % self.filename
+        return f'FCHK("{self.filename}")'
 
     def normalisesym(self, symlabel):
         """Just return label"""
@@ -294,13 +294,13 @@ class FChk(logfileparser.Logfile):
         shell_map = self._parse_block(inputfile, count, int, 'Atomic Orbital Names')
 
         elements = (self.table.element[x] for x in self.atomnos)
-        atom_labels = ["{}{}".format(y, x) for x, y in enumerate(elements, 1)]
+        atom_labels = [f"{y}{x}" for x, y in enumerate(elements, 1)]
 
         # get orbitals for first atom and start aonames and atombasis lists
         atom = shell_map[0] - 1
         shell_offset = 0
         orbitals = _shell_to_orbitals(shell_types[0], shell_offset)
-        aonames = ["{}_{}".format(atom_labels[atom], x) for x in orbitals]
+        aonames = [f"{atom_labels[atom]}_{x}" for x in orbitals]
         atombasis = [list(range(len(orbitals)))]
 
         # get rest
@@ -321,14 +321,18 @@ class FChk(logfileparser.Logfile):
                 shell_offset = 0
 
             orbitals = _shell_to_orbitals(_type, shell_offset)
-            aonames.extend(["{}_{}".format(atom_labels[atom], x) for x in orbitals])
+            aonames.extend([f"{atom_labels[atom]}_{x}" for x in orbitals])
             atombasis[-1].extend(list(range(basis_offset, basis_offset + len(orbitals))))
 
-        assert len(aonames) == self.nbasis, 'Length of aonames != nbasis: {} != {}'.format(len(aonames), self.nbasis)
-        self.set_attribute('aonames', aonames)
+        assert (
+            len(aonames) == self.nbasis
+        ), f"Length of aonames != nbasis: {len(aonames)} != {self.nbasis}"
+        self.set_attribute("aonames", aonames)
 
-        assert len(atombasis) == self.natom, 'Length of atombasis != natom: {} != {}'.format(len(atombasis), self.natom)
-        self.set_attribute('atombasis', atombasis)
+        assert (
+            len(atombasis) == self.natom
+        ), f"Length of atombasis != natom: {len(atombasis)} != {self.natom}"
+        self.set_attribute("atombasis", atombasis)
 
     def after_parsing(self):
         """Correct data or do parser-specific validation after parsing is finished."""

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -50,11 +50,11 @@ class GAMESS(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "GAMESS log file %s" % (self.filename)
+        return f"GAMESS log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'GAMESS("%s")' % (self.filename)
+        return f'GAMESS("{self.filename}")'
 
     def normalisesym(self, label):
         """Normalise the symmetries used by GAMESS.
@@ -87,7 +87,7 @@ class GAMESS(logfileparser.Logfile):
             match = re.search(r"Firefly version\s([\d.]*)\D*(\d*)\s*\*", line)
             if match:
                 base_version, build = match.groups()
-                package_version = "{}+{}".format(base_version, build)
+                package_version = f"{base_version}+{build}"
                 self.metadata["package_version"] = package_version
                 self.metadata["legacy_package_version"] = base_version
         if "GAMESS VERSION =" in line:
@@ -103,8 +103,8 @@ class GAMESS(logfileparser.Logfile):
                 else:
                     # `(R23)` -> 23
                     release = possible_release[2:-1]
-                self.metadata["package_version"] = '{}.r{}'.format(year, release)
-                self.metadata["legacy_package_version"] = "{}R{}".format(year, release)
+                self.metadata["package_version"] = f"{year}.r{release}"
+                self.metadata["legacy_package_version"] = f"{year}R{release}"
 
         if line[1:12] == "INPUT CARD>":
             return
@@ -1134,13 +1134,13 @@ class GAMESS(logfileparser.Logfile):
                                 flag_w = True  # reset flag
                             g2 = g2 + i_atom
 
-                            aoname = "%s%i_%s" % (g[1].capitalize(), g2, g[3])
+                            aoname = f"{g[1].capitalize()}{int(g2)}_{g[3]}"
                             oldatom = str(g2)
                             atomno = g2-1
                             orbno = int(g[0])-1
                         else:  # For F orbitals, as shown above
                             g = [x.strip() for x in line.split()]
-                            aoname = "%s%s_%s" % (g[1].capitalize(), oldatom, g[2])
+                            aoname = f"{g[1].capitalize()}{oldatom}_{g[2]}"
                             atomno = int(oldatom)-1
                             orbno = int(g[0])-1
 

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -25,11 +25,11 @@ class GAMESSUK(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "GAMESS UK log file %s" % (self.filename)
+        return f"GAMESS UK log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'GAMESSUK("%s")' % (self.filename)
+        return f'GAMESSUK("{self.filename}")'
 
     def normalisesym(self, label):
         """Use standard symmetry labels instead of GAMESS UK labels."""
@@ -56,9 +56,7 @@ class GAMESSUK(logfileparser.Logfile):
             revision = line.split()[1]
             package_version = self.metadata.get("package_version")
             if package_version:
-                self.metadata["package_version"] = "{}+{}".format(
-                    package_version, revision
-                )
+                self.metadata["package_version"] = f"{package_version}+{revision}"
 
         if line[1:22] == "total number of atoms":
             natom = int(line.split()[-1])
@@ -364,7 +362,11 @@ class GAMESSUK(logfileparser.Logfile):
 
         if line[3:11] == "SCF TYPE":
             self.scftype = line.split()[-2]
-            assert self.scftype in ['rhf', 'uhf', 'gvb'], "%s not one of 'rhf', 'uhf' or 'gvb'" % self.scftype
+            assert self.scftype in [
+                "rhf",
+                "uhf",
+                "gvb",
+            ], f"{self.scftype} not one of 'rhf', 'uhf' or 'gvb'"
 
         if line[15:31] == "convergence data":
             if not hasattr(self, "scfvalues"):
@@ -387,7 +389,9 @@ class GAMESSUK(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last tester: {}'.format(line.split()[5]))
+                    self.logger.warning(
+                        f"File terminated before end of last SCF! Last tester: {line.split()[5]}"
+                    )
                     break
             self.scfvalues.append(scfvalues)
 
@@ -445,7 +449,13 @@ class GAMESSUK(logfileparser.Logfile):
                     # See GAMESS-UK 7.0 distribution/examples/chap12/pyridine2_21m10r.out
                     # for an example of the latter
                         sym = basisregexp.match(temp[1]).groups()[0]
-                        assert sym in ['s', 'p', 'd', 'f', 'sp'], "'%s' not a recognized symmetry" % sym
+                        assert sym in [
+                            "s",
+                            "p",
+                            "d",
+                            "f",
+                            "sp",
+                        ], f"'{sym}' not a recognized symmetry"
                         if sym == "sp":
                             coeff.setdefault("S", []).append((float(temp[3]), float(temp[6])))
                             coeff.setdefault("P", []).append((float(temp[3]), float(temp[10])))
@@ -502,7 +512,9 @@ class GAMESSUK(logfileparser.Logfile):
                     for j in range(multiple[temp[0]]):
                         mosyms.append(self.normalisesym(temp))  # add twice for 'e', etc.
                 line = next(inputfile)
-            assert len(mosyms) == self.nmo, "mosyms: %d but nmo: %d" % (len(mosyms), self.nmo)
+            assert (
+                len(mosyms) == self.nmo
+            ), f"mosyms: {len(mosyms)} but nmo: {int(self.nmo)}"
             if self.betamosyms:
                 # Only append if beta (otherwise with IPRINT SCF
                 # it will add mosyms for every step of a geo opt)
@@ -555,14 +567,14 @@ class GAMESSUK(logfileparser.Logfile):
                         self.atombasis[atomno].append(orbno)
                     if not self.aonames:
                         pg = p.match(line[:18].strip()).groups()
-                        atomname = "%s%s%s" % (pg[1][0].upper(), pg[1][1:], pg[0])
+                        atomname = f"{pg[1][0].upper()}{pg[1][1:]}{pg[0]}"
                         if atomname != oldatomname:
                             aonum = 1
                         oldatomname = atomname
-                        name = "%s_%d%s" % (atomname, aonum, pg[2].upper())
+                        name = f"{atomname}_{int(aonum)}{pg[2].upper()}"
                         if name in aonames:
                             aonum += 1
-                        name = "%s_%d%s" % (atomname, aonum, pg[2].upper())
+                        name = f"{atomname}_{int(aonum)}{pg[2].upper()}"
                         aonames.append(name)
                     temp = list(map(float, line[19:].split()))
                     mocoeffs[mo:(mo+len(temp)), basis] = temp

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -25,11 +25,11 @@ class Gaussian(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Gaussian log file %s" % (self.filename)
+        return f"Gaussian log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Gaussian("%s")' % (self.filename)
+        return f'Gaussian("{self.filename}")'
 
     def normalisesym(self, label):
         """Use standard symmetry labels instead of Gaussian labels.
@@ -46,7 +46,7 @@ class Gaussian(logfileparser.Logfile):
                 tmp = label[len(k):]
                 label = v
                 if tmp:
-                    label = v + "." + tmp
+                    label = f"{v}.{tmp}"
 
         ans = label.replace("U", "u").replace("G", "g")
         return ans
@@ -192,9 +192,9 @@ class Gaussian(logfileparser.Logfile):
             platform = "-".join(platform_full_version_tokens[:-1])
             year_suffix = full_version[1:3]
             revision = full_version[6:]
-            self.metadata["package_version"] = "{}+{}".format(
-                self.YEAR_SUFFIXES_TO_YEARS[year_suffix], revision
-            )
+            self.metadata[
+                "package_version"
+            ] = f"{self.YEAR_SUFFIXES_TO_YEARS[year_suffix]}+{revision}"
             self.metadata["platform"] = platform
 
         if line.strip().startswith("Link1:  Proceeding to internal job step number"):
@@ -232,7 +232,7 @@ class Gaussian(logfileparser.Logfile):
                 # For the supermolecule, we can parse the charge and multicplicity.
                 regex = r".*=(.*)Mul.*=\s*-?(\d+).*"
                 match = re.match(regex, line)
-                assert match, "Something unusual about the line: '%s'" % line
+                assert match, f"Something unusual about the line: '{line}'"
 
                 self.set_attribute('charge', int(match.groups()[0]))
                 self.set_attribute('mult', int(match.groups()[1]))
@@ -272,7 +272,7 @@ class Gaussian(logfileparser.Logfile):
 
                 regex = r".*=(.*)Mul.*=\s*-?(\d+).*"
                 match = re.match(regex, line)
-                assert match, "Something unusual about the line: '%s'" % line
+                assert match, f"Something unusual about the line: '{line}'"
 
                 self.set_attribute('charge', int(match.groups()[0]))
                 self.set_attribute('mult', int(match.groups()[1]))
@@ -436,7 +436,9 @@ class Gaussian(logfileparser.Logfile):
                     try:
                         numpy.testing.assert_equal(self.moments[4], hexadecapole)
                     except AssertionError:
-                        self.logger.warning("Attribute hexadecapole changed value (%s -> %s)" % (self.moments[4], hexadecapole))
+                        self.logger.warning(
+                            f"Attribute hexadecapole changed value ({self.moments[4]} -> {hexadecapole})"
+                        )
                     self.append_attribute("moments", hexadecapole)
 
         # Catch message about completed optimization.
@@ -961,7 +963,9 @@ class Gaussian(logfileparser.Logfile):
                 try:
                     value = utils.float(parts[2])
                 except ValueError:
-                    self.logger.error("Problem parsing the value for geometry optimisation: %s is not a number." % parts[2])
+                    self.logger.error(
+                        f"Problem parsing the value for geometry optimisation: {parts[2]} is not a number."
+                    )
                 else:
                     newlist[i] = value
                 self.geotargets[i] = utils.float(parts[3])
@@ -1612,7 +1616,9 @@ class Gaussian(logfileparser.Logfile):
                 try:
                     assert nbasis == self.nbasis
                 except AssertionError:
-                    self.logger.warning("Number of basis functions (nbasis) has changed from %i to %i" % (self.nbasis, nbasis))
+                    self.logger.warning(
+                        f"Number of basis functions (nbasis) has changed from {int(self.nbasis)} to {int(nbasis)}"
+                    )
             self.nbasis = nbasis
 
         # Number of linearly-independent basis sets.
@@ -1724,9 +1730,9 @@ class Gaussian(logfileparser.Logfile):
                             if i > 0:
                                 self.atombasis.append(atombasis)
                             atombasis = []
-                            atomname = "%s%s" % (parts[2], parts[1])
+                            atomname = f"{parts[2]}{parts[1]}"
                         orbital = line[start_of_basis_fn_name:20].strip()
-                        self.aonames.append("%s_%s" % (atomname, orbital))
+                        self.aonames.append(f"{atomname}_{orbital}")
                         atombasis.append(i)
 
                     part = line[21:].replace("D", "E").rstrip()
@@ -1779,9 +1785,9 @@ class Gaussian(logfileparser.Logfile):
                             if i > 0:
                                 atombasis.append(basisonatom)
                             basisonatom = []
-                            atomname = "%s%s" % (parts[2], parts[1])
+                            atomname = f"{parts[2]}{parts[1]}"
                         orbital = line[11:20].strip()
-                        aonames.append("%s_%s" % (atomname, orbital))
+                        aonames.append(f"{atomname}_{orbital}")
                         basisonatom.append(i)
                     part = line[21:].replace("D", "E").rstrip()
                     temp = []
@@ -2020,14 +2026,14 @@ class Gaussian(logfileparser.Logfile):
             # Input extracted values into self.atomcharges.
             if has_charges:
                 if is_sum:
-                    self.atomcharges['{}_sum'.format(prop)] = charges
+                    self.atomcharges[f"{prop}_sum"] = charges
                 else:
-                    self.atomcharges['{}'.format(prop)] = charges
+                    self.atomcharges[f"{prop}"] = charges
             if has_spin:
                 if is_sum:
-                    self.atomspins['{}_sum'.format(prop)] = spins
+                    self.atomspins[f"{prop}_sum"] = spins
                 else:
-                    self.atomspins['{}'.format(prop)] = spins
+                    self.atomspins[f"{prop}"] = spins
 
         # Define strings needed for line detection. Older Gaussian
         # versions don't always give the charge type explicitly,
@@ -2047,8 +2053,8 @@ class Gaussian(logfileparser.Logfile):
         # of atom charges or spins.
             for prop in props:
                 for header in headers:
-                    if '{}{}'.format(prop,header).lower() in line.lower():
-                        # When we use "atomic" as the property, only 
+                    if f"{prop}{header}".lower() in line.lower():
+                        # When we use "atomic" as the property, only
                         # extract if the charge type isn't given explicity.
                         # This prevents us from reading some lines twice.
                         # e.g. "Mulliken atomic charges:" is caught by 

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -24,11 +24,11 @@ class Jaguar(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Jaguar output file %s" % (self.filename)
+        return f"Jaguar output file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Jaguar("%s")' % (self.filename)
+        return f'Jaguar("{self.filename}")'
 
     def normalisesym(self, label):
         """Normalise the symmetries used by Jaguar.
@@ -63,7 +63,7 @@ class Jaguar(logfileparser.Logfile):
         if "Jaguar version" in line:
             tokens = line.split()
             base_version = tokens[3][:-1]
-            package_version = "{}+{}".format(base_version, tokens[5])
+            package_version = f"{base_version}+{tokens[5]}"
             self.metadata["package_version"] = package_version
             self.metadata["legacy_package_version"] = base_version
 
@@ -310,7 +310,9 @@ class Jaguar(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(maxdiiserr))
+                    self.logger.warning(
+                        f"File terminated before end of last SCF! Last error: {maxdiiserr}"
+                    )
                     break
             self.scfvalues.append(values)
 
@@ -447,17 +449,17 @@ class Jaguar(logfileparser.Logfile):
                                 dcount = 6  # six d orbitals in Jaguar
 
                             if info[2] == 'S':
-                                aonames.append("%s_%i%s" % (info[1], scount, info[2]))
+                                aonames.append(f"{info[1]}_{int(scount)}{info[2]}")
                                 scount += 1
 
                             if info[2] == 'X' or info[2] == 'Y' or info[2] == 'Z':
-                                aonames.append("%s_%iP%s" % (info[1], pcount / 3, info[2]))
+                                aonames.append(f"{info[1]}_{int(pcount / 3)}P{info[2]}")
                                 pcount += 1
 
                             if info[2] == 'XX' or info[2] == 'YY' or info[2] == 'ZZ' or \
                                info[2] == 'XY' or info[2] == 'XZ' or info[2] == 'YZ':
 
-                                aonames.append("%s_%iD%s" % (info[1], dcount / 6, info[2]))
+                                aonames.append(f"{info[1]}_{int(dcount / 6)}D{info[2]}")
                                 dcount += 1
 
                             lastatom = info[1]

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -205,7 +205,7 @@ class Logfile(ABC):
             self.isstream = False
             self.isfileinput = True
         elif hasattr(source, "read"):
-            self.filename = "stream %s" % str(type(source))
+            self.filename = f"stream {str(type(source))}"
             self.isstream = True
             self.stream = source
         else:
@@ -217,7 +217,7 @@ class Logfile(ABC):
         #   which means that care needs to be taken not to duplicate handlers.
         self.loglevel = loglevel
         self.logname = logname
-        self.logger = logging.getLogger('%s %s' % (self.logname, self.filename))
+        self.logger = logging.getLogger(f"{self.logname} {self.filename}")
         self.logger.setLevel(self.loglevel)
         if len(self.logger.handlers) == 0:
             handler = logging.StreamHandler(logstream)
@@ -257,9 +257,9 @@ class Logfile(ABC):
             # Call logger.info() only if the attribute is new.
             if not hasattr(self, name):
                 if type(value) in [numpy.ndarray, list]:
-                    self.logger.info("Creating attribute %s[]" % name)
+                    self.logger.info(f"Creating attribute {name}[]")
                 else:
-                    self.logger.info("Creating attribute %s: %s" % (name, str(value)))
+                    self.logger.info(f"Creating attribute {name}: {str(value)}")
 
         # Set the attribute.
         object.__setattr__(self, name, value)
@@ -270,11 +270,17 @@ class Logfile(ABC):
         # Check that the sub-class has an extract attribute,
         #  that is callable with the proper number of arguemnts.
         if not hasattr(self, "extract"):
-            raise AttributeError("Class %s has no extract() method." % self.__class__.__name__)
+            raise AttributeError(
+                f"Class {self.__class__.__name__} has no extract() method."
+            )
         if not callable(self.extract):
-            raise AttributeError("Method %s._extract not callable." % self.__class__.__name__)
+            raise AttributeError(
+                f"Method {self.__class__.__name__}._extract not callable."
+            )
         if len(inspect.getfullargspec(self.extract)[0]) != 3:
-            raise AttributeError("Method %s._extract takes wrong number of arguments." % self.__class__.__name__)
+            raise AttributeError(
+                f"Method {self.__class__.__name__}._extract takes wrong number of arguments."
+            )
 
         # Save the current list of attributes to keep after parsing.
         # The dict of self should be the same after parsing.
@@ -318,7 +324,7 @@ class Logfile(ABC):
                 break
             except Exception as e:
                 self.logger.error("Encountered error when parsing.")
-                self.logger.error("Last line read: %s" % inputfile.last_line)
+                self.logger.error(f"Last line read: {inputfile.last_line}")
                 raise
 
         # Close input file object.
@@ -428,7 +434,9 @@ class Logfile(ABC):
             try:
                 numpy.testing.assert_equal(getattr(self, name), value)
             except AssertionError:
-                self.logger.warning("Attribute %s changed value (%s -> %s)" % (name, getattr(self, name), value))
+                self.logger.warning(
+                    f"Attribute {name} changed value ({getattr(self, name)} -> {value})"
+                )
 
         setattr(self, name, value)
 
@@ -503,7 +511,7 @@ class Logfile(ABC):
                 except AssertionError:
                     frame, fname, lno, funcname, funcline, index = inspect.getouterframes(inspect.currentframe())[1]
                     parser = fname.split('/')[-1]
-                    msg = "In %s, line %i, line not blank as expected: %s" % (parser, lno, line.strip())
+                    msg = f"In {parser}, line {int(lno)}, line not blank as expected: {line.strip()}"
                     self.logger.warning(msg)
 
             # All cases of heterogeneous lines can be dealt with by the same code.
@@ -514,7 +522,7 @@ class Logfile(ABC):
                     except AssertionError:
                         frame, fname, lno, funcname, funcline, index = inspect.getouterframes(inspect.currentframe())[1]
                         parser = fname.split('/')[-1]
-                        msg = "In %s, line %i, line not all %s as expected: %s" % (parser, lno, keys[0], line.strip())
+                        msg = f"In {parser}, line {int(lno)}, line not all {keys[0]} as expected: {line.strip()}"
                         self.logger.warning(msg)
                         continue
 

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -24,11 +24,11 @@ class Molcas(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string repeesentation of the object."""
-        return "Molcas log file %s" % (self.filename)
+        return f"Molcas log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Molcas("%s")' % (self.filename)
+        return f'Molcas("{self.filename}")'
 
     def normalisesym(self, label):
         """Normalise the symmetries used by Molcas.
@@ -49,21 +49,17 @@ class Molcas(logfileparser.Logfile):
             # distinction between development and release builds in their
             # version cycle.
             if "tag" in self.metadata and "revision" in self.metadata:
-                self.metadata["package_version"] = "{}+{}.{}".format(
-                    self.metadata["package_version"],
-                    self.metadata["tag"],
-                    self.metadata["revision"]
-                )
+                self.metadata[
+                    "package_version"
+                ] = f"{self.metadata['package_version']}+{self.metadata['tag']}.{self.metadata['revision']}"
             elif "tag" in self.metadata:
-                self.metadata["package_version"] = "{}+{}".format(
-                    self.metadata["package_version"],
-                    self.metadata["tag"]
-                )
+                self.metadata[
+                    "package_version"
+                ] = f"{self.metadata['package_version']}+{self.metadata['tag']}"
             elif "revision" in self.metadata:
-                self.metadata["package_version"] = "{}+{}".format(
-                    self.metadata["package_version"],
-                    self.metadata["revision"]
-                )
+                self.metadata[
+                    "package_version"
+                ] = f"{self.metadata['package_version']}+{self.metadata['revision']}"
 
     def before_parsing(self):
         # Compile the regex for extracting the element symbol from the
@@ -632,10 +628,7 @@ class Molcas(logfileparser.Logfile):
                 self.atomcoords.append(atomcoords)
             else:
                 self.logger.warning(
-                        "Parsed coordinates not consistent with previous, skipping. "
-                        "This could be due to symmetry being turned on during the job. "
-                        "Length was %i, now found %i. New coordinates: %s"
-                        % (len(self.atomcoords[-1]), len(atomcoords), str(atomcoords)))
+                        f"Parsed coordinates not consistent with previous, skipping. This could be due to symmetry being turned on during the job. Length was {len(self.atomcoords[-1])}, now found {len(atomcoords)}. New coordinates: {str(atomcoords)}")
 
         #  **********************************************************************************************************************
         #  *                                    Energy Statistics for Geometry Optimization                                     *
@@ -687,10 +680,7 @@ class Molcas(logfileparser.Logfile):
                 self.atomcoords.append(atomcoords)
             else:
                 self.logger.error(
-                        'Number of atoms (%d) in parsed atom coordinates '
-                        'is smaller than previously (%d), possibly due to '
-                        'symmetry. Ignoring these coordinates.'
-                        % (len(atomcoords), self.natom))
+                        f'Number of atoms ({len(atomcoords)}) in parsed atom coordinates is smaller than previously ({int(self.natom)}), possibly due to symmetry. Ignoring these coordinates.')
 
         ## Parsing Molecular Gradients attributes in this section.
         # ()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()
@@ -813,7 +803,7 @@ class Molcas(logfileparser.Logfile):
                     tokens = line.split()
                     if tokens and tokens[0] == '1':
                         while tokens and tokens[0] != '--':
-                            aonames.append("{atom}_{orbital}".format(atom=tokens[1], orbital=tokens[2]))
+                            aonames.append(f"{tokens[1]}_{tokens[2]}")
                             info = tokens[3:]
                             j = 0
                             for i in orbital_index:

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -41,7 +41,7 @@ def create_atomic_orbital_names(orbitals):
 
         # For spherical functions, we need to construct the names.
         pre = str(i+3) + orb.lower()
-        spherical = [pre + '0'] + [pre + str(j) + s for j in range(1, i+3) for s in ['-', '+']]
+        spherical = [f"{pre}0"] + [pre + str(j) + s for j in range(1, i+3) for s in ['-', '+']]
         atomic_orbital_names[orb] = cartesian + spherical
 
     return atomic_orbital_names
@@ -57,11 +57,11 @@ class Molpro(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Molpro log file %s" % (self.filename)
+        return f"Molpro log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Molpro("%s")' % (self.filename)
+        return f'Molpro("{self.filename}")'
 
     def normalisesym(self, label):
         """Normalise the symmetries used by Molpro."""
@@ -176,7 +176,7 @@ class Molpro(logfileparser.Logfile):
                         else:
                             functype = s
                             element = self.table.element[self.atomnos[atomno-1]]
-                            aoname = "%s%i_%s" % (element, atomno, functype)
+                            aoname = f"{element}{int(atomno)}_{functype}"
                             aonames.append(aoname)
                     line = next(inputfile)
 
@@ -215,7 +215,7 @@ class Molpro(logfileparser.Logfile):
                     try:
                         c = float(p)
                     except ValueError as detail:
-                        self.logger.warn("setting coeff element to zero: %s" % detail)
+                        self.logger.warn(f"setting coeff element to zero: {detail}")
                         c = 0.0
                     coeff.append(c)
                 coeffs.extend(coeff)
@@ -406,7 +406,7 @@ class Molpro(logfileparser.Logfile):
                 # are also printed, but they don't get numbers so they are nor parsed.
                 if line_nr:
                     element = self.table.element[self.atomnos[funcatom-1]]
-                    aoname = "%s%i_%s" % (element, funcatom, functype)
+                    aoname = f"{element}{int(funcatom)}_{functype}"
                     aonames.append(aoname)
                     funcnr = len(aonames)
                     atombasis[funcatom-1].append(funcnr-1)
@@ -495,7 +495,9 @@ class Molpro(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last gradient: {}'.format(grad))
+                    self.logger.warning(
+                        f"File terminated before end of last SCF! Last gradient: {grad}"
+                    )
                     break
             self.scfvalues.append(numpy.array(scfvalues))
 

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -35,11 +35,11 @@ class MOPAC(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "MOPAC log file %s" % (self.filename)
+        return f"MOPAC log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'MOPAC("%s")' % (self.filename)
+        return f'MOPAC("{self.filename}")'
 
     def normalisesym(self, label):
         """MOPAC does not require normalizing symmetry labels."""

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -25,11 +25,11 @@ class NWChem(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "NWChem log file %s" % (self.filename)
+        return f"NWChem log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'NWChem("%s")' % (self.filename)
+        return f'NWChem("{self.filename}")'
 
     def normalisesym(self, label):
         """NWChem does not require normalizing symmetry labels."""
@@ -53,9 +53,9 @@ class NWChem(logfileparser.Logfile):
             self.metadata["package_version"] = base_package_version
             line = next(inputfile)
             if "nwchem revision" in line:
-                self.metadata["package_version"] = "{}+{}".format(
-                    self.metadata["package_version"], line.split()[3].split("-")[-1]
-                )
+                self.metadata[
+                    "package_version"
+                ] = f"{self.metadata['package_version']}+{line.split()[3].split('-')[-1]}"
 
         # This is printed in the input module, so should always be the first coordinates,
         # and contains some basic information we want to parse as well. However, this is not
@@ -418,7 +418,9 @@ class NWChem(logfileparser.Logfile):
                             line = next(inputfile)
                         # Is this the end of the file for some reason?
                         except StopIteration:
-                            self.logger.warning('File terminated before end of last SCF! Last gradient norm: {}'.format(gnorm))
+                            self.logger.warning(
+                                f"File terminated before end of last SCF! Last gradient norm: {gnorm}"
+                            )
                             break
                     if not hasattr(self, 'scfvalues'):
                         self.scfvalues = []
@@ -471,7 +473,9 @@ class NWChem(logfileparser.Logfile):
                     line = next(inputfile)
                 # Is this the end of the file for some reason?
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(diis))
+                    self.logger.warning(
+                        f"File terminated before end of last SCF! Last error: {diis}"
+                    )
                     break
 
             if not hasattr(self, 'scfvalues'):
@@ -610,7 +614,9 @@ class NWChem(logfileparser.Logfile):
                     sym = sym[0].upper() + sym[1:]
                     if self.mosyms[0][index]:
                         if self.mosyms[0][index] != sym:
-                            self.logger.warning("Symmetry of MO %i has changed" % (index+1))
+                            self.logger.warning(
+                                f"Symmetry of MO {int(index + 1)} has changed"
+                            )
                     self.mosyms[0][index] = sym
                 line = next(inputfile)
 
@@ -1313,7 +1319,7 @@ class NWChem(logfileparser.Logfile):
                 self.logger.warning(msg)
                 break
 
-            prefix = "%s%i_" % (element, i + 1)  # (e.g. C1_)
+            prefix = f"{element}{int(i + 1)}_"  # (e.g. C1_)
 
             matches = pattern.match(shell_text)
             for j, group in enumerate(matches.groups()):

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -26,11 +26,11 @@ class ORCA(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "ORCA log file %s" % (self.filename)
+        return f"ORCA log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'ORCA("%s")' % (self.filename)
+        return f'ORCA("{self.filename}")'
 
     def normalisesym(self, label):
         """ORCA does not require normalizing symmetry labels."""
@@ -86,10 +86,8 @@ class ORCA(logfileparser.Logfile):
             self.metadata["package_version"] = self.metadata["legacy_package_version"].replace(".x", "dev")
             possible_revision_line = next(inputfile)
             if "SVN: $Rev" in possible_revision_line:
-                self.metadata["package_version"] += "+{}".format(
-                    re.search(r"\d+", possible_revision_line).group()
-                )
-
+                version = re.search(r'\d+', possible_revision_line).group()
+                self.metadata["package_version"] += f"+{version}"
 
         # ================================================================================
         #                                         WARNINGS
@@ -915,7 +913,7 @@ Dispersion correction           -0.016199959
                             num = int(line[0:3])
                             orbital = line.split()[1].upper()
 
-                            aonames.append("%s%i_%s" % (atomname, num+1, orbital))
+                            aonames.append(f"{atomname}{int(num + 1)}_{orbital}")
                             atombasis[num].append(j)
 
                         # This regex will tease out all number with exactly
@@ -2011,7 +2009,9 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             try:
                 line = next(inputfile).split()
             except StopIteration:
-                self.logger.warning('File terminated before end of last SCF! Last Max-DP: {}'.format(maxDP))
+                self.logger.warning(
+                    f"File terminated before end of last SCF! Last Max-DP: {maxDP}"
+                )
                 break
 
     def parse_scf_expanded_format(self, inputfile, line):

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -21,11 +21,11 @@ class Psi3(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Psi3 log file %s" % (self.filename)
+        return f"Psi3 log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Psi3("%s")' % (self.filename)
+        return f'Psi3("{self.filename}")'
 
     def normalisesym(self, label):
         """Psi3 does not require normalizing symmetry labels."""

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -24,11 +24,11 @@ class Psi4(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Psi4 log file %s" % (self.filename)
+        return f"Psi4 log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Psi4("%s")' % (self.filename)
+        return f'Psi4("{self.filename}")'
 
     def before_parsing(self):
 
@@ -90,13 +90,13 @@ class Psi4(logfileparser.Logfile):
             if "beta" in package_version:
                 self.version_4_beta = True
                 # `beta2+` -> `0!0.beta2`
-                package_version = "0!0.{}".format(package_version)
+                package_version = f"0!0.{package_version}"
                 if package_version[-1] == "+":
                     # There is no good way to keep the bare plus sign around,
                     # but this version is so old...
                     package_version = package_version[:-1]
             else:
-                package_version = "1!{}".format(package_version)
+                package_version = f"1!{package_version}"
             self.skip_line(inputfile, "blank")
             line = next(inputfile)
             if "Git:" in line:
@@ -104,9 +104,7 @@ class Psi4(logfileparser.Logfile):
                 assert tokens[1] == "Rev"
                 revision = '-'.join(tokens[2:]).replace("{", "").replace("}", "")
                 dev_flag = "" if "dev" in package_version else ".dev"
-                package_version = "{}{}+{}".format(
-                    package_version, dev_flag, revision
-                )
+                package_version = f"{package_version}{dev_flag}+{revision}"
             self.metadata["package_version"] = package_version
 
         # This will automatically change the section attribute for Psi4, when encountering
@@ -439,7 +437,9 @@ class Psi4(logfileparser.Logfile):
                 try:
                     line = next(inputfile)
                 except StopIteration:
-                    self.logger.warning('File terminated before end of last SCF! Last density err: {}'.format(ddensity))
+                    self.logger.warning(
+                        f"File terminated before end of last SCF! Last density err: {ddensity}"
+                    )
                     break
             self.section = "Post-Iterations"
             self.scfvalues.append(scfvals)
@@ -651,7 +651,7 @@ class Psi4(logfileparser.Logfile):
         #        2     C     2.99909  2.99909  0.00000  0.00182
         # ...
         for pop_type in ["Mulliken", "Lowdin"]:
-            if line.strip() == "%s Charges: (a.u.)" % pop_type:
+            if line.strip() == f"{pop_type} Charges: (a.u.)":
                 if not hasattr(self, 'atomcharges'):
                     self.atomcharges = {}
                 header = next(inputfile)
@@ -868,8 +868,10 @@ class Psi4(logfileparser.Logfile):
                 while line.strip():
 
                     value = float(line.split()[-1])
-                    fromunits = "ebohr" + (rank > 1)*("%i" % rank)
-                    tounits = "Debye" + (rank > 1)*".ang" + (rank > 2)*("%i" % (rank-1))
+                    fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
+                    tounits = (
+                        f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"
+                    )
                     value = utils.convertor(value, fromunits, tounits)
                     multipole.append(value)
 

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -27,11 +27,11 @@ class QChem(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "QChem log file %s" % (self.filename)
+        return f"QChem log file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'QChem("%s")' % (self.filename)
+        return f'QChem("{self.filename}")'
 
     def normalisesym(self, label):
         """Q-Chem does not require normalizing symmetry labels."""
@@ -162,8 +162,8 @@ class QChem(logfileparser.Logfile):
                         # principal quantum number (1S, 2P, 3D, 4F,
                         # ...).
                         bfcounts[bfname] = angmom.index(bfname[0])
-                    newbfname = '{}{}'.format(bfcounts[bfname], bfname)
-                    self.aonames[bfindex] = '_'.join([atomname, newbfname])
+                    newbfname = f"{bfcounts[bfname]}{bfname}"
+                    self.aonames[bfindex] = "_".join([atomname, newbfname])
 
         # Assign the number of core electrons replaced by ECPs.
         if hasattr(self, 'user_input') and self.user_input.get('rem') is not None:
@@ -328,7 +328,7 @@ cannot be determined. Rerun without `$molecule read`."""
                         if row[2] != '':
                             name = self.atommap.get(row[1] + str(row[2]))
                         else:
-                            name = self.atommap.get(row[1] + '1')
+                            name = self.atommap.get(f"{row[1]}1")
                         # For l > 1, there is a space between l and
                         # m_l when using spherical functions.
                         shell = row[2 + offset]
@@ -454,12 +454,14 @@ cannot be determined. Rerun without `$molecule read`."""
             svn_revision = line.split()[3]
             line = next(inputfile)
             svn_branch = line.split()[3].replace("/", "_")
-            if "package_version" in self.metadata \
-               and hasattr(self, "parsed_svn_revision") \
-               and not self.parsed_svn_revision:
-                self.metadata["package_version"] = "{}dev+{}-{}".format(
-                    self.metadata["package_version"], svn_branch, svn_revision
-                )
+            if (
+                "package_version" in self.metadata
+                and hasattr(self, "parsed_svn_revision")
+                and not self.parsed_svn_revision
+            ):
+                self.metadata[
+                    "package_version"
+                ] = f"{self.metadata['package_version']}dev+{svn_branch}-{svn_revision}"
                 parsed_version = parse_version(self.metadata["package_version"])
                 assert isinstance(parsed_version, Version)
                 self.set_attribute("package_version", parsed_version)
@@ -725,7 +727,7 @@ cannot be determined. Rerun without `$molecule read`."""
                 elif 'Bohr' in line:
                     convertor = lambda x: utils.convertor(x, 'bohr', 'Angstrom')
                 else:
-                    raise ValueError("Unknown units in coordinate header: {}".format(line))
+                    raise ValueError(f"Unknown units in coordinate header: {line}")
                 self.skip_lines(inputfile, ['cols', 'dashes'])
                 atomelements = []
                 atomcoords = []
@@ -865,7 +867,9 @@ cannot be determined. Rerun without `$molecule read`."""
                         line = next(inputfile)
                     # Is this the end of the file for some reason?
                     except StopIteration:
-                        self.logger.warning('File terminated before end of last SCF! Last error: {}'.format(error))
+                        self.logger.warning(
+                            f"File terminated before end of last SCF! Last error: {error}"
+                        )
                         break
 
                     # We've converged, but still need the last iteration.
@@ -1157,7 +1161,7 @@ cannot be determined. Rerun without `$molecule read`."""
                             elif ttype == 'Y':
                                 sec.append([end, start, contrib])
                             else:
-                                raise ValueError('Unknown transition type: %s' % ttype)
+                                raise ValueError(f"Unknown transition type: {ttype}")
                             line = next(inputfile)
                         etsecs.append(sec)
 

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -62,11 +62,11 @@ class Turbomole(logfileparser.Logfile):
 
     def __str__(self):
         """Return a string representation of the object."""
-        return "Turbomole output file %s" % (self.filename)
+        return f"Turbomole output file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Turbomole("%s")' % (self.filename)
+        return f'Turbomole("{self.filename}")'
 
     def normalisesym(self, label):
         """Normalise the symmetries used by Turbomole.
@@ -151,8 +151,10 @@ class Turbomole(logfileparser.Logfile):
             build_id = version_match.group(4)
                             
             self.metadata["legacy_package_version"] = version
-            self.metadata["package_version"] = "{}.r{}".format(version, build_id) if build_id is not None else version
-                
+            self.metadata["package_version"] = (
+                f"{version}.r{build_id}" if build_id is not None else version
+            )
+
             # We have entered a new module (sub program); reset our success flag.
             self.metadata['success'] = False
         
@@ -276,8 +278,10 @@ class Turbomole(logfileparser.Logfile):
                 
                 # Check we won't loose information converting to int.
                 if total_charge != total_charge_int:
-                    self.logger.warning("Converting non integer total charge '{}' to integer".format(total_charge))
-                
+                    self.logger.warning(
+                        f"Converting non integer total charge '{total_charge}' to integer"
+                    )
+
                 # Set regardless.
                 self.set_attribute("charge", total_charge_int)
 
@@ -806,13 +810,13 @@ class Turbomole(logfileparser.Logfile):
             
         # Look for MP energies.
         for mp_level in range(2,6):
-            if "Final MP{} energy".format(mp_level) in line:
+            if f"Final MP{mp_level} energy" in line:
                 mpenergy = utils.convertor(utils.float(line.split()[5]), 'hartree', 'eV')
                 if mp_level == 2:
                     self.append_attribute('mpenergies', [mpenergy])
                 else:
                     self.mpenergies[-1].append(mpenergy)
-                self.metadata['methods'].append("MP{}".format(mp_level))
+                self.metadata["methods"].append(f"MP{mp_level}")
 
         #  *****************************************************
         #  *                                                   *
@@ -896,7 +900,7 @@ class Turbomole(logfileparser.Logfile):
             else:
                 mult = symm_parts[1].capitalize()
             
-            symmetry = "{}-{}".format(mult, symm_parts[-2].capitalize())
+            symmetry = f"{mult}-{symm_parts[-2].capitalize()}"
             self.append_attribute("etsyms", symmetry)
             
             # Energy should be in cm-1...
@@ -1033,7 +1037,7 @@ class Turbomole(logfileparser.Logfile):
                 else:
                     mult = parts[2]
                     
-                symmetry = "{}-{}".format(mult, parts[1].capitalize())
+                symmetry = f"{mult}-{parts[1].capitalize()}"
                 self.append_attribute("etsyms", symmetry)
                     
                 energy = utils.float(parts[6])
@@ -1315,11 +1319,11 @@ class OldTurbomole(logfileparser.Logfile):
         
     def __str__(self):
         """Return a string representation of the object."""
-        return "Turbomole output file %s" % (self.filename)
+        return f"Turbomole output file {self.filename}"
 
     def __repr__(self):
         """Return a representation of the object."""
-        return 'Turbomole("%s")' % (self.filename)
+        return f'Turbomole("{self.filename}")'
 
     def atlist(self, atstr):
         # turn atstr from atoms section into array
@@ -1541,64 +1545,89 @@ class OldTurbomole(logfileparser.Logfile):
                             d_counter=6
                             
                         for j in range(0, len(basis.symmetries), 1):
-                            if basis.symmetries[j]=='s':
-                                self.aonames.append("%s%d_%d%s" % \
-                                              (pa, counter, s_counter, "S"))
-                                s_counter=s_counter+1
-                            elif basis.symmetries[j]=='p':
-                                self.aonames.append("%s%d_%d%s" % \
-                                              (pa, counter, p_counter, "PX"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                              (pa, counter, p_counter, "PY"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                              (pa, counter, p_counter, "PZ"))
-                                p_counter=p_counter+1
-                            elif basis.symmetries[j]=='d':
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, d_counter, "D 0"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, d_counter, "D+1"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, d_counter, "D-1"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, d_counter, "D+2"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, d_counter, "D-2"))
-                                d_counter=d_counter+1
-                            elif basis.symmetries[j]=='f':
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F 0"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F+1"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F-1"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F+2"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F-2"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "F+3"))
-                                 self.aonames.append("%s%d_%d%s" % \
-                                        (pa, counter, f_counter, "F-3"))
-                            elif basis.symmetries[j]=='g':
-                                self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "G 0"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "G+1"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                       (pa, counter, f_counter, "G-1"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                        (pa, counter, g_counter, "G+2"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, g_counter, "G-2"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                         (pa, counter, g_counter, "G+3"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                          (pa, counter, g_counter, "G-3"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                          (pa, counter, g_counter, "G+4"))
-                                self.aonames.append("%s%d_%d%s" % \
-                                          (pa, counter, g_counter, "G-4"))
+                            if basis.symmetries[j] == "s":
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(s_counter)}{'S'}"
+                                )
+                                s_counter = s_counter + 1
+                            elif basis.symmetries[j] == "p":
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(p_counter)}{'PX'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(p_counter)}{'PY'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(p_counter)}{'PZ'}"
+                                )
+                                p_counter = p_counter + 1
+                            elif basis.symmetries[j] == "d":
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(d_counter)}{'D 0'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(d_counter)}{'D+1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(d_counter)}{'D-1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(d_counter)}{'D+2'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(d_counter)}{'D-2'}"
+                                )
+                                d_counter = d_counter + 1
+                            elif basis.symmetries[j] == "f":
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F 0'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F+1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F-1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F+2'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F-2'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F+3'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'F-3'}"
+                                )
+                            elif basis.symmetries[j] == "g":
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'G 0'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'G+1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(f_counter)}{'G-1'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G+2'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G-2'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G+3'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G-3'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G+4'}"
+                                )
+                                self.aonames.append(
+                                    f"{pa}{int(counter)}_{int(g_counter)}{'G-4'}"
+                                )
                         break
                 counter=counter+1
                 

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -137,7 +137,7 @@ def convertor(value, fromunits, tounits):
         "hartree/bohr2_to_mDyne/angstrom": lambda x: x * 8.23872350 / 0.5291772109
     }
 
-    return _convertor["%s_to_%s" % (fromunits, tounits)](value)
+    return _convertor[f"{fromunits}_to_{tounits}"](value)
 
 def _get_rmat_from_vecs(a, b):
     """Get rotation matrix from two 3D vectors, a and b

--- a/cclib/progress/textprogress.py
+++ b/cclib/progress/textprogress.py
@@ -36,12 +36,12 @@ class TextProgress:
             mystr = "\r["
             prog = int(self.progress / 10)
             mystr += prog * "=" + (10-prog) * "-"
-            mystr += "] %3i" % self.progress + "%"
+            mystr += f"] {int(self.progress):3}%"
 
             if text:
-                mystr += "    "+text
+                mystr += f"    {text}"
 
-            sys.stdout.write("\r" + 70 * " ")
+            sys.stdout.write(f"\r{70 * ' '}")
             sys.stdout.flush()
             sys.stdout.write(mystr)
             sys.stdout.flush()

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -67,7 +67,9 @@ def main():
                         help=('overwrite output file in case it already exists'))
     args = parser.parse_args()
     if args.output is not None and not args.force and os.path.exists(args.output):
-        parser.exit(1, 'failure: exiting to avoid overwriting existing file "{}"\n'.format(args.output))
+        parser.exit(
+            1, f'failure: exiting to avoid overwriting existing file "{args.output}"\n'
+        )
 
     process_logfiles(args.compchemlogfiles, args.output, args.identifier)
 

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -113,8 +113,10 @@ def ccget():
             fuzzy_attr = difflib.get_close_matches(arg, ccData._attrlist, n=1, cutoff=0.85)
             if len(fuzzy_attr) > 0:
                 fuzzy_attr = fuzzy_attr[0]
-                logging.warning("Attribute '{0}' not found, but attribute '{1}' is close. "
-                    "Using '{1}' instead.".format(arg, fuzzy_attr))
+                logging.warning(
+                    f"Attribute '{arg}' not found, but attribute '{fuzzy_attr}' is close. "
+                    f"Using '{fuzzy_attr}' instead."
+                )
                 arg = fuzzy_attr
         if arg in ccData._attrlist:
             attrnames.append(arg)
@@ -125,7 +127,7 @@ def ccget():
             if wildcardmatches:
                 filenames.extend(wildcardmatches)
             else:
-                print("%s is neither a filename nor an attribute name." % arg)
+                print(f"{arg} is neither a filename nor an attribute name.")
                 parser.print_usage()
                 parser.exit(1)
 
@@ -153,7 +155,7 @@ def ccget():
     for filename in filenames:
 
         if multifile:
-            name = ", ".join(filename[:-1]) + " and " + filename[-1]
+            name = f"{', '.join(filename[:-1])} and {filename[-1]}"
         else:
             name = filename
 
@@ -172,30 +174,30 @@ def ccget():
         if cjsonfile:
             kwargs['cjson'] = True
 
-        print("Attempting to read %s" % name)
+        print(f"Attempting to read {name}")
         data = ccread(filename, **kwargs)
 
         if data is None:
-            print("Cannot figure out the format of '%s'" % name)
+            print(f"Cannot figure out the format of '{name}'")
             print("Report this to the cclib development team if you think it is an error.")
-            print("\n" + parser.format_usage())
+            print(f"\n{parser.format_usage()}")
             parser.exit(1)
 
         if showattr:
-            print("cclib can parse the following attributes from %s:" % name)
+            print(f"cclib can parse the following attributes from {name}:")
             if cjsonfile:
                 for key in data:
                     print(key)
                 break
             for attr in data._attrlist:
                 if hasattr(data, attr):
-                    print("  %s" % attr)
+                    print(f"  {attr}")
         else:
             invalid = False
             for attr in attrnames:
                 if cjsonfile:
                     if attr in data:
-                        print("%s:\n%s" % (attr, data[attr]))
+                        print(f"{attr}:\n{data[attr]}")
                         continue
                 else:
                     if hasattr(data, attr):
@@ -209,7 +211,7 @@ def ccget():
                             pprint(attr_val)
                         continue
 
-                print("Could not parse %s from this file." % attr)
+                print(f"Could not parse {attr} from this file.")
                 invalid = True
             if invalid:
                 parser.print_help()

--- a/cclib/scripts/ccwrite.py
+++ b/cclib/scripts/ccwrite.py
@@ -66,11 +66,13 @@ def main():
         if future:
             ccopen_kwargs['future'] = True
 
-        print("Attempting to parse {}".format(filename))
+        print(f"Attempting to parse {filename}")
         log = ccopen(filename, **ccopen_kwargs)
 
         if not log:
-            print("Cannot figure out what type of computational chemistry output file '{}' is.".format(filename))
+            print(
+                f"Cannot figure out what type of computational chemistry output file '{filename}' is."
+            )
             print("Report this to the cclib development team if you think this is an error.")
             sys.exit()
 
@@ -80,9 +82,9 @@ def main():
             log.logger.setLevel(logging.ERROR)
         data = log.parse()
 
-        print("cclib can parse the following attributes from {}:".format(filename))
-        hasattrs = ['  {}'.format(attr) for attr in ccData._attrlist if hasattr(data, attr)]
-        print('\n'.join(hasattrs))
+        print(f"cclib can parse the following attributes from {filename}:")
+        hasattrs = [f"  {attr}" for attr in ccData._attrlist if hasattr(data, attr)]
+        print("\n".join(hasattrs))
 
         # Write out to disk.
         outputdest = '.'.join([os.path.splitext(os.path.basename(filename))[0], outputtype])

--- a/cclib/scripts/cda.py
+++ b/cclib/scripts/cda.py
@@ -31,7 +31,7 @@ def main():
 
     if retval:
 
-        print("Charge decomposition analysis of {}\n".format(args.file1))
+        print(f"Charge decomposition analysis of {args.file1}\n")
 
         if len(data1.homos) == 2:
             print("ALPHA SPIN:")
@@ -48,22 +48,18 @@ def main():
 
             for i in range(len(fa.donations[spin])):
 
-                print("%4i: %7.3f %7.3f %7.3f %7.3f" % \
-                        (i + 1, fa.donations[spin][i],
-                                fa.bdonations[spin][i],
-                                fa.repulsions[spin][i],
-                                fa.residuals[spin][i]))
+                print(
+                    f"{int(i + 1):4}: {fa.donations[spin][i]:7.3f} {fa.bdonations[spin][i]:7.3f} {fa.repulsions[spin][i]:7.3f} {fa.residuals[spin][i]:7.3f}"
+                )
 
                 if i == data1.homos[spin]:
                     print("------ HOMO - LUMO gap ------")
                     
 
             print("-------------------------------------")
-            print(" T:   %7.3f %7.3f %7.3f %7.3f" % \
-                    (fa.donations[spin].sum(),
-                        fa.bdonations[spin].sum(),
-                        fa.repulsions[spin].sum(),
-                        fa.residuals[spin].sum()))
+            print(
+                f" T:   {fa.donations[spin].sum():7.3f} {fa.bdonations[spin].sum():7.3f} {fa.repulsions[spin].sum():7.3f} {fa.residuals[spin].sum():7.3f}"
+            )
 
 
 if __name__ == '__main__':

--- a/doc/sphinx/attributes.py
+++ b/doc/sphinx/attributes.py
@@ -48,7 +48,7 @@ def generate_attributes():
             aunit = ''
 
         for i in range(1, 4):
-            atype = atype.replace('[%i]' % i, ' of rank %i' % i)
+            atype = atype.replace(f"[{int(i)}]", f" of rank {int(i)}")
 
         names.append(attr)
         descriptions.append(desc)
@@ -63,7 +63,7 @@ def generate_attributes():
 
     dashes = "    "
     for w in [wattr, wdesc, wunit, wtype]:
-        dashes += "="*(w-1) + " "
+        dashes += f"{'=' * (w - 1)} "
     header = "    "
     header += "Name".ljust(wattr)
     header += "Description".ljust(wdesc)
@@ -77,17 +77,17 @@ def generate_attributes():
         # Print the line with columns align to the table. Note that
         # the description sometimes contain Unicode characters, so
         # decode-encode when justifying to get the correct length.
-        attr = ("`%s`_" % attr).ljust(wattr)
+        attr = f"`{attr}`_".ljust(wattr)
         desc = desc.ljust(wdesc)
         aunit = aunit.ljust(wunit)
 
-        lines.append("    " + attr + desc + aunit + atype)
+        lines.append(f"    {attr}{desc}{aunit}{atype}")
 
     lines.append(dashes)
     lines.append("")
 
     for n in names:
-        lines.append(".. _`%s`: data_notes.html#%s" % (n, n))
+        lines.append(f".. _`{n}`: data_notes.html#{n}")
 
     return "\n".join(lines)
 

--- a/doc/sphinx/coverage.py
+++ b/doc/sphinx/coverage.py
@@ -41,7 +41,7 @@ def generate_coverage():
     from test.test_data import (all_modules, all_parsers, parser_names, DataSuite)
     import inspect
     ds_args = inspect.getfullargspec(DataSuite.__init__).args
-    logpath = thispath + "/coverage.tests.log"
+    logpath = f"{thispath}/coverage.tests.log"
     try:
         with open(logpath, "w") as flog:
             stdout_backup = sys.stdout
@@ -64,8 +64,8 @@ def generate_coverage():
 
     ncols = len(parser_names) + 1
     colwidth = 4 + max(len(attribute) for attribute in attributes)
-    colfmt = "%%-%is" % colwidth
-    dashes = ("=" * (colwidth - 1) + " ") * ncols
+    colfmt = f"%-{int(colwidth)}s"
+    dashes = f"{'=' * (colwidth - 1)} " * ncols
 
     lines.append(dashes)
     lines.append(colfmt * ncols % tuple(["attributes"] + parser_names))
@@ -106,13 +106,13 @@ def generate_coverage():
                     parsed[ip] = "N/P"
                 else:
                     parsed[ip] = "T/D"
-        lines.append(colfmt*ncols % tuple(["`%s`_" % attr] + parsed))
+        lines.append(colfmt * ncols % tuple([f"`{attr}`_"] + parsed))
 
     lines.append(dashes)
     lines.append("")
 
     for attr in attributes:
-        lines.append(".. _`%s`: data_notes.html#%s" % (attr, attr))
+        lines.append(f".. _`{attr}`: data_notes.html#{attr}")
 
     return "\n".join(lines)
 

--- a/manifest.py
+++ b/manifest.py
@@ -23,6 +23,6 @@ for folder in folders:
 
 for f in files:
     if not os.path.isfile(f):
-        print("%s does not exist" % f)
+        print(f"{f} does not exist")
 
 print("\n".join(files), file=open("MANIFEST", "w"))

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -50,7 +50,7 @@ class OpenbabelTest(unittest.TestCase):
 
     def test_readfile(self):
         """Try to load an XYZ file with uracyl through Openbabel"""
-        data = cclib2openbabel.readfile(self.path + "/uracil.xyz", "XYZ")
+        data = cclib2openbabel.readfile(f"{self.path}/uracil.xyz", "XYZ")
         assert data.natom == 12
 
 

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -45,8 +45,7 @@ class GenericBasisTest(unittest.TestCase):
         """Are the name of basis set functions acceptable?"""
         for atom in self.data.gbasis:
             for fns in atom:
-                self.assertTrue(fns[0] in self.names,
-                             "%s not one of S or P" % fns[0])
+                self.assertTrue(fns[0] in self.names, f"{fns[0]} not one of S or P")
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testsizeofbasis(self):

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -88,7 +88,9 @@ class GenericCISTest(unittest.TestCase):
                         found = True
                         self.assertAlmostEqual(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
                 if not found:
-                    self.fail("Excitation %i->%s not found (singlet state %i)" %(exc[0], exc[1], i))
+                    self.fail(
+                        f"Excitation {int(exc[0])}->{exc[1]} not found (singlet state {int(i)})"
+                    )
         # Not all programs do triplets (i.e. Jaguar).
         if len(triplets) >= 4:
             for i in range(4):
@@ -99,7 +101,9 @@ class GenericCISTest(unittest.TestCase):
                             found = True
                             self.assertAlmostEqual(abs(s[2]), abs(exc[2]), delta=self.etsecs_precision)
                     if not found:
-                        self.fail("Excitation %i->%s not found (triplet state %i)" %(exc[0], exc[1], i))
+                        self.fail(
+                            f"Excitation {int(exc[0])}->{exc[1]} not found (triplet state {int(i)})"
+                        )
 
 
 class GAMESSCISTest(GenericCISTest):

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -63,14 +63,16 @@ class GenericGeoOptTest(unittest.TestCase):
         """Are atomcoords consistent with natom and Angstroms?"""
         natom = len(self.data.atomcoords[0])
         ref = self.data.natom
-        msg = "natom is %d but len(atomcoords[0]) is %d" % (ref, natom)
+        msg = f"natom is {int(ref)} but len(atomcoords[0]) is {int(natom)}"
         self.assertEqual(natom, ref, msg)
 
     def testatomcoords_units(self):
         """Are atomcoords consistent with Angstroms?"""
         min_carbon_dist = get_minimum_carbon_separation(self.data)
         dev = abs(min_carbon_dist - 1.34)
-        self.assertTrue(dev < 0.15, "Minimum carbon dist is %.2f (not 1.34)" % min_carbon_dist)
+        self.assertTrue(
+            dev < 0.15, f"Minimum carbon dist is {min_carbon_dist:.2f} (not 1.34)"
+        )
 
     @skipForParser('Molcas', 'The parser is still being developed so we skip this test')
     def testcharge_and_mult(self):
@@ -101,7 +103,7 @@ class GenericGeoOptTest(unittest.TestCase):
     def testhomos(self):
         """Is the index of the HOMO equal to 34?"""
         ref = numpy.array([34], "i")
-        msg = "%s != array([34], 'i')" % numpy.array_repr(self.data.homos)
+        msg = f"{numpy.array_repr(self.data.homos)} != array([34], 'i')"
         numpy.testing.assert_array_equal(self.data.homos, ref, msg)
 
     @skipForParser('MOPAC', 'The scfvalues attribute is not parsed yet')
@@ -115,7 +117,7 @@ class GenericGeoOptTest(unittest.TestCase):
         scf = self.data.scfenergies[-1]
         ref = self.b3lyp_energy
         tol = self.b3lyp_tolerance
-        msg = "Final SCF energy: %f not %i +- %ieV" %(scf, ref, tol)
+        msg = f"Final SCF energy: {scf:f} not {int(ref)} +- {int(tol)}eV"
         self.assertAlmostEqual(scf, ref, delta=40, msg=msg)
 
     def testscfenergydim(self):
@@ -136,7 +138,7 @@ class GenericGeoOptTest(unittest.TestCase):
         """Are atomcoords consistent with geovalues?"""
         count_geovalues = len(self.data.geovalues)
         count_coords = len(self.data.atomcoords) - self.extracoords
-        msg = "len(atomcoords) is %d but len(geovalues) is %d" % (count_coords, count_geovalues)
+        msg = f"len(atomcoords) is {int(count_coords)} but len(geovalues) is {int(count_geovalues)}"
         self.assertEqual(count_geovalues, count_coords, msg)
 
     @skipForParser('MOPAC', 'Not implemented.')

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -83,7 +83,9 @@ class GenericSPTest(unittest.TestCase):
         """Are atomcoords consistent with Angstroms?"""
         min_carbon_dist = get_minimum_carbon_separation(self.data)
         dev = abs(min_carbon_dist - 1.34)
-        self.assertTrue(dev < 0.03, "Minimum carbon dist is %.2f (not 1.34)" % min_carbon_dist)
+        self.assertTrue(
+            dev < 0.03, f"Minimum carbon dist is {min_carbon_dist:.2f} (not 1.34)"
+        )
 
     @skipForParser('Molcas', 'missing mult')
     def testcharge_and_mult(self):
@@ -124,7 +126,7 @@ class GenericSPTest(unittest.TestCase):
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass?"""
         mm = 1000*sum(self.data.atommasses)
-        msg = "Molecule mass: %f not %f +- %fmD" % (mm, self.molecularmass, self.mass_precision)
+        msg = f"Molecule mass: {mm:f} not {self.molecularmass:f} +- {self.mass_precision:f}mD"
         self.assertAlmostEqual(mm, self.molecularmass, delta=self.mass_precision, msg=msg)
 
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
@@ -143,7 +145,11 @@ class GenericSPTest(unittest.TestCase):
 
     def testhomos(self):
         """Is the index of the HOMO equal to 34?"""
-        numpy.testing.assert_array_equal(self.data.homos, numpy.array([34],"i"), "%s != array([34],'i')" % numpy.array_repr(self.data.homos))
+        numpy.testing.assert_array_equal(
+            self.data.homos,
+            numpy.array([34], "i"),
+            f"{numpy.array_repr(self.data.homos)} != array([34],'i')",
+        )
 
     @skipForParser('FChk', 'Formatted Checkpoint files do not have a section for SCF energy')
     def testscfvaluetype(self):

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -84,7 +84,7 @@ class GenericSPunTest(unittest.TestCase):
 
     def testhomos(self):
         """Are the homos correct?"""
-        msg = "%s != array([34,33],'i')" % numpy.array_repr(self.data.homos)
+        msg = f"{numpy.array_repr(self.data.homos)} != array([34,33],'i')"
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34,33],"i"), msg)
 
     def testmoenergies(self):
@@ -123,7 +123,7 @@ class GenericROSPTest(GenericSPunTest):
         """Are the HOMO indices equal to 34 and 33 (one more alpha electron
         than beta electron)?
         """
-        msg = "%s != array([34, 33], 'i')" % numpy.array_repr(self.data.homos)
+        msg = f"{numpy.array_repr(self.data.homos)} != array([34, 33], 'i')"
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34, 33], "i"), msg)
 
     @skipForParser('QChem', 'prints 2 sets of different MO energies?')

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -278,8 +278,10 @@ class QChemIRTest(GenericIRTest):
 
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
-        mm = 1000*sum(self.data.atommasses)
-        self.assertAlmostEqual(mm, 130078.25, delta=0.1, msg = "Molecule mass: %f not 130078 +- 0.1mD" % mm)
+        mm = 1000 * sum(self.data.atommasses)
+        self.assertAlmostEqual(
+            mm, 130078.25, delta=0.1, msg=f"Molecule mass: {mm:f} not 130078 +- 0.1mD"
+        )
 
     def testhessian(self):
         """Do the frequencies from the Hessian match the printed frequencies?"""
@@ -299,8 +301,10 @@ class GamessIRTest(GenericIRTest):
 
     def testatommasses(self):
         """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
-        mm = 1000*sum(self.data.atommasses)
-        self.assertAlmostEqual(mm, 130078.25, delta=0.1, msg = "Molecule mass: %f not 130078 +- 0.1mD" % mm)
+        mm = 1000 * sum(self.data.atommasses)
+        self.assertAlmostEqual(
+            mm, 130078.25, delta=0.1, msg=f"Molecule mass: {mm:f} not 130078 +- 0.1mD"
+        )
 
     def testtemperature(self):
         """Is the temperature 298.15 K?"""

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -108,12 +108,12 @@ class MOLDENTest(unittest.TestCase):
         filenames = ['dvb_un_sp', 'C_bigbasis', 'water_mp2']
         for fn in filenames:
             fpath = os.path.join(__datadir__,
-                                 "data/GAMESS/basicGAMESS-US2018/"+fn+".out")
+                                 f"data/GAMESS/basicGAMESS-US2018/{fn}.out")
             data = cclib.io.ccread(fpath)
             cclib_out = cclib.io.moldenwriter.MOLDEN(data).generate_repr()
             # Reformat cclib's output to remove extra spaces.
             cclib_out_formatted = MoldenReformatter(cclib_out).reformat()
-            fpath = os.path.join(__testdir__, "data/molden5.7_"+fn+".molden")
+            fpath = os.path.join(__testdir__, f"data/molden5.7_{fn}.molden")
             with open(fpath) as handle:
                 molden_out = handle.read()
             # Reformat Molden's output to remove extra spaces,

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -39,16 +39,14 @@ def printResults():
     spin = 0
     for i in range(len(fa.donations[0])):
 
-        print("%2i: %7.3f %7.3f %7.3f" % (i,
-                                            fa.donations[spin][i],
-                                            fa.bdonations[spin][i],
-                                            fa.repulsions[spin][i]))
-
+        print(
+            f"{int(i):2}: {fa.donations[spin][i]:7.3f} {fa.bdonations[spin][i]:7.3f} {fa.repulsions[spin][i]:7.3f}"
+        )
 
     print("---------------------------")
-    print("T:  %7.3f %7.3f %7.3f" % (fa.donations[0].sum(),
-                                        fa.bdonations[0].sum(),
-                                        fa.repulsions[0].sum()))
+    print(
+        f"T:  {fa.donations[0].sum():7.3f} {fa.bdonations[0].sum():7.3f} {fa.repulsions[0].sum():7.3f}"
+    )
     print("\n\n")
 
 

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -34,7 +34,7 @@ class DDEC6Test(unittest.TestCase):
             self.data, self.logfile = getdatafile(Psi4, "basicPsi4-1.2.1", ["water_mp2.out"])
         else:
             self.data = ccread(
-                os.path.join(os.path.dirname(os.path.realpath(__file__)), molecule_name + ".out")
+                os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{molecule_name}.out")
             )
 
     def testmissingrequiredattributes(self):

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -32,7 +32,7 @@ class MBOTest(unittest.TestCase):
         mbo.logger.setLevel(logging.ERROR)
         mbo.calculate()
 
-        e_mbo = numpy.loadtxt(os.path.dirname(os.path.realpath(__file__)) + "/dvb_sp.mbo")
+        e_mbo = numpy.loadtxt(f"{os.path.dirname(os.path.realpath(__file__))}/dvb_sp.mbo")
         self.assertTrue(numpy.all(mbo.fragresults[0] >= e_mbo - 0.25))
         self.assertTrue(numpy.all(mbo.fragresults[0] <= e_mbo + 0.25))
 
@@ -44,7 +44,7 @@ class MBOTest(unittest.TestCase):
         mbo.logger.setLevel(logging.ERROR)
         mbo.calculate()
 
-        e_mbo = numpy.loadtxt(os.path.dirname(os.path.realpath(__file__)) + "/dvb_un_sp.mbo")
+        e_mbo = numpy.loadtxt(f"{os.path.dirname(os.path.realpath(__file__))}/dvb_un_sp.mbo")
         bond_orders = mbo.fragresults[0] + mbo.fragresults[1]
         self.assertTrue(numpy.all(bond_orders >= e_mbo - 0.30))
         self.assertTrue(numpy.all(bond_orders <= e_mbo + 0.30))

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -153,7 +153,7 @@ class GaussianBickelhauptTest(unittest.TestCase):
         bpa.logger.setLevel(logging.ERROR)
         bpa.calculate()
         
-        e_bpa = numpy.loadtxt(os.path.dirname(os.path.realpath(__file__)) + "/dvb_sp.bpa")
+        e_bpa = numpy.loadtxt(f"{os.path.dirname(os.path.realpath(__file__))}/dvb_sp.bpa")
         self.assertTrue(numpy.all(bpa.fragcharges >= e_bpa - 0.05))
         self.assertTrue(numpy.all(bpa.fragcharges <= e_bpa + 0.05))
         
@@ -164,8 +164,8 @@ class GaussianBickelhauptTest(unittest.TestCase):
         bpa.logger.setLevel(logging.ERROR)
         bpa.calculate()
         
-        e_bpaalpha = numpy.loadtxt(os.path.dirname(os.path.realpath(__file__)) + "/dvb_un_sp.bpa")
-        e_bpaspin = numpy.loadtxt(os.path.dirname(os.path.realpath(__file__)) + "/dvb_un_sp.bpaspin")
+        e_bpaalpha = numpy.loadtxt(f"{os.path.dirname(os.path.realpath(__file__))}/dvb_un_sp.bpa")
+        e_bpaspin = numpy.loadtxt(f"{os.path.dirname(os.path.realpath(__file__))}/dvb_un_sp.bpaspin")
         
         self.assertTrue(numpy.all(bpa.fragcharges >= e_bpaalpha - 0.05))
         self.assertTrue(numpy.all(bpa.fragcharges <= e_bpaalpha + 0.05))

--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -73,7 +73,7 @@ class VolumeTest(unittest.TestCase):
         # First six rows are information about the coordinates of the grid and comments.
         tmp = []
 
-        with open(os.path.dirname(os.path.realpath(__file__)) + "/water_mp2.cube") as f:
+        with open(f"{os.path.dirname(os.path.realpath(__file__))}/water_mp2.cube") as f:
             lines = f.readlines()
             for line in lines[6 : len(lines)]:
                 tmp.extend(line.split())

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -69,7 +69,7 @@ class FileWrapperTest(unittest.TestCase):
         ]
         get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
         for lf in logfiles:
-            path = "%s/%s" % (__datadir__, lf)
+            path = f"{__datadir__}/{lf}"
             expected_attributes = get_attributes(cclib.io.ccread(path))
             with open(path) as handle:
                 contents = handle.read()
@@ -104,8 +104,12 @@ class LogfileTest(unittest.TestCase):
         parser.parse()
         try:
             parser.logger.error.assert_called_once()
-        except AttributeError: # assert_called_once is not availible until python 3.6
-            self.assertEqual(parser.logger.error.call_count, 1, "Expected mock to have been called once. Called {} times.".format(parser.logger.error.call_count))
+        except AttributeError:  # assert_called_once is not availible until python 3.6
+            self.assertEqual(
+                parser.logger.error.call_count,
+                1,
+                f"Expected mock to have been called once. Called {parser.logger.error.call_count} times.",
+            )
 
 
 if __name__ == "__main__":

--- a/test/regression.py
+++ b/test/regression.py
@@ -73,7 +73,7 @@ from cclib.io import ccopen, ccread, moldenwriter
 # This assume that the cclib-data repository is located at a specific location
 # within the cclib repository. It would be better to figure out a more natural
 # way to import the relevant tests from cclib here.
-test_dir = os.path.realpath(os.path.dirname(__file__)) + "/../../test"
+test_dir = f"{os.path.realpath(os.path.dirname(__file__))}/../../test"
 # This is safer than sys.path.append, and isn't sys.path.insert(0, ...) so
 # virtualenvs work properly. See https://stackoverflow.com/q/10095037.
 sys.path.insert(1, os.path.abspath(test_dir))
@@ -3507,7 +3507,7 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
 
     # Create the regression test functions from logfiles that were old unittests.
     for path, test_class in old_unittests.items():
-        funcname = "test" + normalisefilename(path)
+        funcname = f"test{normalisefilename(path)}"
         func = make_regression_from_old_unittest(test_class)
         globals()[funcname] = func
 
@@ -3515,7 +3515,7 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
     # to any regression file name.
     orphaned_tests = []
     for pn in parser_names:
-        prefix = "test%s_%s" % (pn, pn)
+        prefix = f"test{pn}_{pn}"
         tests = [fn for fn in globals() if fn[:len(prefix)] == prefix]
         normalized = [normalisefilename(fn.replace(__regression_dir__, '')) for fn in filenames[pn]]
         orphaned = [t for t in tests if t[4:] not in normalized]
@@ -3548,10 +3548,10 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
 
             parser_total += 1
             if parser_total == 1:
-                print("Are the %s files ccopened and parsed correctly?" % pn)
+                print(f"Are the {pn} files ccopened and parsed correctly?")
 
             total += 1
-            print("  %s ..."  % fname, end=" ")
+            print(f"  {fname} ...", end=" ")
 
             # Check if there is a test (needs to be an appropriately named function).
             # If not, there can also be a test that does not assume the file is
@@ -3560,10 +3560,10 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
             test_this = test_noparse = False
             fname_norm = normalisefilename(fname.replace(__regression_dir__, ''))
 
-            funcname = "test" + fname_norm
+            funcname = f"test{fname_norm}"
             test_this = funcname in globals()
 
-            funcname_noparse = "testnoparse" + fname_norm
+            funcname_noparse = f"testnoparse{fname_norm}"
             test_noparse = not test_this and funcname_noparse in globals()
 
             if not test_noparse:
@@ -3596,7 +3596,7 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
                                     res = eval(funcname)(logfile)
                                     if res and len(res.failures) > 0:
                                         failures += len(res.failures)
-                                        print("%i test(s) failed" % len(res.failures))
+                                        print(f"{len(res.failures)} test(s) failed")
                                         if opt_traceback:
                                             for f in res.failures:
                                                 print("Failure for", f[0])
@@ -3604,7 +3604,7 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
                                         continue
                                     elif res and len(res.errors) > 0:
                                         errors += len(res.errors)
-                                        print("{:d} test(s) had errors".format(len(res.errors)))
+                                        print(f"{len(res.errors):d} test(s) had errors")
                                         if opt_traceback:
                                             for f in res.errors:
                                                 print("Error for", f[0])
@@ -3639,24 +3639,28 @@ def test_regressions(which=[], opt_traceback=True, regdir=__regression_dir__, lo
         if parser_total:
             print()
 
-    print("Total: %d   Failed: %d  Errors: %d" % (total, failures, errors))
+    print(f"Total: {int(total)}   Failed: {int(failures)}  Errors: {int(errors)}")
     if not opt_traceback and failures + errors > 0:
         print("\nFor more information on failures/errors, add --traceback as an argument.")
 
     # Show these warnings at the end, so that they're easy to notice. Notice that the lists
     # were populated at the beginning of this function.
     if len(missing_on_disk) > 0:
-        print("\nWARNING: You are missing %d regression file(s)." % len(missing_on_disk))
+        print(f"\nWARNING: You are missing {len(missing_on_disk)} regression file(s).")
         print("Run regression_download.sh in the ../data directory to update.")
         print("Missing files:")
         print("\n".join(missing_on_disk))
     if len(missing_in_list) > 0:
-        print("\nWARNING: The list in 'regressionfiles.txt' is missing %d file(s)." % len(missing_in_list))
+        print(
+            f"\nWARNING: The list in 'regressionfiles.txt' is missing {len(missing_in_list)} file(s)."
+        )
         print("Add these files paths to the list and commit the change.")
         print("Missing files:")
         print("\n".join(missing_in_list))
     if len(orphaned_tests) > 0:
-        print("\nWARNING: There are %d orphaned regression test functions." % len(orphaned_tests))
+        print(
+            f"\nWARNING: There are {len(orphaned_tests)} orphaned regression test functions."
+        )
         print("Please make sure these function names correspond to regression files:")
         print("\n".join(orphaned_tests))
 

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -41,15 +41,17 @@ module_names = [
     "MP", "CC", "CI", "TD", "TDun",             # Post-SCF calculations.
     "BOMD", "NMR", "Polar", "Scan", "vib"       # Other property calculations.
 ]
-all_modules = {tn: importlib.import_module('.data.test' + tn, package='test')
-               for tn in module_names}
+all_modules = {
+    tn: importlib.import_module(f".data.test{tn}", package="test")
+    for tn in module_names
+}
 
 
 def gettestdata():
     """Return a dict of the test file data."""
 
     testdatadir = os.path.dirname(os.path.realpath(__file__))
-    with open(testdatadir + '/testdata') as testdatafile:
+    with open(f"{testdatadir}/testdata") as testdatafile:
         lines = testdatafile.readlines()
 
     # Remove blank lines and those starting with '#'.
@@ -173,8 +175,8 @@ class DataSuite:
             description = ''
             if not self.silent:
                 print("", file=stream_test)
-                description = "%s/%s: %s" % (td['subdir'], ",".join(td['files']), test.__doc__)
-                print("*** %s ***" % description, file=self.stream)
+                description = f"{td['subdir']}/{','.join(td['files'])}: {test.__doc__}"
+                print(f"*** {description} ***", file=self.stream)
 
             test.data, test.logfile = getdatafile(
                 parser, td['subdir'], td['files'], stream=self.stream, loglevel=self.loglevel,
@@ -201,8 +203,12 @@ class DataSuite:
             self.perpackage[td['parser']][3] += len(getattr(results, 'skipped', []))
 
             self.alltests.append(test)
-            self.errors.extend([description + "\n" + "".join(map(str, e)) for e in results.errors])
-            self.failures.extend([description + "\n" + "".join(map(str, f)) for f in results.failures])
+            self.errors.extend(
+                [f"{description}\n{''.join(map(str, e))}" for e in results.errors]
+            )
+            self.failures.extend(
+                [f"{description}\n{''.join(map(str, f))}" for f in results.failures]
+            )
 
         if self.terse:
             devnull.close()
@@ -234,8 +240,10 @@ class DataSuite:
                 total[i] += l[i]
 
         print("\n********* SUMMARY OF EVERYTHING **************", file=self.stream)
-        print("TOTAL: %d\tPASSED: %d\tFAILED: %d\tERRORS: %d\tSKIPPED: %d" \
-                %(total[0], total[0]-(total[1]+total[2]+total[3]), total[2], total[1], total[3]), file=self.stream)
+        print(
+            f"TOTAL: {int(total[0])}\tPASSED: {int(total[0] - (total[1] + total[2] + total[3]))}\tFAILED: {int(total[2])}\tERRORS: {int(total[1])}\tSKIPPED: {int(total[3])}",
+            file=self.stream,
+        )
 
     def visualtests(self, stream=sys.stdout):
         """These are not formal tests -- but they should be eyeballed."""
@@ -260,10 +268,31 @@ class DataSuite:
 
         print("\n*** Visual tests ***", file=self.stream)
         print("MO energies of optimised dvb", file=self.stream)
-        print("      ", "".join(["%-12s" % pn for pn in parser_names]), file=self.stream)
-        print("HOMO", "   ".join(["%+9.4f" % out.moenergies[0][out.homos[0]] for out in output]), file=self.stream)
-        print("LUMO", "   ".join(["%+9.4f" % out.moenergies[0][out.homos[0]+1] for out in output]), file=self.stream)
-        print("H-L ", "   ".join(["%9.4f" % (out.moenergies[0][out.homos[0]+1]-out.moenergies[0][out.homos[0]],) for out in output]), file=self.stream)
+        print(
+            "      ", "".join([f"{pn:12s}" for pn in parser_names]), file=self.stream
+        )
+        print(
+            "HOMO",
+            "   ".join([f"{out.moenergies[0][out.homos[0]]:+9.4f}" for out in output]),
+            file=self.stream,
+        )
+        print(
+            "LUMO",
+            "   ".join(
+                [f"{out.moenergies[0][out.homos[0] + 1]:+9.4f}" for out in output]
+            ),
+            file=self.stream,
+        )
+        print(
+            "H-L ",
+            "   ".join(
+                [
+                    f"{out.moenergies[0][out.homos[0] + 1] - out.moenergies[0][out.homos[0]]:9.4f}"
+                    for out in output
+                ]
+            ),
+            file=self.stream,
+        )
 
 
 def test_all(parsers, modules, terse, silent, loglevel, summary, visual_tests):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -36,8 +36,7 @@ class FloatTest(unittest.TestCase):
 class ConvertorTest(unittest.TestCase):
 
     def test_convertor(self):
-        self.assertEqual("%.3f" % utils.convertor(8.0, "eV", "wavenumber"),
-                         "64524.354")
+        self.assertEqual(f"{utils.convertor(8.0, 'eV', 'wavenumber'):.3f}", "64524.354")
 
 
 class GetRotationTest(unittest.TestCase):


### PR DESCRIPTION
I did some profiling on the regression test set and realized `.format()` calls incur a considerable performance penalty (~10% of the whole runtime for the regression test set!). So I changed everything to f-strings (only Python 3.6+ though).

## Profiling

```
$ git checkout upstream/master
$ python3 -m cProfile -o upstream.pstats -m test.regression
...
$ python3 -m pstats upstream.pstats
Welcome to the profile statistics browser.
upstream.pstats% strip
upstream.pstats% sort time
upstream.pstats% stats 10
Fri Mar 25 21:47:13 2022    upstream.pstats

         332588011 function calls (327605908 primitive calls) in 135.552 seconds

   Ordered by: internal time
   List reduced from 4242 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1562678   36.925    0.000   63.220    0.000 gaussianparser.py:170(extract)
  1783834   12.959    0.000   25.040    0.000 orcaparser.py:79(extract)
 43724395    8.860    0.000    8.860    0.000 {method 'format' of 'str' objects}
 91811535    8.855    0.000    8.855    0.000 {method 'lower' of 'str' objects}
   607366    4.901    0.000    7.767    0.000 adfparser.py:99(extract)
      531    4.820    0.009  132.533    0.250 logfileparser.py:267(parse)
  9789736    4.400    0.000    7.429    0.000 logfileparser.py:90(next)
   404827    3.967    0.000    6.780    0.000 gamessparser.py:80(extract)
 45795664    3.900    0.000    3.900    0.000 {method 'strip' of 'str' objects}
14473526/9965014    3.130    0.000    6.701    0.000 {built-in method builtins.next}

```

[The profile output.](https://github.com/cclib/cclib/files/8354420/upstream.zip)

## Actual benchmarks

### Baseline

upstream `master` branch (f4f95c800cd5681adb2ba693394aa571372544b6):

```
$ git checkout upstream/master
$ hyperfine 'python3 -m test.regression' --warmup 2 --min-runs 7
Benchmark 1: python3 -m test.regression
  Time (mean ± σ):     83.120 s ±  0.575 s    [User: 83.487 s, System: 2.399 s]
  Range (min … max):   82.359 s … 83.677 s    7 runs

```

### This pull request

`use-f-str`:

```
$ git checkout use-f-str
$ hyperfine 'python3 -m test.regression' --warmup 2 --min-runs 7
Benchmark 1: python3 -m test.regression
  Time (mean ± σ):     77.278 s ±  0.528 s    [User: 77.663 s, System: 2.376 s]
  Range (min … max):   76.615 s … 78.074 s    7 runs

```

Which is an improvement of 7.6% (±1.0%) overall.

## Reproducing

```console
$ cargo install hyperfine  # benchmarking tool, requires Rust
$ hyperfine -V
hyperfine 1.13.0
$ git clone git@github.com:cclib/cclib.git
$ cd cclib/data
$ source regression_download.sh
$ cd ..
$ python3 -m test.regression
...
Total: 531   Failed: 0  Errors: 0

WARNING: There are 1 orphaned regression test functions.
Please make sure these function names correspond to regression files:
testQChem_QChem5_1_old_final_print_1_out

```
