### PR TITLE
Fix for crash when parsing multiple files with various parsers

### DIFF
--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -166,7 +166,7 @@ class ADF(logfileparser.Logfile):
         # this with the previous block, if possible.
         if line[:6] == "Create":
             while line[:5] != "title" and "NO TITLE" not in line:
-                line = inputfile.next()
+                line = next(inputfile)
 
         if line[1:10] == "Symmetry:":
             info = line.split()
@@ -322,17 +322,17 @@ class ADF(logfileparser.Logfile):
 
             self.skip_line(inputfile, 'blank')
 
-            line = inputfile.next()
+            line = next(inputfile)
             while line.strip():
 
                 colline = line
                 assert colline.split()[0] == "column"
                 columns = [int(i) for i in colline.split()[1:]]
 
-                rowline = inputfile.next()
+                rowline = next(inputfile)
                 assert rowline.strip() == "row"
 
-                line = inputfile.next()
+                line = next(inputfile)
                 while line.strip():
 
                     i = int(line.split()[0])
@@ -342,9 +342,9 @@ class ADF(logfileparser.Logfile):
                         overlaps[k-1][i-1] = o
                         overlaps[i-1][k-1] = o
 
-                    line = inputfile.next()
+                    line = next(inputfile)
 
-                line = inputfile.next()
+                line = next(inputfile)
 
             # Now all values should be parsed, and so no Nones remaining.
             assert all([all([x is not None for x in ao]) for ao in overlaps])
@@ -954,23 +954,23 @@ class ADF(logfileparser.Logfile):
 #            # There will be some text, followed by a line:
 #            #       (power of) X  Y  Z  R     Alpha  on Atom
 #            while not line[1:11] == "(power of)":
-#                line = inputfile.next()
-#            dashes = inputfile.next()
-#            blank = inputfile.next()
-#            line = inputfile.next()
+#                line = next(inputfile)
+#            dashes = next(inputfile)
+#            blank = next(inputfile)
+#            line = next(inputfile)
 #            # There will be two blank lines when there are no more atom types.
 #            while line.strip() != "":
 #                atoms = [int(i)-1 for i in line.split()[1:]]
 #                for n in range(len(atoms)):
 #                    self.atombasis.append([])
-#                dashes = inputfile.next()
-#                line = inputfile.next()
+#                dashes = next(inputfile)
+#                line = next(inputfile)
 #                while line.strip() != "":
 #                    indices = [int(i)-1 for i in line.split()[5:]]
 #                    for i in range(len(indices)):
 #                        self.atombasis[atoms[i]].append(indices[i])
-#                    line = inputfile.next()
-#                line = inputfile.next()
+#                    line = next(inputfile)
+#                line = next(inputfile)
 
         if line[48:67] == "SFO MO coefficients":
 

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -530,7 +530,7 @@ class DALTON(logfileparser.Logfile):
 
             self.skip_lines(inputfile, ['d', 'b'])
 
-            line = inputfile.next()
+            line = next(inputfile)
             self.symcounts = [int(c) for c in line.split(':')[1].split()]
 
             self.symlabels = []
@@ -540,7 +540,7 @@ class DALTON(logfileparser.Logfile):
 
                 # If the number of orbitals for a symmetry is zero, the printout
                 # is different (see MP2 unittest logfile for an example).
-                line = inputfile.next()
+                line = next(inputfile)
 
                 if sc == 0:
                     assert "No orbitals in symmetry" in line
@@ -549,7 +549,7 @@ class DALTON(logfileparser.Logfile):
                     self.symlabels.append(line.split()[1])
                     self.skip_line(inputfile, 'blank')
                     for i in range(sc):
-                        orbital = inputfile.next()
+                        orbital = next(inputfile)
 
         if "Starting in Wave Function Section (SIRIUS)" in line:
             self.section = "SIRIUS"

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -721,13 +721,13 @@ class GAMESSUK(logfileparser.Logfile):
             occupations = []
 
             self.skip_line(inputfile, "blank")
-            line = inputfile.next()
+            line = next(inputfile)
 
             while line.strip():
                 occupations += map(float, line.split())
 
                 self.skip_line(inputfile, "blank")
