### PR TITLE
Psi4 parser update

### DIFF
--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -788,7 +788,7 @@ class Psi4(logfileparser.Logfile):
         # This message signals a converged optimization, in which case we want
         # to append the index for this step to optdone, which should be equal
         # to the number of geovalues gathered so far.
-        if "Optimization is complete!" in line:
+        if "Final optimized geometry and variables:" in line:
 
             # This is a workaround for Psi4.0/sample_opt-irc-2.out;
             # IRC calculations currently aren't parsed properly for

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -896,7 +896,7 @@ class Psi4(logfileparser.Logfile):
                 while line.strip():
 
                     tokens = line.split()
-                    if tokens[0] == "Magnitude":
+                    if tokens[0] in ("Magnitude", "Traceless"):
                         line = next(inputfile)
                         continue
                     value = float(tokens[-1])
@@ -914,7 +914,7 @@ class Psi4(logfileparser.Logfile):
                 line = next(inputfile)
 
             if not hasattr(self, 'moments'):
-                self.moments = moments
+                self.set_attribute("moments", moments)
             else:
                 for im, m in enumerate(moments):
                     if len(self.moments) <= im:

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -812,9 +812,16 @@ class Psi4(logfileparser.Logfile):
         # Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
         #
         if "Properties will be evaluated at" in line.strip():
-            self.origin = numpy.array([float(x.strip(',')) for x in line.split()[-4:-1]])
-            assert line.split()[-1] in ["Bohr", "[a0]"]
-            self.origin = utils.convertor(self.origin, 'bohr', 'Angstrom')
+            tokens = line.split()
+            assert tokens[-1] in ["Bohr", "[a0]"]
+            self.set_attribute(
+                "origin",
+                utils.convertor(
+                    numpy.array([float(x.strip(',')) for x in line.split()[-4:-1]]),
+                    'bohr',
+                    'Angstrom'
+                )
+            )
 
         # The properties section print the molecular dipole moment:
         #

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -1237,12 +1237,12 @@ class Psi4(logfileparser.Logfile):
         line = next(inputfile)
         assert 'Reduced mass' in line
         chomp = line.split()
-        vibrmasses = [utils.float(x) for x in chomp[3:]]
+        vibrmasses = [float(x) for x in chomp[3:]]
 
         line = next(inputfile)
         assert 'Force const' in line
         chomp = line.split()
-        vibfconsts = [utils.float(x) for x in chomp[3:]]
+        vibfconsts = [float(x) for x in chomp[3:]]
 
         line = next(inputfile)
         assert 'Turning point' in line
@@ -1253,7 +1253,7 @@ class Psi4(logfileparser.Logfile):
         line = next(inputfile)
         if 'IR activ' in line:
             chomp = line.split()
-            vibirs = [utils.float(x) for x in chomp[3:]]
+            vibirs = [float(x) for x in chomp[3:]]
             line = next(inputfile)
         else:
             vibirs = []

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -895,7 +895,11 @@ class Psi4(logfileparser.Logfile):
                 line = next(inputfile)
                 while line.strip():
 
-                    value = float(line.split()[-1])
+                    tokens = line.split()
+                    if tokens[0] == "Magnitude":
+                        line = next(inputfile)
+                        continue
+                    value = float(tokens[-1])
                     fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
                     tounits = (
                         f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -787,11 +787,7 @@ class Psi4(logfileparser.Logfile):
             # IRC calculations currently aren't parsed properly for
             # optimization parameters.
             if hasattr(self, 'geovalues'):
-
-                if not hasattr(self, 'optdone'):
-                    self.optdone = []
-                self.optdone.append(len(self.geovalues))
-
+                self.append_attribute("optdone", len(self.geovalues))
                 assert hasattr(self, "optstatus") and len(self.optstatus) > 0
                 self.optstatus[-1] += data.ccData.OPT_DONE
 

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -841,22 +841,24 @@ class Psi4(logfileparser.Logfile):
         if (self.section == "Properties") and line.strip() == "Dipole Moment: (a.u.)":
 
             line = next(inputfile)
-            dipole = numpy.array([float(line.split()[1]), float(line.split()[3]), float(line.split()[5])])
-            dipole = utils.convertor(dipole, "ebohr", "Debye")
+            tokens = line.split()
+            dipole = utils.convertor(
+                numpy.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]),
+                "ebohr",
+                "Debye"
+            )
 
             if not hasattr(self, 'moments'):
                 # Old versions of Psi4 don't print the origin; assume
                 # it's at zero.
                 if not hasattr(self, 'origin'):
