### PR TITLE
NWChem: fix sign of atomcharges

### DIFF
--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -806,11 +806,11 @@ class NWChem(logfileparser.Logfile):
             while line.strip():
                 index, atomname, nuclear, atom = line.split()[:4]
                 shells = line.split()[4:]
-                charges.append(float(atom)-float(nuclear))
+                charges.append(float(nuclear)-float(atom))
                 line = next(inputfile)
             self.atomcharges['mulliken'] = charges
 
-        # Not the the 'overlap population' as printed in the Mulliken population analysis,
+        # Note the 'overlap population' as printed in the Mulliken population analysis
         # is not the same thing as the 'overlap matrix'. In fact, it is the overlap matrix
         # multiplied elementwise times the density matrix.
         #
@@ -872,15 +872,15 @@ class NWChem(logfileparser.Logfile):
                 ncharge = float(ncharge)
                 epop = float(epop)
                 assert iatom == (i+1)
-                charges.append(epop-ncharge)
+                charges.append(ncharge-epop)
 
             if not hasattr(self, 'atomcharges'):
                 self.atomcharges = {}
-            if not "mulliken" in self.atomcharges:
-                self.atomcharges['mulliken'] = charges
-            else:
+            if "mulliken" in self.atomcharges:
                 assert max(self.atomcharges['mulliken'] - numpy.array(charges)) < 0.01
-                self.atomcharges['mulliken'] = charges
+            # This is going to be higher precision than "Mulliken analysis of
+            # the total density".
+            self.atomcharges['mulliken'] = charges
 
         # NWChem prints the dipole moment in atomic units first, and we could just fast forward
         # to the values in Debye, which are also printed. But we can also just convert them

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -33,6 +33,36 @@ class GenericSPunTest(unittest.TestCase):
         self.assertEqual(self.data.atomnos.shape, (20,) )
         self.assertEqual(sum(self.data.atomnos==6) + sum(self.data.atomnos==1), 20)
 
+    @skipForParser('ADF', '???')
+    @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
+    @skipForParser('FChk', 'The parser is still being developed so we skip this test')
+    @skipForParser('Jaguar', '???')
+    @skipForParser('Molcas', 'Length is zero for some reason')
+    @skipForParser('Molpro', '???')
+    @skipForParser('Turbomole', '???')
+    def testatomcharges(self):
+        """Are atomic charges consistent with natom?"""
+        for atomcharge_type in self.data.atomcharges:
+            charges = self.data.atomcharges[atomcharge_type]
+            natom = self.data.natom
+            self.assertEqual(
+                len(charges),
+                natom,
+                msg=f"len(atomcharges['{atomcharge_type}']) = {len(charges)}, natom = {natom}"
+            )
+
+    @skipForParser('ADF', '???')
+    @skipForParser('DALTON', 'DALTON has a very low accuracy for the printed values of all populations (2 decimals rounded in a weird way), so let it slide for now')
+    @skipForParser('FChk', 'The parser is still being developed so we skip this test')
+    @skipForParser('Jaguar', '???')
+    @skipForParser('Molcas', 'Length is zero for some reason')
+    @skipForParser('Molpro', '???')
+    @skipForParser('Turbomole', '???')
+    def testatomcharges_mulliken(self):
+        """Do Mulliken atomic charges sum to positive one?"""
+        charges = self.data.atomcharges["mulliken"]
+        self.assertAlmostEqual(sum(charges), 1.0, delta=1.0e-2)
+
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""
         self.assertEqual(self.data.atomcoords.shape,(1,self.data.natom,3))
@@ -174,14 +204,10 @@ class GamessUK80SPunTest(GenericSPunTest):
 class GaussianSPunTest(GenericSPunTest):
     """Customized unrestricted single point unittest"""
 
-    def testatomcharges(self):
-        """Are atomcharges (at least Mulliken) consistent with natom and sum to one?"""
-        for type_ in set(['mulliken'] + list(self.data.atomcharges.keys())):
-            charges = self.data.atomcharges[type_]
-            self.assertEqual(len(charges), self.data.natom)
-            self.assertAlmostEqual(sum(charges), 1.0, delta=0.001)
-
     def testatomspins(self):
+        """Are atomic spins from Mulliken population analysis consistent with
+        natom and sum to one (doublet)?
+        """
         spins = self.data.atomspins['mulliken']
         self.assertEqual(len(spins), self.data.natom)
         self.assertAlmostEqual(sum(spins), 1.0, delta=0.001)

--- a/test/regression.py
+++ b/test/regression.py
@@ -2912,6 +2912,12 @@ class GAMESSUSSPunTest_charge0(GenericSPunTest):
     def testcharge_and_mult(self):
         """The charge in the input was wrong."""
         self.assertEqual(self.data.charge, 0)
+
+    def testatomcharges_mulliken(self):
+        """The charge in the input was wrong."""
+        charges = self.data.atomcharges["mulliken"]
+        self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
+
     @unittest.skip('HOMOs were incorrect due to charge being wrong')
     def testhomos(self):
         """HOMOs were incorrect due to charge being wrong."""
@@ -3148,9 +3154,16 @@ class OrcaSPunTest_charge0(GenericSPunTest):
     def testcharge_and_mult(self):
         """The charge in the input was wrong."""
         self.assertEqual(self.data.charge, 0)
+
+    def testatomcharges_mulliken(self):
+        """The charge in the input was wrong."""
+        charges = self.data.atomcharges["mulliken"]
+        self.assertAlmostEqual(sum(charges), 0.0, delta=0.001)
+
     @unittest.skip('HOMOs were incorrect due to charge being wrong.')
     def testhomos(self):
         """HOMOs were incorrect due to charge being wrong."""
+
     def testorbitals(self):
         """Closed-shell calculation run as open-shell."""
         self.assertTrue(self.data.closed_shell)


### PR DESCRIPTION
In the process of making sure `atomcharges` is tested for all unrestricted calculations and not just Gaussian, I discovered that the sign of (Mulliken) atomic charges in NWChem was wrong.