-                line = inputfile.next()
+                line = next(inputfile)
 
             self.set_attribute('nooccnos', occupations)
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -228,7 +228,7 @@ class Gaussian(logfileparser.Logfile):
 
             self.updateprogress(inputfile, "Symbolic Z-matrix", self.fupdate)
 
-            line = inputfile.next()
+            line = next(inputfile)
             while line.split()[0] == 'Charge':
 
                 # For the supermolecule, we can parse the charge and multicplicity.
@@ -245,7 +245,7 @@ class Gaussian(logfileparser.Logfile):
                 if line.strip()[-13:] == "model system.":
                     self.nmodels = getattr(self, 'nmodels', 0) + 1
 
-                line = inputfile.next()
+                line = next(inputfile)
 
             # The remaining part will allow us to get the atom count.
             # When coordinates are given, there is a blank line at the end, but if
@@ -256,7 +256,7 @@ class Gaussian(logfileparser.Logfile):
             natom = 0
             while line.split() and not "Variables" in line and not "Leave Link" in line:
                 natom += 1
-                line = inputfile.next()
+                line = next(inputfile)
             self.set_attribute('natom', natom)
 
         # Continuing from above, there is not always a symbolic matrix, for example
@@ -319,7 +319,7 @@ class Gaussian(logfileparser.Logfile):
             self.reference = [0.0, 0.0, 0.0]
             self.moments = [self.reference]
 
-            tokens = inputfile.next().split()
+            tokens = next(inputfile).split()
             # split - dipole would need to be *huge* to fail a split
             # and G03 and G09 use different spacing
             if len(tokens) >= 6:
@@ -339,7 +339,7 @@ class Gaussian(logfileparser.Logfile):
             #   XX=    -6.1213   YY=    -4.2950   ZZ=    -5.4175
             quadrupole = {}
             for j in range(2): # two rows
-                line = inputfile.next()
+                line = next(inputfile)
                 if line[22] == '=': # g03 file
                     for i in (1, 18, 35):
                         quadrupole[line[i:i+4]] = float(line[i+5:i+16])
@@ -368,7 +368,7 @@ class Gaussian(logfileparser.Logfile):
             #  YYZ=             -0.5848  XYZ=              0.0000
             octapole = {}
             for j in range(2): # two rows
-                line = inputfile.next()
+                line = next(inputfile)
                 if line[22] == '=': # g03 file
                     for i in (1, 18, 35, 52):
                         octapole[line[i:i+4]] = float(line[i+5:i+16])
@@ -377,7 +377,7 @@ class Gaussian(logfileparser.Logfile):
                         octapole[line[i:i+4]] = float(line[i+5:i+25])
 
             # last line only 2 moments
-            line = inputfile.next()
+            line = next(inputfile)
             if line[22] == '=': # g03 file
                 for i in (1, 18):
                     octapole[line[i:i+4]] = float(line[i+5:i+16])
@@ -408,7 +408,7 @@ class Gaussian(logfileparser.Logfile):
             hexadecapole = {}
             # read three lines worth of 4 moments per line
             for j in range(3):
-                line = inputfile.next()
+                line = next(inputfile)
                 if line[22] == '=': # g03 file
                     for i in (1, 18, 35, 52):
                         hexadecapole[line[i:i+4]] = float(line[i+5:i+16])
@@ -417,7 +417,7 @@ class Gaussian(logfileparser.Logfile):
                         hexadecapole[line[i:i+4]] = float(line[i+5:i+25])
 
             # last line only 3 moments
-            line = inputfile.next()
+            line = next(inputfile)
             if line[22] == '=': # g03 file
                 for i in (1, 18, 35):
                     hexadecapole[line[i:i+4]] = float(line[i+5:i+16])
@@ -642,7 +642,7 @@ class Gaussian(logfileparser.Logfile):
         # we will want to parse the model systems, too, and that is what nmodels could track.
         if "ONIOM: generating point" in line and line.strip()[-13:] == 'model system.' and getattr(self, 'nmodels', 0) > 0:
             while not line[1:30] == 'ONIOM: Integrating ONIOM file':
