### PR TITLE
Orca etoscs with SOC

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1379,7 +1379,8 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                     else:
                         # Because these energies are new, we do not know if they correspond to the same level of theory
                         # as the previously parsed etsyms etc.
-                        self.logger.warning("New excited state energies encountered in spectrum section, resetting excited state attributes")
+                        self.logger.warning(
+                            "New excited state energies encountered in spectrum section, resetting excited state attributes")
                         
                         for attr in ("etenergies", "etsyms", "etoscs", "etsecs", "etrotats"):
                             if hasattr(self, attr):

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1352,21 +1352,22 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                 if not any([soc_header in name for soc_header in ["SPIN ORBIT CORRECTED", "SOC CORRECTED", "ROCIS COMBINED"]]):
                     # We need to be careful about how we parse etenergies from these spectrum sections.
                     # First, and in most cases, energies printed here will be the same as those printed in 
-                    # previous sections, except to fewer decimal places. It would be disadvantageous to 
-                    # lose this extra precision that's already been parsed.
-                    # Secondly, it is challenging to determine exactly whether the energies printed here have already
-                    # been parsed, due to this aforementioned rounding.
-                    # Thirdly, some methods (ROCIS, CASSCF, SOC to name a few) may only print their final excited state
+                    # previous sections. The energies in cm-1 aught to match exactly to those parsed previously,
+                    # but other units may have rounding errors.
+                    # Secondly, some methods (ROCIS, CASSCF, SOC to name a few) may only print their final excited state
                     # energies in this spectrum section, in which case the energies will not match those previously parsed
                     # (which will be from lower levels of theory that we're not interested in). This means we cannot simply
                     # ignore the energies printed. Also, in this case we must decide whether to discard other previously
                     # parsed etdata (etsyms, etsecs etc).
+                    # Thirdly, SOC prints spin-mixed excited state spectra. This is interesting, but does not match the 
+                    # number of states or symmetry of data parsed in previous sections, so is not used to overwrite etenergies.
                     
                     # If we have no previously parsed etnergies, there's nothing to worry about.
                     if not hasattr(self, "etenergies"):
                         self.set_attribute("etenergies", etenergies)
                     
-                    # Determine if these energies are ~same as those previously parsed.
+                    # Determine if these energies are same as those previously parsed.
+                    # May want to use a smarter comparison?
                     elif len(etenergies) == len(self.etenergies) and all([self.etenergies[index] == etenergy for index, etenergy in enumerate(etenergies)]):
                         pass
                     

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1339,9 +1339,26 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                     etoscs.append(float(intensity))
 
                     line = next(inputfile)
-
-                self.set_attribute('etenergies', etenergies)
-                self.set_attribute('etoscs', etoscs)
+                
+                # Some of these sections contain data that we probably do not want to be populating etenergies
+                # and/or etoscs with.  For example, the SOC corrected spectra are for mixed singlet/triplet states,
+                # so they do not correspond to the symmetries given in etsyms, and the energy values given are
+                # probably not what the user would expect to find in etenergies anyway?
+                # Also, there are twice as many SOC states as true spin states, so half of the etenergies wouldn't 
+                # have a symmetry in etsyms at all...
+                #
+                # Only keep etosc given by the normal electric TDM.
+                if name == "ABSORPTION SPECTRUM VIA TRANSITION ELECTRIC DIPOLE MOMENTS":
+                    # There's no point overwriting the etenergies we've already parsed,
+                    # especially because the previously parsed values are probably more accurate.
+                    # We could do a check to make sure the energies match, but we will fall foul
+                    # of rounding errors.
+                    if not hasattr(self, "etenergies"):
+                        self.set_attribute("etenergies", etenergies)
+                    
+                    self.set_attribute('etoscs', etoscs)
+                
+                # Save everything to transprop.
                 self.transprop[name] = (numpy.asarray(etenergies), numpy.asarray(etoscs))
 
         if line.strip() == "CD SPECTRUM":

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1368,7 +1368,11 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                     
                     # Determine if these energies are same as those previously parsed.
                     # May want to use a smarter comparison?
-                    elif len(etenergies) == len(self.etenergies) and all([self.etenergies[index] == etenergy for index, etenergy in enumerate(etenergies)]):
+                    elif len(etenergies) == len(self.etenergies) and \
+                        all(
+                            [self.etenergies[index] == etenergy for
+                            index, etenergy in enumerate(etenergies)]
+                        ):
                         pass
                     
                     # New energies.

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1387,14 +1387,6 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
                                 
                         self.set_attribute("etenergies", etenergies)
                     
-#                     # There's no point overwriting the etenergies we've already parsed,
-#                     # especially because the previously parsed values normally have greater precision.
-#                     # We could do a check to make sure the energies match, but we will fall foul
-#                     # of rounding errors.
-#                     #if not hasattr(self, "etenergies"):
-#                     if True:
-#                         self.set_attribute("etenergies", etenergies)
-                    
                     self.set_attribute('etoscs', etoscs)
                 
                 # Save everything to transprop.

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -226,6 +226,7 @@ class GenericTDDFTtrpTest(GenericTDTest):
 class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
     number = 57
+    number = 4
     expected_l_max = 2316970.8
     # per 1085, no VELOCITY DIPOLE MOMENTS are parsed
     n_spectra = 7

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -225,7 +225,6 @@ class GenericTDDFTtrpTest(GenericTDTest):
 
 class OrcaROCISTest(GenericTDTest):
     """Customized test for ROCIS"""
-    number = 57
     number = 4
     expected_l_max = 2316970.8
     # per 1085, no VELOCITY DIPOLE MOMENTS are parsed


### PR DESCRIPTION
Spin-orbit coupling calculations in Orca generate a number of SOC-corrected absorption spectra. The current version of cclib parses all of these and uses the corresponding values to overwrite values of etenergies and etoscs. This is probably undesirable, as in most cases it is the bare electronic transitions that are of interest, rather than the spin-mixed ones. 

Even if this is the desired behaviour, it is currently incompatible with the values of etsyms that are parsed, which are only for the un-mixed states (there are also more spin-mixed states than etsyms).

This PR changes this behaviour so only the etoscs corresponding to the unmixed states are parsed (but please note that this is technically a loss in functionality if it really was the spin-mixed states you were after). The test for the ORCA ROCIS file has been changed to reflect this.