### PR TITLE
Break apart atomcharges tests per type into Mulliken and Lowdin

### DIFF
--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -48,7 +48,9 @@ class Psi4(logfileparser.Logfile):
         # Regular expression for matching the start of an atomic charges
         # section; the second format of the header (with square brackets) is
         # for old Psi4 versions.
-        self.re_atomic_charges_header = re.compile(r"^\s*(\w+) Charges(:?: \(a\.u\.\)| \[a\.u\.\]:)")
+        self.re_atomic_charges_header = re.compile(
+            r"^\s*(Mulliken|Lowdin|MBIS) Charges(:?: \(a\.u\.\)| \[a\.u\.\]:)"
+        )
 
     def after_parsing(self):
         super(Psi4, self).after_parsing()

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -8,6 +8,7 @@
 """Parser for Psi4 output files."""
 
 from collections import namedtuple
+import re
 
 import numpy
 
@@ -43,6 +44,11 @@ class Psi4(logfileparser.Logfile):
         # There are also sometimes subsections within each section, denoted
         # with =>/<= rather than ==>/<==.
         self.subsection = None
+
+        # Regular expression for matching the start of an atomic charges
+        # section; the second format of the header (with square brackets) is
+        # for old Psi4 versions.
+        self.re_atomic_charges_header = re.compile(r"^\s*(\w+) Charges(:?: \(a\.u\.\)| \[a\.u\.\]:)")
 
     def after_parsing(self):
         super(Psi4, self).after_parsing()
@@ -650,22 +656,21 @@ class Psi4(logfileparser.Logfile):
         #        1     C     2.99909  2.99909  0.00000  0.00182
         #        2     C     2.99909  2.99909  0.00000  0.00182
         # ...
-        for pop_type in ["Mulliken", "Lowdin"]:
-            if line.strip() == f"{pop_type} Charges: (a.u.)":
-                if not hasattr(self, 'atomcharges'):
-                    self.atomcharges = {}
-                header = next(inputfile)
+        atomic_charges_header = self.re_atomic_charges_header.search(line)
+        if atomic_charges_header is not None:
+            if not hasattr(self, 'atomcharges'):
+                self.atomcharges = {}
 
+            while "Center  Symbol    Alpha" not in line:
                 line = next(inputfile)
-                while not line.strip():
-                    line = next(inputfile)
+            line = next(inputfile)
 
-                charges = []
-                while line.strip():
-                    ch = float(line.split()[-1])
-                    charges.append(ch)
-                    line = next(inputfile)
-                self.atomcharges[pop_type.lower()] = charges
+            charges = []
+            while line.strip():
+                ch = float(line.split()[-1])
+                charges.append(ch)
+                line = next(inputfile)
+            self.atomcharges[atomic_charges_header.groups()[0].lower()] = charges
 
         # This is for the older conventional MP2 code in 4.0b5.
         mp_trigger = "MP2 Total Energy (a.u.)"

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -68,11 +68,40 @@ class GenericSPTest(unittest.TestCase):
     @skipForLogfile('Molpro/basicMolpro2006', "These tests were run a long time ago and since we don't have access to Molpro 2006 anymore, we can skip this test (it is tested in 2012)")
     @skipForParser('Turbomole','The parser is still being developed so we skip this test')
     def testatomcharges(self):