-                line = inputfile.next()
+                line = next(inputfile)
 
         # With the gfinput keyword, the atomic basis set functions are:
         #
@@ -683,14 +683,14 @@ class Gaussian(logfileparser.Logfile):
             if self.counterpoise != 0:
                 return
 
-            atom_line = inputfile.next()
+            atom_line = next(inputfile)
             self.gfprint = atom_line.split()[0] == "Atom"
             self.gfinput = not self.gfprint
 
             # Note how the shell information is on a separate line for gfinput,
             # whereas for gfprint it is on the same line as atom information.
             if self.gfinput:
-                shell_line = inputfile.next()
+                shell_line = next(inputfile)
 
             shell = []
             while len(self.gbasis) < self.natom:
@@ -706,7 +706,7 @@ class Gaussian(logfileparser.Logfile):
 
                 parameters = []
                 for ig in range(ngauss):
-                    line = inputfile.next()
+                    line = next(inputfile)
                     parameters.append(list(map(utils.float, line.split())))
                 for iss, ss in enumerate(subshells):
                     contractions = []
@@ -718,7 +718,7 @@ class Gaussian(logfileparser.Logfile):
                     shell.append(subshell)
 
                 if self.gfprint:
-                    line = inputfile.next()
+                    line = next(inputfile)
                     if line.split()[0] == "Atom":
                         atomnum = int(re.sub(r"\D", "", line.split()[1]))
                         if atomnum == len(self.gbasis) + 2:
@@ -728,12 +728,12 @@ class Gaussian(logfileparser.Logfile):
                     else:
                         self.gbasis.append(shell)
                 else:
-                    line = inputfile.next()
+                    line = next(inputfile)
                     if line.strip() == "****":
                         self.gbasis.append(shell)
                         shell = []
-                        atom_line = inputfile.next()
-                        shell_line = inputfile.next()
+                        atom_line = next(inputfile)
+                        shell_line = next(inputfile)
                     else:
                         shell_line = line
 

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -165,7 +165,7 @@ def openlogfile(filename, object=None):
         if len(filename) == 0:
             return None
 
-        return fileinput.input(filename, openhook=fileinput.hook_compressed)
+        return FileWrapper(fileinput.input(filename, openhook=fileinput.hook_compressed))
 
 
 class Logfile(ABC):

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -117,10 +117,10 @@ class MOPAC(logfileparser.Logfile):
             self.inputcoords = []
             self.inputatoms = []
 
-            blankline = inputfile.next()
+            blankline = next(inputfile)
 
             atomcoords = []
-            line = inputfile.next()
+            line = next(inputfile)
             while len(line.split()) > 6:
                 # MOPAC Version 14.019L 64BITS suddenly appends this block with
                 # "CARTESIAN COORDINATES" block with no blank line.
@@ -130,7 +130,7 @@ class MOPAC(logfileparser.Logfile):
                 yc = float(tokens[4])
                 zc = float(tokens[6])
                 atomcoords.append([xc, yc, zc])
-                line = inputfile.next()
+                line = next(inputfile)
 
             self.inputcoords.append(atomcoords)
 
@@ -170,8 +170,8 @@ class MOPAC(logfileparser.Logfile):
         # note that the last occurence of this in the thermochemistry section has reduced precision,
         # so we will want to use the 2nd to last instance
         if line[0:40] == '          ROTATIONAL CONSTANTS IN CM(-1)':
-            blankline = inputfile.next()
-            rotinfo = inputfile.next()
+            blankline = next(inputfile)
+            rotinfo = next(inputfile)
             if not hasattr(self, "rotconsts"):
                 self.rotconsts = []
             broken = rotinfo.split()
@@ -206,14 +206,14 @@ class MOPAC(logfileparser.Logfile):
                     self.vibsyms = []
                 self.vibsyms.append(sym)
 
-            line = inputfile.next()
+            line = next(inputfile)
             if 'FREQ' in line:
                 if not hasattr(self, 'vibfreqs'):
                     self.vibfreqs = []
                 freq = float(line.split()[1])
                 self.vibfreqs.append(freq)
 
