### PR TITLE
Stop testing Python 3.6

### DIFF
--- a/.github/workflows/cclib_pytest.yml
+++ b/.github/workflows/cclib_pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        container: ['shivupa/cclib-ci:py36', 'shivupa/cclib-ci:py37', 'shivupa/cclib-ci:py38']
+        container: ['shivupa/cclib-ci:py37', 'shivupa/cclib-ci:py38']
     container:
       image: ${{ matrix.container }}
     defaults:


### PR DESCRIPTION
According to https://endoflife.date/python, 3.6 stopped receiving security updates on 2021-12-23. Once this and https://github.com/shivupa/cclib-ci/pull/8 are done, CI should be fixed.