### PR TITLE
bump GHA actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash -eo pipefail -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Prepare conda environment
         run: |
           echo "/env/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This should fix https://github.com/cclib/cclib/runs/6739894876?check_suite_focus=true.