-            line = inputfile.next()
+            line = next(inputfile)
             if 'T-DIPOLE' in line:
                 if not hasattr(self, 'vibirs'):
                     self.vibirs = []
@@ -221,11 +221,11 @@ class MOPAC(logfileparser.Logfile):
                 # transform to km/mol
                 self.vibirs.append(math.sqrt(tdipole))
 
-            line = inputfile.next()
+            line = next(inputfile)
             if 'TRAVEL' in line:
                 pass
 
-            line = inputfile.next()
+            line = next(inputfile)
             if 'RED. MASS' in line:
                 if not hasattr(self, 'vibrmasses'):
                     self.vibrmasses = []
@@ -241,10 +241,10 @@ class MOPAC(logfileparser.Logfile):
                 self.moenergies = [] # list of arrays
 
             energies = []
-            line = inputfile.next()
+            line = next(inputfile)
             while len(line.split()) > 0:
                 energies.extend([float(i) for i in line.split()])
-                line = inputfile.next()
+                line = next(inputfile)
             self.moenergies.append(energies)
 
         # todo:

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -361,11 +361,11 @@ class NWChem(logfileparser.Logfile):
 
                 self.skip_line(inputfile, 'blank')
 
-                indices = [int(i) for i in inputfile.next().split()]
+                indices = [int(i) for i in next(inputfile).split()]
                 assert indices[0] == len(aooverlaps) + 1
 
                 self.skip_line(inputfile, "dashes")
-                data = [inputfile.next().split() for i in range(self.nbasis)]
+                data = [next(inputfile).split() for i in range(self.nbasis)]
                 indices = [int(d[0]) for d in data]
                 assert indices == list(range(1, self.nbasis+1))
 

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1404,9 +1404,9 @@ cannot be determined. Rerun without `$molecule read`."""
 
                 # This line appears not by default, but only when
                 # `multipole_order` > 4:
-                line = inputfile.next()
+                line = next(inputfile)
                 if 'LMN = < X^L Y^M Z^N >' in line:
-                    line = inputfile.next()
+                    line = next(inputfile)
 
                 # The reference point is always the origin, although normally the molecule
                 # is moved so that the center of charge is at the origin.
@@ -1416,15 +1416,15 @@ cannot be determined. Rerun without `$molecule read`."""
                 # Watch out! This charge is in statcoulombs without the exponent!
                 # We should expect very good agreement, however Q-Chem prints
                 # the charge only with 5 digits, so expect 1e-4 accuracy.
-                charge_header = inputfile.next()
+                charge_header = next(inputfile)
                 assert charge_header.split()[0] == "Charge"
-                charge = float(inputfile.next().strip())
+                charge = float(next(inputfile).strip())
                 charge = utils.convertor(charge, 'statcoulomb', 'e') * 1e-10
                 # Allow this to change until fragment jobs are properly implemented.
                 # assert abs(charge - self.charge) < 1e-4
 
                 # This will make sure Debyes are used (not sure if it can be changed).
-                line = inputfile.next()
+                line = next(inputfile)
                 assert line.strip() == "Dipole Moment (Debye)"
 
                 while "-----" not in line:
@@ -1432,14 +1432,14 @@ cannot be determined. Rerun without `$molecule read`."""
                     # The current multipole element will be gathered here.
                     multipole = []
 
-                    line = inputfile.next()
+                    line = next(inputfile)
                     while ("-----" not in line) and ("Moment" not in line):
 
                         cols = line.split()
 
                         # The total (norm) is printed for dipole but not other multipoles.
                         if cols[0] == 'Tot':
-                            line = inputfile.next()
+                            line = next(inputfile)
                             continue
 
                         # Find and replace any 'stars' with NaN before moving on.
@@ -1468,7 +1468,7 @@ cannot be determined. Rerun without `$molecule read`."""
                                 m = cols[4*i + 3]
                                 multipole.append([lbl, m])
 
-                        line = inputfile.next()
+                        line = next(inputfile)
 
                     # Sort should use the first element when sorting lists,
                     # so this should simply work, and afterwards we just need

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -28,7 +28,7 @@ class AtomBasis:
 
     def parse_basis(self, inputfile):
         i=0
