### PR TITLE
Add method for computing CM5 atomic charges

### DIFF
--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -10,6 +10,7 @@
 from cclib.method.bader import Bader
 from cclib.method.bickelhaupt import Bickelhaupt
 from cclib.method.cda import CDA
+from cclib.method.cm5 import CM5
 from cclib.method.cspa import CSPA
 from cclib.method.ddec import DDEC6
 from cclib.method.density import Density

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -30,7 +30,7 @@ class CM5(Method):
     Parameters
     ----------
     data : ccData
-        The parsed data to be used for atomic coordinates and numbers
+        The parsed data to be used for atomic coordinates, numbers, and Hirshfeld charges
     radii : str, default "hokru"
         Specify the set of radii to be used.  One of:
          - "hokru": Values copied from https://github.com/hokru/cm5charges,

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -1,0 +1,186 @@
+'''
+This file is an implementation of the Charge Model 5 that can be used to calculate CM5 Charges, dipole moment and quadrupole moment
+
+It is based on this Fortran implementation: https://github.com/hokru/cm5charges
+-----------------------------------------------
+Points to be noted:
+-----------------------------------------------
+1) Only ORCA output files are supported, and "Print[P_Hirshfeld] 1" must be entered in the ORCA input file to produce Hirshfeld charges.
+2) Single bond atomic radii are considered.
+3) For Carbon, only sp3 atomic radius is considered.
+
+-----------------------------------------------
+Example on how to Use this class:
+-----------------------------------------------
+from cclib.method import CM5
+from cclib.parser import ORCA
+
+parser = ORCA("water_hpa.out") #test file found in /cclib/data/ORCA/basicORCA4.2/
+data = parser.parse()
+
+cm5 = CM5(data, 1.20)
+print(cm5.cm5_charges())
+print(cm5.dipole_moment())
+print(cm5.quadrupole_moment())
+
+------------------------------------------------
+Output:
+------------------------------------------------
+[-0.3880329  0.2227029  0.16703  ]
+(array([-3.7422439 , -3.34907393,  0.80222668]), 5.0856910330516865)
+[[ 2.9476879   0.39972848 -0.47709812]
+ [ 2.648237   -0.2199436  -0.65167883]
+ [ 1.183168    1.256816   -0.11061444]]
+'''
+
+import logging
+
+import numpy as np
+
+from cclib.method.calculationmethod import Method
+from cclib.parser.utils import PeriodicTable
+from cclib.parser.utils import find_package
+
+_found_periodictable = find_package("periodictable")
+if _found_periodictable:
+    import periodictable.covalent_radius as pt
+
+def _check_periodictable(found_periodictable):
+    if not _found_periodictable:
+        raise ImportError("You must install `periodictable` to use this class")
+
+class CM5(Method):
+    def __init__(self, data, fscale=1.20, progress=None, loglevel=logging.INFO, logname="Log"):
+
+            self.required_attrs = ('natom', 'atomcoords','atomnos')
+            self.fscale = fscale
+            self.atomradius = np.empty(119)
+            self.atomradius[0] = 0.20
+
+            for line in pt.CorderoPyykko.split('\n'):
+                fields = line.split() #splits at space                       
+                if line[0] == '#':
+                    continue
+                else:
+                    fields = line.split()
+                    Z = int(fields[0])
+
+                    if len(fields) < 6:
+                        for i in range(len(fields), 6):
+                            fields.append('0.0')
+
+                    if fields[2] == '-':
+                        rC = 0.0
+                        drC = 0.0
+                    else:
+                        sfields = fields[2].split('(')
+                        rC = float(sfields[0])                        
+                        drC = float(sfields[1].split(')', 1)[0]) / 100 if len(sfields) == 2 else 0.0
+
+                    r1 = float(fields[3])
+
+                    r1_avg = (rC + r1) / 2 if r1 is not 0.0 else rC
+
+                    r2 = float(fields[4])
+
+                    r3 = float(fields[5])
+
+                self.atomradius[Z] = r1_avg
+
+            super(CM5, self).__init__(data, progress, loglevel, logname)
+
+    def cm5_charges(self):
+	'''Returns an array with cm5 charges'''
+        nat = self.data.natom
+        qcm5 = np.empty(nat)
+        z = self.data.atomnos
+        xyz = self.data.atomcoords[-1]
+
+        alpha = 2.474  # Angstrom
+
+        for i in range(0, nat - 1):
+                s = 0
+                for j in range(0, nat - 1):
+                    if(i != j):
+                        rij =  np.linalg.norm(np.subtract(xyz[i], xyz[j]))# = nuclear.get_distances()
+                        bij = np.exp(-alpha * (rij - self.atomradius[z[i]] - self.atomradius[z[j]])) # eq.2
+                        s += (tij(z[i], z[j]) * bij)
+                qcm5[i] = self.data.atomcharges['hirshfeld'][i] + s
+        return qcm5
+
+    #CM5 dipole moment
+    def dipole_moment(self):
+	'''Returns (the dipole moment vector, it's magnitude)'''
+        nat = self.data.natom
+        dipole = np.empty(nat)
+        for i in range(0, nat):
+            for j in range(0, 2):
+                dipole[j] += self.cm5_charges()[i] * self.data.atomcoords[-1, j, i] * self.fscale
+        dipole *= 4.802889778
+        s = np.sqrt(dipole[0]**2 + dipole[1]**2 + dipole[2]**2)
+        return dipole, s
+
+    #Quadrupole moment
+    def quadrupole_moment(self):
+	'''Returns a 3*3 matrix with quadrupole moment'''
+        bohr = 0.52917726
+        nat = self.data.natom
+        quad = np.empty([nat, nat])
+        for k in range(0, nat - 1):
+            dx = self.data.atomcoords[-1, k, 0] / bohr
+            dy = self.data.atomcoords[-1, k, 1] / bohr
+            dz = self.data.atomcoords[-1, k, 2] / bohr
+            quad[0, 0] += dx * dx * self.cm5_charges()[k]
+            quad[1, 1] += dy * dy * self.cm5_charges()[k]
+            quad[2, 2] += dz * dz * self.cm5_charges()[k]
+            quad[0, 1] += dx * dy * self.cm5_charges()[k]
+            quad[0, 2] += dx * dz * self.cm5_charges()[k]
+            quad[1, 2] += dy * dz * self.cm5_charges()[k]
+        return quad
+
+def tij(i, j):
+        #              NULL H       He       Li   Be      B        C        N        O        F        Ne
+        dz = np.array([0.0, 0.0056, -0.1543, 0.0, 0.0333, -0.1030, -0.0446, -0.1072, -0.0802, -0.0629, -0.1088, \
+    #   Na      Mg   Al       Si       P        S        Cl       Ar
+        0.0184, 0.0, -0.0726, -0.0790, -0.0756, -0.0565, -0.0444, -0.07676, \
+    #   K       Ca                                                Zn   Ga       Ge       As       Se       Br   Kr
+        0.0130, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.0557, -0.0533, -0.0399, -0.0313, 0.0, 0.0, \
+    #                                                                                   I        Xe
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.0220, 0.0])
+
+        #               H-C     H-N     H-O     C-N     C-O     N-O
+        dzz = np.array([0.0502, 0.1747, 0.1671, 0.0556, 0.0234, -0.0346])
+        
+        # catch special cases
+        if i == 1:
+            if j == 6:
+                tij = dzz[1]
+            if j == 7:
+                tij = dzz[2]
+            if j == 8:
+                tij = dzz[3]
+        elif i == 6:
+            if j == 7:
+                tij = dzz[4]
+            if j == 8:
+                tij = dzz[5]
+            if j == 1:
+                tij = -dzz[1]
+        elif i == 7:
+            if j == 8:
+                tij = dzz[6]
+            if j == 1:
+                tij = -dzz[2]
+            if j == 6:
+                tij = -dzz[4]
+        elif i == 8:
+            if j == 1:
+                tij = -dzz[3]
+            if j == 6:
+                tij = -dzz[5]
+            if j == 7:
+                tij = -dzz[6]
+        else:
+            tij = dz[i] - dz[j]
+
+        return tij

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -39,8 +39,8 @@ class CM5(Method):
              in CRC Handbook of Chemistry and Physics, 91st Edition (2010-2011),
              edited by W. M. Haynes (CRC Press, Boca Raton, FL, 2010), pages 9-49-9-50;
              corrected Nov. 17, 2010 for the 92nd edition.