-        """Are atomcharges (at least Mulliken) consistent with natom and sum to zero?"""
-        for type in set(['mulliken'] + list(self.data.atomcharges.keys())):
-            charges = self.data.atomcharges[type]
-            self.assertEqual(len(charges), self.data.natom)
-            self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
+        """Are atomic charges consistent with natom?"""
+        for atomcharge_type in self.data.atomcharges:
+            charges = self.data.atomcharges[atomcharge_type]
+            natom = self.data.natom
+            self.assertEqual(
+                len(charges),
+                natom,
+                msg=f"len(atomcharges['{atomcharge_type}']) = {len(charges)}, natom = {natom}"
+            )
+
+    @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
+    @skipForParser('FChk', 'The parser is still being developed so we skip this test')
+    @skipForLogfile('Jaguar/basicJaguar7', 'We did not print the atomic partial charges in the unit tests for this version')
+    @skipForLogfile('Molpro/basicMolpro2006', "These tests were run a long time ago and since we don't have access to Molpro 2006 anymore, we can skip this test (it is tested in 2012)")
+    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
+    def testatomcharges_mulliken(self):
+        """Do Mulliken atomic charges sum to zero?"""
+        charges = self.data.atomcharges["mulliken"]
+        self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
+
+    @skipForParser('ADF', 'Lowdin charges not present by default')
+    @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
+    @skipForParser('FChk', 'The parser is still being developed so we skip this test')
+    @skipForParser('Gaussian', 'Lowdin charges not present by default')
+    @skipForParser('Jaguar', 'Lowdin charges not present by default')
+    @skipForParser('NWChem', 'Lowdin charges not present by default')
+    @skipForParser('Molcas', 'Lowdin charges not present by default')
+    @skipForParser('Molpro', 'Lowdin charges not present by default')
+    @skipForParser('QChem', 'Lowdin charges not present by default')
+    @skipForParser('Turbomole','The parser is still being developed so we skip this test')
+    def testatomcharges_lowdin(self):
+        """Do Lowdin atomic charges sum to zero?"""
+        charges = self.data.atomcharges["lowdin"]
+        self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
 
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -174,11 +174,6 @@ class GamessUK80SPunTest(GenericSPunTest):
 class GaussianSPunTest(GenericSPunTest):
     """Customized unrestricted single point unittest"""
 
-    def testatomnos(self):
-        """Does atomnos have the right dimension (20)?"""
-        size = len(self.data.atomnos)
-        self.assertEqual(size, 20)
-    
     def testatomcharges(self):
         """Are atomcharges (at least Mulliken) consistent with natom and sum to one?"""
         for type_ in set(['mulliken'] + list(self.data.atomcharges.keys())):

--- a/test/regression.py
+++ b/test/regression.py
@@ -2971,7 +2971,23 @@ class GaussianPolarTest(ReferencePolarTest):
 # Jaguar #
 
 
-class JaguarSPTest_6_31gss(JaguarSPTest):
+class JaguarSPTest_noatomcharges(JaguarSPTest):
+    """Atomic partial charges were not printed in old Jaguar unit tests."""
+
+    @unittest.skip("Cannot parse atomcharges from this file.")
+    def testatomcharges(self):
+        """Are atomic charges consistent with natom?"""
+
+    @unittest.skip("Cannot parse atomcharges from this file.")
+    def testatomcharges_mulliken(self):
+        """Do Mulliken atomic charges sum to zero?"""
+
+    @unittest.skip("Cannot parse atomcharges from this file.")
+    def testatomcharges_lowdin(self):
+        """Do Lowdin atomic charges sum to zero?"""
+
+
+class JaguarSPTest_6_31gss(JaguarSPTest_noatomcharges):
     """AO counts and some values are different in 6-31G** compared to STO-3G."""
     nbasisdict = {1: 5, 6: 15}
     b3lyp_energy = -10530
@@ -3021,7 +3037,7 @@ class JaguarGeoOptTest_nmo45(GenericGeoOptTest):
         self.assertEqual(len(self.data.moenergies[0]), 45)
 
 
-class JaguarSPTest_nmo45(GenericSPTest):
+class JaguarSPTest_nmo45(JaguarSPTest_noatomcharges):
     def testlengthmoenergies(self):
         """Without special options, Jaguar only print Homo+10 orbital energies."""
         self.assertEqual(len(self.data.moenergies[0]), 45)


### PR DESCRIPTION
This also includes a fix for old versions of Psi4 where the charge header was inconsistent.