-        line=inputfile.next()
+        line=next(inputfile)
 
         while(line[0]!="*"):
             (nbasis_text, symm)=line.split()
@@ -38,13 +38,13 @@ class AtomBasis:
             coeff_arr=numpy.zeros((nbasis, 2), float)
 
             for j in range(0, nbasis, 1):
-                line=inputfile.next()
+                line=next(inputfile)
                 (e1_text, e2_text)=line.split()
                 coeff_arr[j][0]=float(e1_text)
                 coeff_arr[j][1]=float(e2_text)
 
             self.coefficients.append(coeff_arr)
-            line=inputfile.next()
+            line=next(inputfile)
 
 class Turbomole(logfileparser.Logfile):
     """A Turbomole log file."""
@@ -1404,33 +1404,33 @@ class OldTurbomole(logfileparser.Logfile):
         if line[0:6] == "$basis":
             print("Found basis")
             self.basis_lib=[]
-            line = inputfile.next()
-            line = inputfile.next()
+            line = next(inputfile)
+            line = next(inputfile)
 
             while line[0] != '*' and line[0] != '$':
                 temp=line.split()
-                line = inputfile.next()
+                line = next(inputfile)
                 while line[0]=="#":
-                    line = inputfile.next()
+                    line = next(inputfile)
                 self.basis_lib.append(AtomBasis(temp[0], temp[1], inputfile))
-                line = inputfile.next()
+                line = next(inputfile)
         if line == "$ecp\n":
             self.ecp_lib=[]
             
-            line = inputfile.next()
-            line = inputfile.next()
+            line = next(inputfile)
+            line = next(inputfile)
             
             while line[0] != '*' and line[0] != '$':
                 fields=line.split()
                 atname=fields[0]
                 ecpname=fields[1]
-                line = inputfile.next()
-                line = inputfile.next()
+                line = next(inputfile)
+                line = next(inputfile)
                 fields=line.split()
                 ncore = int(fields[2])
 
                 while line[0] != '*':
-                    line = inputfile.next()
+                    line = next(inputfile)
                 self.ecp_lib.append([atname, ecpname, ncore])
         
         if line[0:6] == "$coord":
@@ -1444,7 +1444,7 @@ class OldTurbomole(logfileparser.Logfile):
             atomcoords = []
             atomnos = []
 
-            line = inputfile.next()
+            line = next(inputfile)
             if line[0:5] == "$user":
 #                print "Breaking"
                 return
@@ -1455,7 +1455,7 @@ class OldTurbomole(logfileparser.Logfile):
                 atomnos.append(self.table.number[atsym])
                 atomcoords.append([utils.convertor(float(x), "bohr", "Angstrom")
                                    for x in temp[0:3]])
-                line = inputfile.next()
+                line = next(inputfile)
             self.atomcoords.append(atomcoords)
             self.atomnos = numpy.array(atomnos, "i")
 
@@ -1463,7 +1463,7 @@ class OldTurbomole(logfileparser.Logfile):
             atomcoords = []
             atomnos = []
 
-            line = inputfile.next()
+            line = next(inputfile)
            
             while len(line) > 2:
                 temp = line.split()
@@ -1471,7 +1471,7 @@ class OldTurbomole(logfileparser.Logfile):
                 atomnos.append(self.table.number[atsym])
                 atomcoords.append([utils.convertor(float(x), "bohr", "Angstrom")
                                     for x in temp[0:3]])
-                line = inputfile.next()
+                line = next(inputfile)
 
             if not hasattr(self,"atomcoords"):
                 self.atomcoords = []
@@ -1481,32 +1481,32 @@ class OldTurbomole(logfileparser.Logfile):
 
         if line[0:6] == "$atoms":
             print("parsing atoms")
-            line = inputfile.next()
+            line = next(inputfile)
             self.atomlist=[]
             while line[0]!="$":
                 temp=line.split()
                 at=temp[0]
                 atnosstr=temp[1]
                 while atnosstr[-1] == ",":
-                    line = inputfile.next()
+                    line = next(inputfile)
                     temp=line.split()
                     atnosstr=atnosstr+temp[0]
 #                print "Debug:", atnosstr
                 atlist=self.atlist(atnosstr)
 
