### PR TITLE
Orca: add methods and basis set to metadata

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -629,6 +629,7 @@ Dispersion correction           -0.016199959
                 'ccenergies',
                 utils.convertor(utils.float(line.split()[-1]), 'hartree', 'eV')
             )
+            self.metadata['methods'].append('CCSD')
             line = next(inputfile)
             assert line[:23] == 'Singles Norm <S|S>**1/2'
             line = next(inputfile)

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -88,6 +88,13 @@ class ORCA(logfileparser.Logfile):
             if "SVN: $Rev" in possible_revision_line:
                 version = re.search(r'\d+', possible_revision_line).group()
                 self.metadata["package_version"] += f"+{version}"
+        
+        # Extract basis-set info.
+        # ----- Orbital basis set information -----
+        # Your calculation utilizes the basis: cc-pVDZ
+        if "Your calculation utilizes the basis:" == line[:36]:
+            self.metadata['basis_set'] = line[37:].strip()
+        
 
         # ================================================================================
         #                                         WARNINGS

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -356,7 +356,6 @@ class GenericSPTest(unittest.TestCase):
     @skipForParser('ADF', 'reading basis set names is not implemented')
     @skipForParser('GAMESSUK', 'reading basis set names is not implemented')
     @skipForParser('Molcas', 'reading basis set names is not implemented')
-    @skipForParser('ORCA', 'reading basis set names is not implemented')
     @skipForParser('Psi4', 'reading basis set names is not implemented')
     def testmetadata_basis_set(self):
         """Does metadata have expected keys and values?"""

--- a/test/regression.py
+++ b/test/regression.py
@@ -3126,6 +3126,15 @@ class MolproBigBasisTest_cart(MolproBigBasisTest):
 # ORCA #
 
 
+class OrcaSPTest_nobasis(OrcaSPTest):
+    """Versions pre-4.0 do not concretely print the basis set(s) used aside
+    from repeating the input file.
+    """
+
+    def testmetadata_basis_set(self):
+        self.assertNotIn("basis_set", self.data.metadata)
+
+
 class OrcaSPTest_3_21g(OrcaSPTest):
     nbasisdict = {1: 2, 6: 9}
     b3lyp_energy = -10460
@@ -3400,7 +3409,7 @@ old_unittests = {
 
     "ORCA/ORCA2.8/dvb_gopt.out":    OrcaGeoOptTest,
     "ORCA/ORCA2.8/dvb_sp.out":      GenericBasisTest,
-    "ORCA/ORCA2.8/dvb_sp.out":      OrcaSPTest,
+    "ORCA/ORCA2.8/dvb_sp.out":      OrcaSPTest_nobasis,
     "ORCA/ORCA2.8/dvb_sp_un.out":   OrcaSPunTest_charge0,
     "ORCA/ORCA2.8/dvb_td.out":      OrcaTDDFTTest_pre1085,
     "ORCA/ORCA2.8/dvb_ir.out":      OrcaIRTest_old,
@@ -3410,7 +3419,7 @@ old_unittests = {
     "ORCA/ORCA2.9/dvb_raman.out":   GenericRamanTest,
     "ORCA/ORCA2.9/dvb_scan.out":    OrcaRelaxedScanTest,
     "ORCA/ORCA2.9/dvb_sp.out":      GenericBasisTest,
-    "ORCA/ORCA2.9/dvb_sp.out":      OrcaSPTest,
+    "ORCA/ORCA2.9/dvb_sp.out":      OrcaSPTest_nobasis,
     "ORCA/ORCA2.9/dvb_sp_un.out":   GenericSPunTest,
     "ORCA/ORCA2.9/dvb_td.out":      OrcaTDDFTTest_pre1085,
 
@@ -3421,7 +3430,7 @@ old_unittests = {
     "ORCA/ORCA3.0/dvb_scan.out":          OrcaRelaxedScanTest,
     "ORCA/ORCA3.0/dvb_sp_un.out":         GenericSPunTest,
     "ORCA/ORCA3.0/dvb_sp.out":            GenericBasisTest,
-    "ORCA/ORCA3.0/dvb_sp.out":            OrcaSPTest,
+    "ORCA/ORCA3.0/dvb_sp.out":            OrcaSPTest_nobasis,
     "ORCA/ORCA3.0/dvb_td.out":            OrcaTDDFTTest_pre1085,
     "ORCA/ORCA3.0/Trp_polar.out":         ReferencePolarTest,
     "ORCA/ORCA3.0/trithiolane_polar.out": GaussianPolarTest,


### PR DESCRIPTION
Added some missing metadata (`methods` and `basis_set`) for ORCA