### PR TITLE
ORCA: fix field width for parsing Hirshfeld charges

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2208,7 +2208,7 @@ States  Energy Wavelength    D2        m2        Q2         D2+m2+Q2       D2/TO
             start, stop = 11, 26
         elif chargestype == 'hirshfeld':
             should_stop = lambda x: not bool(x.strip())
-            start, stop = 9, 17
+            start, stop = 9, 18
             self.skip_lines(
                 inputfile,
                 [

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -116,7 +116,7 @@ class GenericSPTest(unittest.TestCase):
     def testatomcharges_hirshfeld(self):
         """Do Hirshfeld atomic charges sum to roughly zero?"""
         charges = self.data.atomcharges["hirshfeld"]
-        assert abs(sum(charges)) < 5.0e-2
+        assert abs(sum(charges)) < 4.0e-3
 
     def testatomcoords(self):
         """Are the dimensions of atomcoords 1 x natom x 3?"""


### PR DESCRIPTION
Closes #1209

Tightening the threshold could have been done without the fix.  It might take a lot of work to construct a test case that would actually trigger the bug.