-                line = inputfile.next()
+                line = next(inputfile)
 
                 temp=line.split()
 #                print "Debug basisname (temp):",temp
                 basisname=temp[2]
                 ecpname=''
-                line = inputfile.next()
+                line = next(inputfile)
                 while(line.find('jbas')!=-1 or line.find('ecp')!=-1 or
                       line.find('jkbas')!=-1):
                     if line.find('ecp')!=-1:
                         temp=line.split()
                         ecpname=temp[2]
-                    line = inputfile.next()
+                    line = next(inputfile)
 
                 self.atomlist.append( (at, basisname, ecpname, atlist))
 
@@ -1656,30 +1656,30 @@ class OldTurbomole(logfileparser.Logfile):
                 counter=counter+1
                 
         if line=="$closed shells\n":
-            line = inputfile.next()
+            line = next(inputfile)
             temp = line.split()
             occs = int(temp[1][2:])
             self.homos = numpy.array([occs-1], "i")
 
         if line == "$alpha shells\n":
-            line = inputfile.next()
+            line = next(inputfile)
             temp = line.split()
             occ_a = int(temp[1][2:])
-            line = inputfile.next() # should be $beta shells
-            line = inputfile.next() # the beta occs
+            line = next(inputfile) # should be $beta shells
+            line = next(inputfile) # the beta occs
             temp = line.split()
             occ_b = int(temp[1][2:])
             self.homos = numpy.array([occ_a-1,occ_b-1], "i")
 
         if line[12:24]=="OVERLAP(CAO)":
-            line = inputfile.next()
-            line = inputfile.next()
+            line = next(inputfile)
+            line = next(inputfile)
             overlaparray=[]
             self.aooverlaps=numpy.zeros( (self.nbasis, self.nbasis), "d")
             while line != "       ----------------------\n":
                 temp=line.split()
                 overlaparray.extend(map(float, temp))
-                line = inputfile.next()
+                line = next(inputfile)
             counter=0
 
             for i in range(0, self.nbasis, 1):
@@ -1704,18 +1704,18 @@ class OldTurbomole(logfileparser.Logfile):
             self.mocoeffs=[]
 
             for spin in range(unrestricted + 1): # make sure we cover all instances
-                title = inputfile.next()
+                title = next(inputfile)
                 while(title[0] == "#"):
-                    title = inputfile.next()
+                    title = next(inputfile)
 
 #                mocoeffs = numpy.zeros((self.nbasis, self.nbasis), "d")
                 moenergies = []
                 moarray=[]
 
                 if spin == 1 and title[0:11] == "$uhfmo_beta":
-                    title = inputfile.next()
+                    title = next(inputfile)
                     while title[0] == "#":
-                        title = inputfile.next()
+                        title = next(inputfile)
 
                 while(title[0] != '$'):
                     temp=title.split()
@@ -1734,12 +1734,12 @@ class OldTurbomole(logfileparser.Logfile):
                     
                     while(len(single_mo)<self.nbasis):
                         self.updateprogress(inputfile, "Coefficients", self.cupdate)
-                        title = inputfile.next()
+                        title = next(inputfile)
                         lines_coeffs=self.split_molines(title)
                         single_mo.extend(lines_coeffs)
                         
                     moarray.append(single_mo)
-                    title = inputfile.next()
+                    title = next(inputfile)
 
 #                for i in range(0, len(moarray), 1):
 #                    for j in range(0, self.nbasis, 1):
@@ -1764,13 +1764,13 @@ class OldTurbomole(logfileparser.Logfile):
         if line[12:26] == "ATOMIC WEIGHTS":
 #begin parsing atomic weights
            self.vibmasses=[]
-           line=inputfile.next() # lines =======
-           line=inputfile.next() # notes
-           line=inputfile.next() # start reading
+           line=next(inputfile) # lines =======
+           line=next(inputfile) # notes
+           line=next(inputfile) # start reading
            temp=line.split()
            while(len(temp) > 0):
                 self.vibmasses.append(float(temp[2]))
