### PR TITLE
install pyquante2 with Python 3 fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ periodictable
 # bridges
 biopython==1.76
 ase>=3.21 ; python_version >= '3.5'
-git+https://github.com/berquist/pyquante2.git@py37 ; python_version > '3.0'
+git+https://github.com/berquist/pyquante2.git@py37
+git+https://github.com/theochem/iodata.git@1.0.0a2
 
 # For building the documentation
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ periodictable
 # bridges
 biopython==1.76
 ase>=3.21 ; python_version >= '3.5'
-git+https://github.com/rpmuller/pyquante2.git ; python_version > '3.0'
+git+https://github.com/berquist/pyquante2.git@py37 ; python_version > '3.0'
 
 # For building the documentation
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ periodictable
 # bridges
 biopython==1.76
 ase>=3.21 ; python_version >= '3.5'
-# for pyquante2
-cython
 git+https://github.com/cclib/pyquante2.git@py37
 git+https://github.com/theochem/iodata.git@1.0.0a2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ periodictable
 # bridges
 biopython==1.76
 ase>=3.21 ; python_version >= '3.5'
-git+https://github.com/berquist/pyquante2.git@py37
+# for pyquante2
+cython
+git+https://github.com/cclib/pyquante2.git@py37
 git+https://github.com/theochem/iodata.git@1.0.0a2
 
 # For building the documentation


### PR DESCRIPTION
My fork has some fixes that let us use pyquante2 with all new Python versions.

iodata is required by tests and wasn't being installed.