### PR TITLE
Fix for symmetry detection in Gaussian with ghost atoms

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -573,7 +573,7 @@ class Gaussian(logfileparser.Logfile):
                 line = next(inputfile)
 
         # Symmetry: point group
-        if line.strip() == "Symmetry turned off by external request.":
+        if "Symmetry turned off" in line:
             self.set_attribute('uses_symmetry', False)
         if "Full point group" in line:
             point_group_detected = line.split()[3].lower()

--- a/test/regression.py
+++ b/test/regression.py
@@ -1161,6 +1161,10 @@ def testGaussian_Gaussian09_benzene_excited_states_optimization_issue889_log(log
     assert len(logfile.data.etsecs) == 20
     assert logfile.data.etveldips.shape == (20,3)
 
+def testGaussian_Gaussian09_issue1150_log(logfile):
+    """ Symmetry parsing for Gaussian09 was broken"""
+    assert logfile.metadata['symmetry_detected'] == 'c1'
+
 def testGaussian_Gaussian16_H3_natcharge_log(logfile):
     """A calculation with natural charges calculated. Test issue 1055 where 
     only the beta set of charges was parsed rather than the spin independent"""


### PR DESCRIPTION
Hello,

I just wanted to add a small fix to the Gaussian parser.

I am attaching the file that I am interested in, [neutral.log](https://github.com/cclib/cclib/files/9453835/neutral.log). This file could be parsed with cclib v1.7.1 but with v1.7.2 it tells me.

~~~~
[Gaussian neutral.log ERROR] Unexpectedly encountered end of logfile.
~~~~
Changing the line as shown below seems to fix this.

