### PR TITLE
Optstate

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1487,6 +1487,11 @@ class Gaussian(logfileparser.Logfile):
                 CIScontrib.append([(fromMO, frommoindex), (toMO, tomoindex), percent])
                 line = next(inputfile)
             self.etsecs.append(CIScontrib)
+            
+            # Check if this state is our 'state of interest' (for optimisations etc).
+            if "This state for optimization and/or second-order correction" in line:
+                # Index to the current excited state.
+                self.metadata['opt_state'] = len(self.etenergies) -1
 
         # Electronic transition transition-dipole data
         #

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1488,6 +1488,12 @@ class Gaussian(logfileparser.Logfile):
                 line = next(inputfile)
             self.etsecs.append(CIScontrib)
             
+            # Skip over 'de-excitation' contributions (these are typically hidden but can be revealed
+            # by iop(9/40=2)).
+            while line.find(" <-") >= 0:
+                # These are not processed atm.
+                line = next(inputfile)
+            
             # Check if this state is our 'state of interest' (for optimisations etc).
             if "This state for optimization and/or second-order correction" in line:
                 # Index to the current excited state.

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -81,6 +81,20 @@ class GenericTDTest(unittest.TestCase):
     def testrotatsnumber(self):
         """Is the length of etrotats correct?"""
         self.assertEqual(len(self.data.etrotats), self.number)
+    
+    @skipForParser('ADF', 'optstate is not yet implemented')
+    @skipForParser('DALTON', 'optstate are not yet implemented')
+    @skipForParser('FChk', 'optstate are not yet implemented')
+    @skipForParser('GAMESS', 'optstate are not yet implemented')
+    @skipForParser('GAMESSUK', 'optstate are not yet implemented')
+    @skipForParser('Jaguar', 'optstate are not yet implemented')
+    @skipForParser('NWChem', 'optstate are not yet implemented')
+    @skipForParser('ORCA', 'optstate are not yet implemented')
+    @skipForParser('QChem', 'optstate are not yet implemented')
+    @skipForParser('Turbomole', 'optstate are not yet implemented')
+    def testoptstate(self):
+        # All our examples have a default state-of-interest of 1 (index 0).
+        self.assertEqual(self.data.metadata['opt_state'], 0)
 
 class ADFTDDFTTest(GenericTDTest):
     """Customized time-dependent DFT unittest"""


### PR DESCRIPTION
Support for 'optstate', a metadata item which indicates which excited state is the 'state-of-interest' for optimisation and other properties.

See #1149 