-                    self.origin = numpy.array([0.0, 0.0, 0.0])
-                self.moments = [self.origin, dipole]
+                    self.set_attribute("origin", numpy.array([0.0, 0.0, 0.0]))
+                self.set_attribute("moments", [self.origin, dipole])
             else:
                 try:
                     assert numpy.all(self.moments[1] == dipole)
                 except AssertionError:
-                    self.logger.warning('Overwriting previous multipole moments with new values')
-                    self.logger.warning('This could be from post-HF properties or geometry optimization')
-                    self.moments = [self.origin, dipole]
+                    self.set_attribute("moments", [self.origin, dipole])
 
         # Higher multipole moments are printed separately, on demand, in lexicographical order.
         #

--- a/test/testdata
+++ b/test/testdata
@@ -41,6 +41,8 @@ Basis     Psi4        GenericBasisTest      basicPsi4-1.2.1       dvb_sp_rhf.out
 Basis     Psi4        GenericBasisTest      basicPsi4-1.2.1       dvb_sp_rks.out
 Basis     Psi4        GenericBasisTest      basicPsi4-1.3.1       dvb_sp_rhf.out
 Basis     Psi4        GenericBasisTest      basicPsi4-1.3.1       dvb_sp_rks.out
+Basis     Psi4        GenericBasisTest      basicPsi4-1.7         dvb_sp_rhf.out
+Basis     Psi4        GenericBasisTest      basicPsi4-1.7         dvb_sp_rks.out
 Basis     QChem       GenericBasisTest      basicQChem5.1         dvb_sp.out
 Basis     QChem       GenericBasisTest      basicQChem5.4         dvb_sp.out
 
@@ -60,6 +62,7 @@ Basis     NWChem      GenericBigBasisTest   basicNWChem6.5        C_bigbasis.out
 Basis     NWChem      GenericBigBasisTest   basicNWChem7.0        C_bigbasis.out
 Basis     Psi4        Psi4BigBasisTest      basicPsi4-1.2.1       C_bigbasis.out
 Basis     Psi4        Psi4BigBasisTest      basicPsi4-1.3.1       C_bigbasis.out
+Basis     Psi4        Psi4BigBasisTest      basicPsi4-1.7         C_bigbasis.out
 Basis     QChem       QChemBigBasisTest     basicQChem5.1         C_bigbasis.out
 Basis     QChem       QChemBigBasisTest     basicQChem5.4         C_bigbasis.out
 
@@ -103,6 +106,8 @@ CC        Psi4        Psi4CCSDTest          basicPsi4-1.2.1       water_ccsd.out
 CC        Psi4        Psi4CCSDPTTest        basicPsi4-1.2.1       water_ccsd(t).out
 CC        Psi4        Psi4CCSDTest          basicPsi4-1.3.1       water_ccsd.out
 CC        Psi4        Psi4CCSDPTTest        basicPsi4-1.3.1       water_ccsd(t).out
+CC        Psi4        Psi4CCSDTest          basicPsi4-1.7         water_ccsd.out
+CC        Psi4        Psi4CCSDPTTest        basicPsi4-1.7         water_ccsd(t).out
 CC        QChem       GenericCCDTest        basicQChem5.1         water_ccd.out
 CC        QChem       GenericCCSDTest       basicQChem5.1         water_ccsd.out
 CC        QChem       GenericCCSDPTTest     basicQChem5.1         water_ccsd(t).out
@@ -170,6 +175,8 @@ GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.2.1       dvb_gopt_rhf.o
 GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.2.1       dvb_gopt_rks.out
 GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.3.1       dvb_gopt_rhf.out
 GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.3.1       dvb_gopt_rks.out
+GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.7         dvb_gopt_rhf.out
+GeoOpt    Psi4        Psi4GeoOptTest        basicPsi4-1.7         dvb_gopt_rks.out
 GeoOpt    QChem       GenericGeoOptTest     basicQChem5.1         dvb_gopt.out
 GeoOpt    QChem       GenericGeoOptTest     basicQChem5.4         dvb_gopt.out
 GeoOpt    Turbomole   TurbomoleGeoOptTest   basicTurbomole5.9     dvb_gopt/basis      dvb_gopt/control      dvb_gopt/mos      dvb_gopt/job.last
@@ -214,6 +221,7 @@ MP        ORCA        GenericMP3Test        basicORCA4.2          water_mp3.out
 MP        ORCA        GenericMP3Test        basicORCA5.0          water_mp3.out
 MP        Psi4        GenericMP2Test        basicPsi4-1.2.1       water_mp2.out
 MP        Psi4        GenericMP2Test        basicPsi4-1.3.1       water_mp2.out
