### PR TITLE
Turbo etmagdips

### DIFF
--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -1007,7 +1007,7 @@ class Turbomole(logfileparser.Logfile):
             line = next(inputfile)
             tmdm_z = float(line.split()[1])
             
-            # It's not at all clear what units turbomole is using for its TMDM,
+            # No idea what units Turbomole is using for its TMDM here,
             # they appear to be equal to bohr-magneton / ~274.03011803.
             # For now, we will multiply the values by 137.015059015 (to get into
             # a.u. which is the defacto TMDM unit in cclib?).

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -995,6 +995,26 @@ class Turbomole(logfileparser.Logfile):
             
             self.append_attribute("etdips", [tdm_x, tdm_y, tdm_z])
             
+            # Mag dips.
+            while "Magnetic transition dipole moment / i:" not in line:
+                line = next(inputfile)
+            line = next(inputfile)
+            
+            line = next(inputfile)
+            tmdm_x = float(line.split()[1])
+            line = next(inputfile)
+            tmdm_y = float(line.split()[1])
+            line = next(inputfile)
+            tmdm_z = float(line.split()[1])
+            
+            # It's not at all clear what units turbomole is using for its TMDM,
+            # they appear to be equal to bohr-magneton / ~274.03011803.
+            # For now, we will multiply the values by 137.015059015 (to get into
+            # a.u. which is the defacto TMDM unit in cclib?).
+            self.append_attribute("etmagdips", [i * 137.015059015 for i in (tmdm_x, tmdm_y, tmdm_z)])
+            
+            
+            
         # Excitation energies with ricc2.
         #  +================================================================================+
         #  | sym | multi | state |          CC2 excitation energies       |  %t1   |  %t2   |

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -229,6 +229,11 @@ class TurbomoleTDTest(GenericTDTest):
         """Is the maximum of etoscs in the right range?"""
         self.assertEqual(len(self.data.etoscs), self.number)
         self.assertAlmostEqual(max(self.data.etoscs), 0.19, delta=0.1)
+    
+    @skipForLogfile('Turbomole/basicTurbomole7.4/CO_cc2_TD', 'There are no dipole moments in ricc2')
+    def testetmagdipsshape(self):
+        """Is the shape of etmagdips correct?"""
+        self.assertEqual(numpy.shape(self.data.etmagdips), (self.number, 3))
 
 class TurbomoleTDADC2Test(GenericTDTest):
     """Customized time-dependent HF/DFT unittest"""


### PR DESCRIPTION
Adds support for etmagdips for Turbomole.

The units for etmagdips are assumed to be a.u. following the Gaussian parser's example.