-         - "CorderoPyykko": Values averaged from doi:10.1039/b801115j and Cordero.
-         - "Cordero": Values from 10.1002/chem.200901472.
+         - "Cordero": Values from doi:10.1039/b801115j.
+         - "CorderoPyykko": Values averaged from doi:10.1002/chem.200901472 and Cordero.
         The final charges seem relatively insensitive to this choice.
 
     progress : Optional[cclib.progress.Progress], default None

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -39,6 +39,7 @@ import numpy as np
 import periodictable.covalent_radius as pt
 
 from cclib.method.calculationmethod import Method
+from cclib.parser.utils import convertor
 
 
 class CM5(Method):
@@ -98,7 +99,7 @@ class CM5(Method):
                     bij = np.exp(
                         -alpha * (rij - self.atomradius[z[i]] - self.atomradius[z[j]])
                     )  # eq.2
-                    s += tij(z[i], z[j]) * bij
+                    s += _tij(z[i], z[j]) * bij
             qcm5[i] = hirshfeld_charges[i] + s
         return qcm5
 
@@ -135,12 +136,33 @@ class CM5(Method):
         return quad
 
 
-def tij(i, j):
-    """Compute eq. 4 from 10.1021/ct200866d.
+def _tij(i: int, j: int, extended: bool = True) -> float:
+    """Compute a single $T_{kk'}$ in eq. (1) from 10.1021/ct200866d.
+
+    This term may be computed from special case pairwise values in eq. (3) or
+    more generally via eq. (4), depending on the atomic numbers i and j.
+
+    Notation-wise, k and k prime are renamed to i and j.
 
     These include the extended set of parameters presented in the Supporting
     Information.
+
+    Arguments
+    ---------
+    i : int
+        Atomic number of first index
+    j : int
+        Atomic number of second index
+    extended : bool (default True)
+        Should the extended set of $D_{Z}$ parameters presented in the
+        Supporting Information be used?
+
+    Returns
+    -------
+    $T_{ij}$ : float
     """
+
+    tij = 0.0
 
     #               H-C     H-N     H-O     C-N     C-O     N-O
     dzz = np.array([0.0502, 0.1747, 0.1671, 0.0556, 0.0234, -0.0346])
@@ -175,6 +197,7 @@ def tij(i, j):
         elif j == 7:
             tij = -dzz[6]
     else:
+        # Indices used here correspond directly to atomic number.
         dz = np.zeros((119,))
         dz[1] = 0.0056
         dz[2] = -0.1543
@@ -193,33 +216,36 @@ def tij(i, j):
         dz[17] = -0.0444
         dz[18] = -0.0767
         dz[19] = 0.0130
-        dz[31] = -0.0512
+        if extended:
+            dz[31] = -0.0512
         dz[32] = -0.0557
         dz[33] = -0.0533
         dz[34] = -0.0399
         dz[35] = -0.0313
-        dz[36] = -0.0541
-        dz[37] = 0.0092
-        dz[49] = -0.0361
-        dz[50] = -0.0393
-        dz[51] = -0.0376
-        dz[52] = -0.0281
+        if extended:
+            dz[36] = -0.0541
+            dz[37] = 0.0092
+            dz[49] = -0.0361
+            dz[50] = -0.0393
+            dz[51] = -0.0376
+            dz[52] = -0.0281
         dz[53] = -0.0220
-        dz[54] = -0.0381
-        dz[55] = 0.0065
-        dz[81] = -0.0255
-        dz[82] = -0.0277
-        dz[83] = -0.0265
-        dz[84] = -0.0198
-        dz[85] = -0.0155
-        dz[86] = -0.0269
-        dz[87] = 0.0046
-        dz[113] = -0.0179
-        dz[114] = -0.0195
-        dz[115] = -0.0187
-        dz[116] = -0.0140
-        dz[117] = -0.0110
-        dz[118] = -0.0189
+        if extended:
+            dz[54] = -0.0381
+            dz[55] = 0.0065
+            dz[81] = -0.0255
+            dz[82] = -0.0277
+            dz[83] = -0.0265
+            dz[84] = -0.0198
+            dz[85] = -0.0155
+            dz[86] = -0.0269
+            dz[87] = 0.0046
+            dz[113] = -0.0179
+            dz[114] = -0.0195
+            dz[115] = -0.0187
+            dz[116] = -0.0140
+            dz[117] = -0.0110
+            dz[118] = -0.0189
 
         tij = dz[i] - dz[j]
 

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -1,4 +1,4 @@
-'''
+"""
 This file is an implementation of the Charge Model 5 that can be used to calculate CM5 Charges, dipole moment and quadrupole moment
 
 It is based on this Fortran implementation: https://github.com/hokru/cm5charges
@@ -31,156 +31,200 @@ Output:
 [[ 2.9476879   0.39972848 -0.47709812]
  [ 2.648237   -0.2199436  -0.65167883]
  [ 1.183168    1.256816   -0.11061444]]
-'''
+"""
 
 import logging
 
 import numpy as np
+import periodictable.covalent_radius as pt
 
 from cclib.method.calculationmethod import Method
-from cclib.parser.utils import PeriodicTable
-from cclib.parser.utils import find_package
 
-_found_periodictable = find_package("periodictable")
-if _found_periodictable:
-    import periodictable.covalent_radius as pt
-
-def _check_periodictable(found_periodictable):
-    if not _found_periodictable:
-        raise ImportError("You must install `periodictable` to use this class")
 
 class CM5(Method):
     def __init__(self, data, fscale=1.20, progress=None, loglevel=logging.INFO, logname="Log"):
+        super().__init__(data, progress, loglevel, logname)
 
-            self.required_attrs = ('natom', 'atomcoords','atomnos')
-            self.fscale = fscale
-            self.atomradius = np.empty(119)
-            self.atomradius[0] = 0.20
+        self.required_attrs = ("natom", "atomcoords", "atomnos")
+        self.fscale = fscale
+        self.atomradius = np.empty(119)
+        self.atomradius[0] = 0.20
 
-            for line in pt.CorderoPyykko.split('\n'):
-                fields = line.split() #splits at space                       
-                if line[0] == '#':
-                    continue
+        for line in pt.CorderoPyykko.split("\n"):
+            fields = line.split()
+            if line[0] == "#":
+                continue
+            else:
+                fields = line.split()
+                Z = int(fields[0])
+
+                if len(fields) < 6:
+                    for _ in range(len(fields), 6):
+                        fields.append("0.0")
+
+                if fields[2] == "-":
+                    rC = 0.0
+                    drC = 0.0
                 else:
-                    fields = line.split()
-                    Z = int(fields[0])
+                    sfields = fields[2].split("(")
+                    rC = float(sfields[0])
+                    drC = float(sfields[1].split(")", 1)[0]) / 100 if len(sfields) == 2 else 0.0
 
-                    if len(fields) < 6:
-                        for i in range(len(fields), 6):
-                            fields.append('0.0')
+                r1 = float(fields[3])
+                r1_avg = (rC + r1) / 2 if r1 is not 0.0 else rC
+                r2 = float(fields[4])
+                r3 = float(fields[5])
 
-                    if fields[2] == '-':
-                        rC = 0.0
-                        drC = 0.0
-                    else:
-                        sfields = fields[2].split('(')
-                        rC = float(sfields[0])                        
-                        drC = float(sfields[1].split(')', 1)[0]) / 100 if len(sfields) == 2 else 0.0
-
-                    r1 = float(fields[3])
-
-                    r1_avg = (rC + r1) / 2 if r1 is not 0.0 else rC
-
-                    r2 = float(fields[4])
-
-                    r3 = float(fields[5])
-
-                self.atomradius[Z] = r1_avg
-
-            super(CM5, self).__init__(data, progress, loglevel, logname)
+            self.atomradius[Z] = r1_avg
 
     def cm5_charges(self):
-	'''Returns an array with cm5 charges'''
+        """Returns an array with cm5 charges"""
         nat = self.data.natom
         qcm5 = np.empty(nat)
         z = self.data.atomnos
         xyz = self.data.atomcoords[-1]
+        hirshfeld_charges = self.data.atomcharges["hirshfeld"]
 
         alpha = 2.474  # Angstrom
 
         for i in range(0, nat - 1):
-                s = 0
-                for j in range(0, nat - 1):
-                    if(i != j):
-                        rij =  np.linalg.norm(np.subtract(xyz[i], xyz[j]))# = nuclear.get_distances()
-                        bij = np.exp(-alpha * (rij - self.atomradius[z[i]] - self.atomradius[z[j]])) # eq.2
-                        s += (tij(z[i], z[j]) * bij)
-                qcm5[i] = self.data.atomcharges['hirshfeld'][i] + s
+            s = 0
+            for j in range(0, nat - 1):
+                if i != j:
+                    rij = np.linalg.norm(np.subtract(xyz[i], xyz[j]))  # = nuclear.get_distances()
+                    bij = np.exp(
+                        -alpha * (rij - self.atomradius[z[i]] - self.atomradius[z[j]])
+                    )  # eq.2
+                    s += tij(z[i], z[j]) * bij
+            qcm5[i] = hirshfeld_charges[i] + s
         return qcm5
 
-    #CM5 dipole moment
     def dipole_moment(self):
-	'''Returns (the dipole moment vector, it's magnitude)'''
+        """Returns the dipole moment computed from CM5 atomic charges."""
         nat = self.data.natom
         dipole = np.empty(nat)
+        cm5_charges = self.cm5_charges()
         for i in range(0, nat):
             for j in range(0, 2):
-                dipole[j] += self.cm5_charges()[i] * self.data.atomcoords[-1, j, i] * self.fscale
+                dipole[j] += cm5_charges[i] * self.data.atomcoords[-1, j, i] * self.fscale
         dipole *= 4.802889778
-        s = np.sqrt(dipole[0]**2 + dipole[1]**2 + dipole[2]**2)
+        s = np.sqrt(dipole[0] ** 2 + dipole[1] ** 2 + dipole[2] ** 2)
         return dipole, s
 
-    #Quadrupole moment
     def quadrupole_moment(self):
-	'''Returns a 3*3 matrix with quadrupole moment'''
+        """Returns the quadrupole moment computed from CM5 atomic charges."""
         bohr = 0.52917726
         nat = self.data.natom
         quad = np.empty([nat, nat])
+        cm5_charges = self.cm5_charges()
         for k in range(0, nat - 1):
             dx = self.data.atomcoords[-1, k, 0] / bohr
             dy = self.data.atomcoords[-1, k, 1] / bohr
             dz = self.data.atomcoords[-1, k, 2] / bohr
-            quad[0, 0] += dx * dx * self.cm5_charges()[k]
-            quad[1, 1] += dy * dy * self.cm5_charges()[k]
-            quad[2, 2] += dz * dz * self.cm5_charges()[k]
-            quad[0, 1] += dx * dy * self.cm5_charges()[k]
-            quad[0, 2] += dx * dz * self.cm5_charges()[k]
-            quad[1, 2] += dy * dz * self.cm5_charges()[k]
+            quad[0, 0] += dx * dx * cm5_charges[k]
+            quad[1, 1] += dy * dy * cm5_charges[k]
+            quad[2, 2] += dz * dz * cm5_charges[k]
+            quad[0, 1] += dx * dy * cm5_charges[k]
+            quad[0, 2] += dx * dz * cm5_charges[k]
+            quad[1, 2] += dy * dz * cm5_charges[k]
         return quad
 
+
 def tij(i, j):
-        #              NULL H       He       Li   Be      B        C        N        O        F        Ne
-        dz = np.array([0.0, 0.0056, -0.1543, 0.0, 0.0333, -0.1030, -0.0446, -0.1072, -0.0802, -0.0629, -0.1088, \
-    #   Na      Mg   Al       Si       P        S        Cl       Ar
-        0.0184, 0.0, -0.0726, -0.0790, -0.0756, -0.0565, -0.0444, -0.07676, \
-    #   K       Ca                                                Zn   Ga       Ge       As       Se       Br   Kr
-        0.0130, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.0557, -0.0533, -0.0399, -0.0313, 0.0, 0.0, \
-    #                                                                                   I        Xe
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.0220, 0.0])
+    #              NULL H       He       Li   Be      B        C        N        O        F        Ne
+    dz = np.array(
+        [
+            0.0,
+            0.0056,
+            -0.1543,
+            0.0,
+            0.0333,
+            -0.1030,
+            -0.0446,
+            -0.1072,
+            -0.0802,
+            -0.0629,
+            -0.1088,  #   Na      Mg   Al       Si       P        S        Cl       Ar
+            0.0184,
+            0.0,
+            -0.0726,
+            -0.0790,
+            -0.0756,
+            -0.0565,
+            -0.0444,
+            -0.07676,  #   K       Ca                                                Zn   Ga       Ge       As       Se       Br   Kr
+            0.0130,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            -0.0557,
+            -0.0533,
+            -0.0399,
+            -0.0313,
+            0.0,
+            0.0,  #                                                                                   I        Xe
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            -0.0220,
+            0.0,
+        ]
+    )
 
-        #               H-C     H-N     H-O     C-N     C-O     N-O
-        dzz = np.array([0.0502, 0.1747, 0.1671, 0.0556, 0.0234, -0.0346])
-        
-        # catch special cases
-        if i == 1:
-            if j == 6:
-                tij = dzz[1]
-            if j == 7:
-                tij = dzz[2]
-            if j == 8:
-                tij = dzz[3]
-        elif i == 6:
-            if j == 7:
-                tij = dzz[4]
-            if j == 8:
-                tij = dzz[5]
-            if j == 1:
-                tij = -dzz[1]
-        elif i == 7:
-            if j == 8:
-                tij = dzz[6]
-            if j == 1:
-                tij = -dzz[2]
-            if j == 6:
-                tij = -dzz[4]
-        elif i == 8:
-            if j == 1:
-                tij = -dzz[3]
-            if j == 6:
-                tij = -dzz[5]
-            if j == 7:
-                tij = -dzz[6]
-        else:
-            tij = dz[i] - dz[j]
+    #               H-C     H-N     H-O     C-N     C-O     N-O
+    dzz = np.array([0.0502, 0.1747, 0.1671, 0.0556, 0.0234, -0.0346])
 
-        return tij
+    # catch special cases
+    if i == 1:
+        if j == 6:
+            tij = dzz[1]
+        elif j == 7:
+            tij = dzz[2]
+        elif j == 8:
+            tij = dzz[3]
+    elif i == 6:
+        if j == 7:
+            tij = dzz[4]
+        elif j == 8:
+            tij = dzz[5]
+        elif j == 1:
+            tij = -dzz[1]
+    elif i == 7:
+        if j == 8:
+            tij = dzz[6]
+        elif j == 1:
+            tij = -dzz[2]
+        elif j == 6:
+            tij = -dzz[4]
+    elif i == 8:
+        if j == 1:
+            tij = -dzz[3]
+        elif j == 6:
+            tij = -dzz[5]
+        elif j == 7:
+            tij = -dzz[6]
+    else:
+        tij = dz[i] - dz[j]
+
+    return tij

--- a/test/method/testcm5.py
+++ b/test/method/testcm5.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Test the CM5 method in cclib"""
+
+import unittest
+
+import numpy as np
+
+from cclib.method import CM5
+from cclib.parser import QChem
+
+from ..test_data import getdatafile
+
+
+class CM5Test(unittest.TestCase):
+    """Tests for Charge Model 5 (CM5) calculations."""
+
+    def testcm5restricted(self):
+        """Check that our computed CM5 charges match those parsed from a
+        restricted calculation.
+        """
+        data, _ = getdatafile(QChem, "basicQChem5.4", ["dvb_sp.out"])
+        res = CM5(data).charges()
+        ref = data.atomcharges["cm5"]
+        np.testing.assert_allclose(res, ref, atol=1.0e-6)
+
+    def testcm5unrestricted(self):
+        """Check that our computed CM5 charges match those parsed from an
+        unrestricted calculation.
+        """
+        data, _ = getdatafile(QChem, "basicQChem5.4", ["dvb_sp_un.out"])
+        res = CM5(data).charges()
+        ref = data.atomcharges["cm5"]
+        np.testing.assert_allclose(res, ref, atol=1.0e-6)

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -14,6 +14,7 @@ sys.path.insert(1, "method")
 
 from .method.testbader import *
 from .method.testcda import *
+from .method.testcm5 import *
 from .method.testddec import *
 from .method.testelectrons import *
 from .method.testhirshfeld import *


### PR DESCRIPTION
Closes #676. This replaces #852.

As one of the requirements, it also adds Hirshfeld charge reading from ORCA.