### PR TITLE
Turbomole MP2 Opt Fix

### DIFF
--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -839,8 +839,8 @@ class Turbomole(logfileparser.Logfile):
         #     Method          :  MP2     
         #     Total Energy    :    -75.0009789796
         # ------------------------------------------------
-        # Need to be careufl here, in some ricc2 calcs this line will appear even tho
-        # we already have this MP2 energy from the above section.
+        # Need to be careufl here, in some ricc2 calcs (opts?) this line will appear even
+        # though we already have this MP2 energy from the above section.
         if not hasattr(self, "mpenergies"):
             if "Method          :  MP2" in line:
                 line = next(inputfile)

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -839,11 +839,14 @@ class Turbomole(logfileparser.Logfile):
         #     Method          :  MP2     
         #     Total Energy    :    -75.0009789796
         # ------------------------------------------------
-        if "Method          :  MP2" in line:
-            line = next(inputfile)
-            mp2energy = [utils.convertor(utils.float(line.split()[3]), 'hartree', 'eV')]
-            self.append_attribute('mpenergies', mp2energy)
-            self.metadata['methods'].append("MP2")
+        # Need to be careufl here, in some ricc2 calcs this line will appear even tho
+        # we already have this MP2 energy from the above section.
+        if not hasattr(self, "mpenergies"):
+            if "Method          :  MP2" in line:
+                line = next(inputfile)
+                mp2energy = [utils.convertor(utils.float(line.split()[3]), 'hartree', 'eV')]
+                self.append_attribute('mpenergies', mp2energy)
+                self.metadata['methods'].append("MP2")
 
 
         # Excited state info from escf.

--- a/test/regression.py
+++ b/test/regression.py
@@ -2689,6 +2689,9 @@ def testTurbomole_Turbomole7_2_dvb_gopt_b3_lyp_Gaussian__(logfile):
     assert logfile.data.natom == 20
 
 
+def testTurbomole_Turbomole7_5_mp2_opt__(logfile):
+    assert len(logfile.data.scfenergies) == len(logfile.data.mpenergies)
+
 # These regression tests are for logfiles that are not to be parsed
 # for some reason, and the function should start with 'testnoparse'.
 


### PR DESCRIPTION
In some cases, such as MP2 optimisations run with ricc2, the list of mpenergies would contain the same energy twice for each step, resulting in mpenergies being twice as long as expected. This is a fix for this problem, along with a regression test.