-                line=inputfile.next()
+                line=next(inputfile)
                 temp=line.split()
 
         if line[5:14] == "frequency":
@@ -1786,43 +1786,43 @@ class OldTurbomole(logfileparser.Logfile):
             freqs = [utils.float(f) for f in temp[1:]]
             self.vibfreqs.extend(freqs)
                     
-            line=inputfile.next()
-            line=inputfile.next()
+            line=next(inputfile)
+            line=next(inputfile)
 
             syms=line.split()
             self.vibsyms.extend(syms[1:])
 
-            line=inputfile.next()
-            line=inputfile.next()
-            line=inputfile.next()
-            line=inputfile.next()
+            line=next(inputfile)
+            line=next(inputfile)
+            line=next(inputfile)
+            line=next(inputfile)
 
             temp=line.split()
             irs = [utils.float(f) for f in temp[2:]]
             self.vibirs.extend(irs)
 
-            line=inputfile.next()
-            line=inputfile.next()
-            line=inputfile.next()
-            line=inputfile.next()
+            line=next(inputfile)
+            line=next(inputfile)
+            line=next(inputfile)
+            line=next(inputfile)
 
             x=[]
             y=[]
             z=[]
 
-            line=inputfile.next()
+            line=next(inputfile)
             while len(line) > 1:
                 temp=line.split()
                 x.append(map(float, temp[3:]))
 
-                line=inputfile.next()
+                line=next(inputfile)
                 temp=line.split()
                 y.append(map(float, temp[1:]))
 
-                line=inputfile.next()
+                line=next(inputfile)
                 temp=line.split()
                 z.append(map(float, temp[1:]))
-                line=inputfile.next()
+                line=next(inputfile)
 
 # build xyz vectors for each mode
 
@@ -1832,7 +1832,7 @@ class OldTurbomole(logfileparser.Logfile):
                     disp.append( [x[j][i], y[j][i], z[j][i]])
                 self.vibdisps.append(disp)
 
-#        line=inputfile.next()
+#        line=next(inputfile)
 
     def after_parsing(self):
 


### PR DESCRIPTION
Different parsers use different styles for obtaining the next line from the current input file, either they tend to use `line = next(inputfile)` or `line = inputfile.next()`. This is sadly a problem because not all `inputfile` objects support the `next()` method.

In particular, when parsing a single log file, `inputfile` is normally a `FileWrapper` object, while when parsing multiple log files, the `inputfile` is instead a `FileInput` object. `FileWrapper` support the `next()` method while `FileInput` does not, so parsers that do not typically expect multiple log files as input will crash when given so. For example the Gaussian parser when given any two files:

```
Attempting to read 246tCzPPC.log and 246tCzPPC.log
[Gaussian ['246tCzPPC.log', '246tCzPPC.log'] ERROR] Encountered error when parsing.
Traceback (most recent call last):
  File "/home/oliver/dev/cclib/cclib Src/cclib/parser/logfileparser.py", line 321, in parse
    self.extract(inputfile, line)
  File "/home/oliver/dev/cclib/cclib Src/cclib/parser/gaussianparser.py", line 241, in extract
    line = inputfile.next()
AttributeError: 'FileInput' object has no attribute 'next'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/oliver/.local/bin/ccget", line 8, in <module>
    sys.exit(ccget())
  File "/home/oliver/dev/cclib/cclib Src/cclib/scripts/ccget.py", line 178, in ccget
    data = ccread(filename, **kwargs)
  File "/home/oliver/dev/cclib/cclib Src/cclib/io/ccio.py", line 170, in ccread
    return log.parse()
  File "/home/oliver/dev/cclib/cclib Src/cclib/parser/logfileparser.py", line 327, in parse
    self.logger.error(f"Last line read: {inputfile.last_line}")
AttributeError: 'FileInput' object has no attribute 'last_line'
```

This PR changes all `inputfile.next()` instances to the more general `next(inputfile)`, and also correctly wraps `FileInput` objects with `FileWrapper` (this also gives access to the `last_line` attribute, and perhaps other stuff too). The change from .next() to next() is technically unnecessary but I thought it made sense to address at the same time to prevent problems in the future?