### PR TITLE
FChk: fix hessian parsing

### DIFF
--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -8,13 +8,8 @@
 """Parser for Formatted Checkpoint files"""
 
 
-from __future__ import print_function
-
-import re
-
 import numpy
 
-from cclib.parser import data
 from cclib.parser import logfileparser
 from cclib.parser import utils
 
@@ -196,7 +191,7 @@ class FChk(logfileparser.Logfile):
 
             hessian = numpy.array(self._parse_block(inputfile, count, float, 'Hessian'))
 
-            self.set_attribute('hessian', hessian)
+            self.set_attribute('hessian', utils.block_to_matrix(hessian))
 
         if line[0:13] == 'ETran scalars':
             count = int(line.split()[-1])

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -45,14 +45,15 @@ def symmetrize(m: numpy.ndarray, use_triangle: str = 'lower') -> numpy.ndarray:
 
     dim = m.shape[0]
 
-    lower_indices = numpy.tril_indices(dim, k=-1)
-    upper_indices = numpy.triu_indices(dim, k=1)
-
     ms = m.copy()
 
     if use_triangle == 'lower':
+        lower_indices = numpy.tril_indices(dim, k=-1)
+        upper_indices = (lower_indices[1], lower_indices[0])
         ms[upper_indices] = ms[lower_indices]
     if use_triangle == 'upper':
+        upper_indices = numpy.triu_indices(dim, k=1)
+        lower_indices = (upper_indices[1], upper_indices[0])
         ms[lower_indices] = ms[upper_indices]
 
     return ms

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -10,6 +10,7 @@
 import importlib
 import re
 from itertools import accumulate
+from math import sqrt
 from typing import Iterable, List, Sequence, TypeVar
 
 import numpy
@@ -250,3 +251,21 @@ class WidthSplitter:
             while len(elements) and elements[-1] == '':
                 elements.pop()
         return elements
+
+
+def _dim_from_tblock_size(x: int) -> int:
+    """Given the number of elements in a symmetric matrix lower triangle,
+    compute the dimension of the full matrix.
+    """
+    return int(max(0.5 * (sqrt(8*x + 1) - 1), 0.5 * (-sqrt(8*x + 1) - 1)))
+
+
+def block_to_matrix(block: numpy.ndarray) -> numpy.ndarray:
+    """Convert a flattened symmetric matrix lower triangle to its full
+    symmetrized form.
+    """
+    assert len(block.shape) == 1
+    dim = _dim_from_tblock_size(block.shape[0])
+    mat = numpy.empty(shape=(dim, dim), dtype=block.dtype)
+    mat[numpy.tril_indices_from(mat)] = block
+    return symmetrize(mat)

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -256,9 +256,17 @@ class WidthSplitter:
 
 def _dim_from_tblock_size(x: int) -> int:
     """Given the number of elements in a symmetric matrix lower triangle,
-    compute the dimension of the full matrix.
+    including the diagonal, compute the dimension (length of one side) of the
+    full matrix.
     """
-    return int(max(0.5 * (sqrt(8*x + 1) - 1), 0.5 * (-sqrt(8*x + 1) - 1)))
+    r1 = 0.5 * (sqrt(8*x + 1) - 1)
+    r2 = 0.5 * (-sqrt(8*x + 1) - 1)
+    m = max(r1, r2)
+    if _BUILTIN_FLOAT(round(m)) != m:
+        raise RuntimeError(
+            f"The number of elements ({x}) isn't possible for a matrix triangle"
+        )
+    return int(m)
 
 
 def block_to_matrix(block: numpy.ndarray) -> numpy.ndarray:

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -96,7 +96,6 @@ class GenericIRTest(unittest.TestCase):
         assert abs(self.data.zpve - self.zpve) < 1.0e-3
 
     @skipForParser('ADF', 'not implemented yet')
-    @skipForParser('FChk', 'not implemented yet')
     @skipForParser('GAMESSUK', 'not implemented yet')
     @skipForParser('Gaussian', 'not implemented yet')
     @skipForParser('Jaguar', 'not implemented yet')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -113,5 +113,37 @@ class WidthSplitterTest(unittest.TestCase):
         assert ref_not_truncated == tokens_not_truncated
 
 
+class SymmetrizeTest(unittest.TestCase):
+
+    def test_dim_from_tblock_size(self) -> None:
+        assert utils._dim_from_tblock_size(1) == 1
+        # This isn't possible until we fully move to pytest.
+        # with pytest.raises(
+        #     RuntimeError,
+        #     match="The number of elements (2) isn't possible for a matrix triangle"
+        # ):
+        #     assert utils._dim_from_tblock_size(2)
+        assert utils._dim_from_tblock_size(3) == 2
+        assert utils._dim_from_tblock_size(6) == 3
+        assert utils._dim_from_tblock_size(10) == 4
+
+    def test_block_to_matrix(self) -> None:
+        inp = numpy.array([1, 2, 3, 4, 5, 6], dtype=int)
+        ref = numpy.array([[1, 2, 4], [2, 3, 5], [4, 5, 6]], dtype=int)
+        numpy.testing.assert_equal(utils.block_to_matrix(inp), ref)
+
+    def test_symmetrize(self) -> None:
+        inp = numpy.array([[1, 9, 7],
+                           [4, 8, 3],
+                           [6, 2, 5]], dtype=int)
+        ref_lower = numpy.array([[1, 4, 6],
+                                 [4, 8, 2],
+                                 [6, 2, 5]], dtype=int)
+        ref_upper = numpy.array([[1, 9, 7],
+                                 [9, 8, 3],
+                                 [7, 3, 5]], dtype=int)
+        numpy.testing.assert_equal(utils.symmetrize(inp, "lower"), ref_lower)
+        numpy.testing.assert_equal(utils.symmetrize(inp, "upper"), ref_upper)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A followup to #1199.  The 3N-by-3N matrix wasn't being saved.