+MP        Psi4        GenericMP2Test        basicPsi4-1.7         water_mp2.out
 MP        QChem       GenericMP2Test        basicQChem5.1         water_mp2.out
 MP        QChem       GenericMP3Test        basicQChem5.1         water_mp3.out
 MP        QChem       QChemMP4SDQTest       basicQChem5.1         water_mp4sdq.out
@@ -296,6 +304,8 @@ SP        Psi4        PsiHFSPTest           basicPsi4-1.2.1             dvb_sp_r
 SP        Psi4        PsiSPTest             basicPsi4-1.2.1             dvb_sp_rks.out
 SP        Psi4        PsiHFSPTest           basicPsi4-1.3.1             dvb_sp_rhf.out
 SP        Psi4        PsiSPTest             basicPsi4-1.3.1             dvb_sp_rks.out
+SP        Psi4        PsiHFSPTest           basicPsi4-1.7               dvb_sp_rhf.out
+SP        Psi4        PsiSPTest             basicPsi4-1.7               dvb_sp_rks.out
 SP        QChem       GenericSPTest         basicQChem5.1               dvb_sp.out
 SP        QChem       GenericSPTest         basicQChem5.4               dvb_sp.out
 SP        Turbomole   TurbomoleSPTest       basicTurbomole5.9           dvb_sp_symm/mos       dvb_sp_symm/basis      dvb_sp_symm/control      dvb_sp_symm/dscf.out      dvb_sp_symm/coord
@@ -312,6 +322,7 @@ SP        ORCA        GenericDispersionTest basicORCA4.2                dvb_disp
 SP        ORCA        GenericDispersionTest basicORCA5.0                dvb_dispersion_bp86_d3zero.out
 SP        Psi4        GenericDispersionTest basicPsi4-1.2.1             dvb_dispersion_bp86_d3zero.out
 SP        Psi4        GenericDispersionTest basicPsi4-1.3.1             dvb_dispersion_bp86_d3zero.out
+SP        Psi4        GenericDispersionTest basicPsi4-1.7               dvb_dispersion_bp86_d3zero.out
 SP        QChem       GenericDispersionTest basicQChem5.1               dvb_dispersion_bp86_d3zero.out
 SP        QChem       GenericDispersionTest basicQChem5.4               dvb_dispersion_bp86_d3zero.out
 
@@ -349,6 +360,9 @@ SPun      Psi4        GenericSPunTest       basicPsi4-1.2.1       dvb_sp_uks.out
 SPun      Psi4        GenericROSPTest       basicPsi4-1.3.1       dvb_sp_rohf.out
 SPun      Psi4        GenericSPunTest       basicPsi4-1.3.1       dvb_sp_uhf.out
 SPun      Psi4        GenericSPunTest       basicPsi4-1.3.1       dvb_sp_uks.out
+SPun      Psi4        GenericROSPTest       basicPsi4-1.7         dvb_sp_rohf.out
+SPun      Psi4        GenericSPunTest       basicPsi4-1.7         dvb_sp_uhf.out
+SPun      Psi4        GenericSPunTest       basicPsi4-1.7         dvb_sp_uks.out
 SPun      QChem       GenericSPunTest       basicQChem5.1         dvb_sp_un.out
 SPun      QChem       GenericSPunTest       basicQChem5.4         dvb_sp_un.out
 SPun      Turbomole   GenericSPunTest       basicTurbomole5.9     dvb_un_sp/alpha    dvb_un_sp/beta    dvb_un_sp/basis    dvb_un_sp/control    dvb_un_sp/dscf.out    dvb_un_sp/coord    dvb_un_sp/gradient
@@ -410,6 +424,7 @@ vib       ORCA        GenericIRTest         basicORCA4.2          dvb_ir.out
 vib       ORCA        GenericIRTest         basicORCA5.0          dvb_ir.out
 vib       Psi4        Psi4IRTest            basicPsi4-1.2.1       dvb_ir_rhf.out
 vib       Psi4        Psi4IRTest            basicPsi4-1.3.1       dvb_ir_rhf.out
+vib       Psi4        Psi4IRTest            basicPsi4-1.7         dvb_ir_rhf.out
 vib       QChem       QChemIRTest           basicQChem5.1         dvb_ir.out
 vib       QChem       QChemIRTest           basicQChem5.4         dvb_ir.out
 vib       Turbomole   TurbomoleIRTest       basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out


### PR DESCRIPTION
The existing parser fails when parsing current (v1.7) Psi4 outputs. I've added new sample data and fixed the parser for the Convergence Check and IR Vibrations sections. I also changed the line endings to LF. 