### PR TITLE
initial devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "name": "cclib",
+    "image": "shivupa/cclib-ci:py38"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
     "name": "cclib",
-    "image": "shivupa/cclib-ci:py38"
+    "image": "shivupa/cclib-ci:py310-edge"
 }


### PR DESCRIPTION
This is a file used by [Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers) and the [devcontainers CLI](https://github.com/devcontainers/cli) based on a [specification](https://containers.dev/) that eases the ability to develop inside a container.  It lets you either build an image on the fly, or in our case, reuse an image that contains all of the development and runtime dependencies for the codebase, and an editor/the CLI can start a container with the correct location mounted so that the working copy of the source code is visible inside the container.  The presence of this file triggers VSC to prompt on startup/opening a file in cclib if you want to use a Dev Container.

Our initial version is based upon our CI images ([definitions](https://github.com/shivupa/cclib-ci), [Docker Hub](https://hub.docker.com/r/shivupa/cclib-ci)).  The correct Python environment (`/opt/conda/envs/cclib/bin/python`) is already active in the built-in terminal (container) and is visible in the Python VS Code extension.  Running `bash .github/scripts/run_pytest.bash` in the terminal works as expected because it's the same as the CI environment.

Current issues are
- the image user is `root`, which means that built-in terminal operations that create or modify files will show as `root` on the parent filesystem.  This doesn't affect pytest.
- https://github.com/actions/checkout/issues/760 as on CI.  Run `git status` and the error message tells you exactly what to do.  This might go away once the above is fixed because the root cause file ownership, not that the image comes with an older version of Git.
- it is confusing which `cclib` is being used.  When running through the devcontainer interface, it is mounted as `/workspace/cclib`.  However, there is a copy baked into the image at `/root/cclib` because of https://github.com/shivupa/cclib-ci/blob/5b031c7b95b79bfd9560b036060798579908ff7a/py310/Dockerfile#L35 for the purposes of testing the image during building.  If you try and use this image outside the devcontainer interface and don't set a proper bind mount, you'll only see this copy, which is *not* the one you want.