### PR TITLE
Fix for not all input objects supporting `last_line`

### DIFF
--- a/cclib/io/__init__.py
+++ b/cclib/io/__init__.py
@@ -25,4 +25,3 @@ from cclib.io.ccio import ccframe
 from cclib.io.ccio import ccopen
 from cclib.io.ccio import ccread
 from cclib.io.ccio import ccwrite
-from cclib.io.ccio import URL_PATTERN

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -162,7 +162,7 @@ def ccread(source, *args, **kwargs):
         return fallback(source)
 
 
-def ccopen(source, *args, quiet = False, **kwargs):
+def ccopen(source, *args, quiet = False, cjson = False, **kwargs):
     """Guess the identity of a particular log file and return an instance of it.
 
     Inputs:
@@ -192,7 +192,8 @@ def ccopen(source, *args, quiet = False, **kwargs):
         # If the input file isn't a standard compchem log file, try one of
         # the readers, falling back to Open Babel.
         if not filetype:
-            if kwargs.get("cjson"):
+            
+            if cjson:
                 filetype = readerclasses['cjson']
                 
             else:

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -109,25 +109,17 @@ class UnknownOutputFormatError(Exception):
 
 def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     """Try to guess the filetype by searching for trigger strings."""
-    if not inputfile:
-        return None
 
     filetype = None
-    if isinstance(inputfile, str):
-        for line in inputfile:
-            for parser, phrases, do_break in triggers:
-                if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
-                    filetype = parser
-                    if do_break:
-                        return filetype
-    else:
-        for fname in inputfile:
-            for line in inputfile:
-                for parser, phrases, do_break in triggers:
-                    if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
-                        filetype = parser
-                        if do_break:
-                            return filetype
+    print(inputfile)
+
+    for line in inputfile:
+        for parser, phrases, do_break in triggers:
+            if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
+                filetype = parser
+                if do_break:
+                    return filetype
+    
     return filetype
 
 

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -207,6 +207,10 @@ def ccopen(source, *args, quiet = False, cjson = False, **kwargs):
         # We're going to swallow this exception if quiet is True.
         # This can hide a lot of errors, so we'll make sure to log it.
         logging.error("Failed to open logfile", exc_info = True)
+        
+    # If we get here, we've failed to identify the log file type.
+    if not quiet:
+        raise ValueError("Unable to determine the type of logfile {}".format(source))
 
 
 def fallback(source):

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -145,7 +145,7 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
     try:
         log = ccopen(source, *args, **kwargs)
         if log:
-            logging.getLogger("cclib").info(f"Identified logfile to be in {log.logname} format")
+            logging.getLogger("cclib").info("Identified logfile to be in {} format".format(type(log).__name__))
 
             return log.parse()
         else:

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -160,8 +160,8 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
 def ccopen(
         source: Union[str, typing.IO, FileWrapper, list],
         *args,
-        quiet = False,
-        cjson = False,
+        quiet: bool = False,
+        cjson: bool = False,
         **kwargs
     ):
     """Guess the identity of a particular log file and return an instance of it.

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -182,7 +182,7 @@ def ccopen(
       Molpro, MOPAC, NWChem, ORCA, Psi3, Psi/Psi4, QChem, CJSON or None
       (if it cannot figure it out or the file does not exist).
     """
-    if isinstance(source, str) or not hasattr(source, "__iter__"):
+    if not isinstance(source, list):
         source = [source]
         
     inputfile = None

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -205,7 +205,7 @@ def ccopen(
         # the readers, falling back to Open Babel.
         if not filetype:
             # TODO: This assumes we only got a single file...
-            filename = list(inputfile.input_files)[0]
+            filename = list(inputfile.filenames)[0]
             ext = pathlib.Path(filename).name[1:].lower()
             
             for extension in readerclasses:

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -145,14 +145,9 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
     try:
         log = ccopen(source, *args, **kwargs)
         if log:
-            # If the input file is a CJSON file and not a standard compchemlog file
-            cjson_as_input = kwargs.get("cjson", False)
-            if cjson_as_input:
-                return log.read_cjson()
-            else:
-                return log.parse()
             logging.getLogger("cclib").info(f"Identified logfile to be in {log.logname} format")
 
+            return log.parse()
         else:
             logging.getLogger("cclib").info('Attempting to use fallback mechanism to read file')
             return fallback(source)

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -171,31 +171,29 @@ def ccopen(source, *args, quiet = False, cjson = False, **kwargs):
         source = [source]
         
     try:
+        # Wrap our input with custom file object.
         inputfile = FileWrapper(*source)
-    
-        # Proceed to return an instance of the logfile parser only if the filetype
-        # could be guessed. Need to make sure the input file is closed before creating
-        # an instance, because parsers will handle opening/closing on their own.
-        filetype = guess_filetype(inputfile)
         
-        # Reset our position back to 0.
-        inputfile.reset()
+        if cjson:
+            filetype = readerclasses['cjson']
+        
+        else:
+            # Try and guess the parser we need.
+            filetype = guess_filetype(inputfile)
+        
+            # Reset our position back to 0.
+            inputfile.reset()
     
         # If the input file isn't a standard compchem log file, try one of
         # the readers, falling back to Open Babel.
         if not filetype:
+            # TODO: This assumes we only got a single file...
+            filename = list(inputfile.input_files)[0]
+            ext = pathlib.Path(filename).name[1:].lower()
             
-            if cjson:
-                filetype = readerclasses['cjson']
-                
-            else:
-                # TODO: This assumes we only got a single file...
-                filename = list(inputfile.input_files)[0]
-                ext = pathlib.Path(filename).name[1:].lower()
-                
-                for extension in readerclasses:
-                    if ext == extension:
-                        filetype = readerclasses[extension]
+            for extension in readerclasses:
+                if ext == extension:
+                    filetype = readerclasses[extension]
     
         # Proceed to return an instance of the logfile parser only if the filetype
         # could be guessed.

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -127,7 +127,11 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     return filetype
 
 
-def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
+def ccread(
+        source: Union[str, typing.IO, FileWrapper, typing.List[Union[str, typing.IO]]],
+        *args,
+        **kwargs
+    ):
     """Attempt to open and read computational chemistry data from a file.
 
     If the file is not appropriate for cclib parsers, a fallback mechanism
@@ -158,7 +162,7 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
 
 
 def ccopen(
-        source: Union[str, typing.IO, FileWrapper, list],
+        source: Union[str, typing.IO, FileWrapper, typing.List[Union[str, typing.IO]]],
         *args,
         quiet: bool = False,
         cjson: bool = False,

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -111,13 +111,16 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     """Try to guess the filetype by searching for trigger strings."""
 
     filetype = None
-
-    for line in inputfile:
-        for parser, phrases, do_break in triggers:
-            if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
-                filetype = parser
-                if do_break:
-                    return filetype
+    try:
+        for line in inputfile:
+            for parser, phrases, do_break in triggers:
+                if all([line.lower().find(p.lower()) >= 0 for p in phrases]):
+                    filetype = parser
+                    if do_break:
+                        return filetype
+    except Exception:
+        # guess_filetype() is expected to be quiet by default...
+        logging.error("Failed to determine log file type", exc_info = True)
     
     return filetype
 

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -145,17 +145,16 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
     try:
         log = ccopen(source, *args, **kwargs)
         if log:
-            if kwargs.get("verbose", None):
-                print(f"Identified logfile to be in {log.logname} format")
             # If the input file is a CJSON file and not a standard compchemlog file
             cjson_as_input = kwargs.get("cjson", False)
             if cjson_as_input:
                 return log.read_cjson()
             else:
                 return log.parse()
+            logging.getLogger("cclib").info(f"Identified logfile to be in {log.logname} format")
+
         else:
-            if kwargs.get('verbose', None):
-                print('Attempting to use fallback mechanism to read file')
+            logging.getLogger("cclib").info('Attempting to use fallback mechanism to read file')
             return fallback(source)
     
     finally:
@@ -255,7 +254,9 @@ def fallback(source):
             if ext in pb.informats:
                 return cclib2openbabel.readfile(source, ext)
         else:
-            print("Could not import `openbabel`, fallback mechanism might not work.")
+            # This should be a warning, but warnings are currently disabled by default.
+            logging.getLogger("cclib").error(
+                "Could not import `openbabel`, fallback mechanism might not work.")
 
 
 def ccwrite(ccobj, outputtype=None, outputdest=None,

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -122,7 +122,7 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
                         return filetype
     except Exception:
         # guess_filetype() is expected to be quiet by default...
-        logging.error("Failed to determine log file type", exc_info = True)
+        logging.getLogger("cclib").error("Failed to determine log file type", exc_info = True)
     
     return filetype
 
@@ -234,7 +234,7 @@ def ccopen(
         
         # We're going to swallow this exception if quiet is True.
         # This can hide a lot of errors, so we'll make sure to log it.
-        logging.error("Failed to open logfile", exc_info = True)
+        logging.getLogger("cclib").error("Failed to open logfile", exc_info = True)
 
 
 def fallback(source):

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -13,6 +13,7 @@ import typing
 from typing import Optional
 import logging
 from typing import Union
+import warnings
 
 from cclib.parser import data
 from cclib.parser import logfileparser
@@ -126,6 +127,25 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     
     return filetype
 
+def sort_turbomole_outputs(fileinputs):
+    """
+    Sorts a list of inputs (or list of log files) according to the order
+    required by the Turbomole parser for correct parsing. Unrecognised
+    files are appended to the end of the list in the same order they are
+    given.
+    
+    This function has been deprecated as of version 1.8; use:
+    cclib.parser.turbomoleparser.Turbomole.sort_input() instead
+
+    Inputs:
+      filelist - a list of Turbomole log files needed to be parsed.
+    Returns:
+      sorted_list - a sorted list of Turbomole files needed for proper parsing.
+    """
+    warnings.warn(
+        "sort_turbomole_outputs() has been deprecated as of v1.8; use: "+ \
+        "cclib.parser.turbomoleparser.Turbomole.sort_input() instead")
+    return Turbomole.sort_input(fileinputs)
 
 def ccread(
         source: Union[str, typing.IO, FileWrapper, typing.List[Union[str, typing.IO]]],

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -9,8 +9,10 @@
 import io
 import os
 import pathlib
+import typing
 from typing import Optional
 import logging
+from typing import Union
 
 from cclib.parser import data
 from cclib.parser import logfileparser
@@ -125,7 +127,7 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     return filetype
 
 
-def ccread(source, *args, **kwargs):
+def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
     """Attempt to open and read computational chemistry data from a file.
 
     If the file is not appropriate for cclib parsers, a fallback mechanism
@@ -161,7 +163,13 @@ def ccread(source, *args, **kwargs):
             log.inputfile.close()
 
 
-def ccopen(source, *args, quiet = False, cjson = False, **kwargs):
+def ccopen(
+        source: Union[str, typing.IO, FileWrapper, list],
+        *args,
+        quiet = False,
+        cjson = False,
+        **kwargs
+    ):
     """Guess the identity of a particular log file and return an instance of it.
 
     Inputs:

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -141,7 +141,7 @@ def ccread(source: Union[str, typing.IO, FileWrapper, list], *args, **kwargs):
     Returns:
         a ccData object containing cclib data attributes
     """
-
+    log = None
     try:
         log = ccopen(source, *args, **kwargs)
         if log:

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -111,7 +111,6 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     """Try to guess the filetype by searching for trigger strings."""
 
     filetype = None
-    print(inputfile)
 
     for line in inputfile:
         for parser, phrases, do_break in triggers:

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -8,12 +8,15 @@
 """Generic file reader and related tools"""
 
 from abc import ABC, abstractmethod
+import typing
+
+from cclib.parser.logfilewrapper import FileWrapper
 
 
 class Reader(ABC):
     """Abstract class for reader objects."""
 
-    def __init__(self, source: str, *args, **kwargs) -> None:
+    def __init__(self, source: str | typing.io | FileWrapper, *args, **kwargs) -> None:
         """Initialize the Reader object.
 
         This should be called by a subclass in its own __init__ method.
@@ -21,18 +24,14 @@ class Reader(ABC):
         Inputs:
           source - A single filename, stream [TODO], or list of filenames/streams [TODO].
         """
-        if isinstance(source, str):
-            self.filename = source
-        else:
-            raise ValueError
+        if not isinstance(source, FileWrapper):
+            source = FileWrapper(source)
+        
+        self.file = source
 
     def parse(self) -> None:
         """Read the raw contents of the source into the Reader."""
-        # TODO This cannot currently handle streams.
-        with open(self.filename) as handle:
-            self.filecontents = handle.read()
-
-        return None
+        self.filecontents = self.file.read()
 
     @abstractmethod
     def generate_repr(self) -> None:

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -16,7 +16,10 @@ from cclib.parser.logfilewrapper import FileWrapper
 class Reader(ABC):
     """Abstract class for reader objects."""
 
-    def __init__(self, source: typing.Union[str, typing.IO, FileWrapper, list], *args, **kwargs) -> None:
+    def __init__(self,
+        source: typing.Union[str, typing.IO, FileWrapper, typing.List[typing.Union[str, typing.IO]]],
+        *args,
+        **kwargs)-> None:
         """Initialize the Reader object.
 
         This should be called by a subclass in its own __init__ method.

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -27,11 +27,11 @@ class Reader(ABC):
         if not isinstance(source, FileWrapper):
             source = FileWrapper(source)
         
-        self.file = source
+        self.inputfile = source
 
     def parse(self) -> None:
         """Read the raw contents of the source into the Reader."""
-        self.filecontents = self.file.read()
+        self.filecontents = self.inputfile.read()
 
     @abstractmethod
     def generate_repr(self) -> None:

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -16,7 +16,7 @@ from cclib.parser.logfilewrapper import FileWrapper
 class Reader(ABC):
     """Abstract class for reader objects."""
 
-    def __init__(self, source: str | typing.io | FileWrapper, *args, **kwargs) -> None:
+    def __init__(self, source: typing.Union[str, typing.IO, FileWrapper, list], *args, **kwargs) -> None:
         """Initialize the Reader object.
 
         This should be called by a subclass in its own __init__ method.

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -96,12 +96,12 @@ class Writer(ABC):
     def _make_openbabel_from_ccdata(self):
         """Create Open Babel and Pybel molecules from ccData."""
         if not hasattr(self.ccdata, 'charge'):
-            logging.warning("ccdata object does not have charge, setting to 0")
+            logging.getLogger("cclib").warning("ccdata object does not have charge, setting to 0")
             _charge = 0
         else:
             _charge = self.ccdata.charge
         if not hasattr(self.ccdata, 'mult'):
-            logging.warning("ccdata object does not have spin multiplicity, setting to 1")
+            logging.getLogger("cclib").warning("ccdata object does not have spin multiplicity, setting to 1")
             _mult = 1
         else:
             _mult = self.ccdata.mult

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -14,6 +14,7 @@ import numpy
 
 from cclib.parser import logfileparser
 from cclib.parser import utils
+from cclib.parser.logfileparser import StopParsing
 
 
 class ADF(logfileparser.Logfile):
@@ -106,8 +107,9 @@ class ADF(logfileparser.Logfile):
         # not always be the best indicator.
         if line.strip() == "(INPUT FILE)" and hasattr(self, "scftargets"):
             self.logger.warning("Skipping remaining calculations")
-            inputfile.seek(0, 2)
-            return
+            #inputfile.seek(0, 2)
+            #return
+            raise StopParsing()
 
         # We also want to check to make sure we aren't parsing "Create" jobs,
         # which normally come before the calculation we actually want to parse.

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -107,8 +107,6 @@ class ADF(logfileparser.Logfile):
         # not always be the best indicator.
         if line.strip() == "(INPUT FILE)" and hasattr(self, "scftargets"):
             self.logger.warning("Skipping remaining calculations")
-            #inputfile.seek(0, 2)
-            #return
             raise StopParsing()
 
         # We also want to check to make sure we aren't parsing "Create" jobs,

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -15,6 +15,7 @@ import numpy
 from cclib.parser import data
 from cclib.parser import logfileparser
 from cclib.parser import utils
+from cclib.parser.logfileparser import StopParsing
 
 
 class Gaussian(logfileparser.Logfile):
@@ -709,7 +710,8 @@ class Gaussian(logfileparser.Logfile):
         # all fragment, but that will happen in a newer version of cclib.
         if line[1:16] == "Fragment guess:" and getattr(self, 'nfragments', 0) > 1:
             if not "full" in line:
-                inputfile.seek(0, 2)
+                #inputfile.seek(0, 2)
+                raise StopParsing()
 
         # Another hack for regression Gaussian03/ortho_prod_freq.log, which is an ONIOM job.
         # Basically for now we stop parsing after the output for the real system, because

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -710,7 +710,6 @@ class Gaussian(logfileparser.Logfile):
         # all fragment, but that will happen in a newer version of cclib.
         if line[1:16] == "Fragment guess:" and getattr(self, 'nfragments', 0) > 1:
             if not "full" in line:
-                #inputfile.seek(0, 2)
                 raise StopParsing()
 
         # Another hack for regression Gaussian03/ortho_prod_freq.log, which is an ONIOM job.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -58,7 +58,7 @@ class Logfile(ABC):
             
         self.inputfile = source
         # If our parser needs a certain file ordering, set that now.
-        self.inputfile.input_files = self.sort_input(self.inputfile.input_files)
+        self.inputfile.sort(self.sort_input(self.inputfile.filenames))
 
         # Set up the logger.
         # Note that calling logging.getLogger() with one name always returns the same instance.
@@ -102,11 +102,11 @@ class Logfile(ABC):
     def filename(self):
         return self.inputfile.file_name
         
-    def sort_input(self, file_objects):
+    def sort_input(self, file_names: list) -> list:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """
-        return file_objects
+        return file_names
 
     def __setattr__(self, name, value):
 

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -25,6 +25,11 @@ from cclib.parser.logfilewrapper import FileWrapper
 logging.logMultiprocessing = 0    
 
 
+class StopParsing(Exception):
+    """
+    An exception to signal that parsing should stop.
+    """
+
 class Logfile(ABC):
     """Abstract class for logfile objects.
 
@@ -162,6 +167,9 @@ class Logfile(ABC):
             #   in data._attrlist will be moved to final data object that is returned.
             try:
                 self.extract(self.inputfile, line)
+            except StopParsing:
+                # This is fine
+                break
             except StopIteration:
                 self.logger.error("Unexpectedly encountered end of logfile.")
                 break

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -107,8 +107,9 @@ class Logfile(ABC):
     @property
     def filename(self):
         return self.inputfile.file_name
-        
-    def sort_input(self, file_names: list) -> list:
+    
+    @classmethod
+    def sort_input(self, file_names: typing.List(str)) -> typing.List:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -205,12 +205,12 @@ class Logfile(ABC):
         # assumed to be filenames. Otherwise, assume the source is a file-like object
         # if it has a read method, and we will try to use it like a stream.
         self.isfileinput = False
-        if isinstance(source, str):
+        if isinstance(source, str) or \
+            (isinstance(source, list) and all([isinstance(s, str) for s in source])):
+            # 'Source' is actually just a (list of) filename(s).
             self.filename = source
             self.isstream = False
-        elif isinstance(source, list) and all([isinstance(s, str) for s in source]):
-            self.filename = source
-            self.isstream = False
+        
         elif isinstance(source, fileinput.FileInput):
             self.filename = source
             self.isstream = False

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -176,7 +176,7 @@ def openlogfile(filename: Union[str, List[str]], object=None):
         
         # The 'errors' argument of fileinput.FileInput() looks like it should do what we want here,
         # but it's only available in python3.10 and even then doesn't work properly in conjunction with openhook...
-        return fileinput.FileInput(filename, openhook = opencompressedfile)
+        return FileWrapper(fileinput.FileInput(filename, openhook = opencompressedfile))
 
 
 class Logfile(ABC):

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -340,7 +340,10 @@ class Logfile(ABC):
                     break
                 except Exception as e:
                     self.logger.error("Encountered error when parsing.")
-                    self.logger.error(f"Last line read: {inputfile.last_line}")
+                    
+                    # Not all input files support last_line.
+                    if hasattr(inputfile, "last_line"):
+                        self.logger.error(f"Last line read: {inputfile.last_line}")
                     raise
         
         finally:

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -6,177 +6,23 @@
 # the terms of the BSD 3-Clause License.
 """Generic output file parser and related tools"""
 
-
-import typing
-import bz2
-import fileinput
-import gzip
 import inspect
-import io
 import logging
-import os
 import random
 import sys
-import zipfile
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, List, Union, Optional
-import codecs
+from typing import Any, Iterable, List, Optional
 
 import numpy
 
 from cclib.parser import utils
 from cclib.parser.data import ccData
 from cclib.parser.data import ccData_optdone_bool
+from cclib.parser.logfilewrapper import FileWrapper
 
 
 # This seems to avoid a problem with Avogadro.
-logging.logMultiprocessing = 0
-
-
-class FileWrapper:
-    """Wrap a file-like object or stream with some custom tweaks"""
-
-    def __init__(self, source, pos: int = 0) -> None:
-
-        self.src = source
-
-        # Most file-like objects have seek and tell methods, but streams returned
-        # by urllib.urlopen in Python2 do not, which will raise an AttributeError
-        # in this code. On the other hand, in Python3 these methods do exist since
-        # urllib uses the stream class in the io library, but they raise a different
-        # error, namely io.UnsupportedOperation. That is why it is hard to be more
-        # specific with except block here.
-        try:
-            self.src.seek(0, 2)
-            self.size = self.src.tell()
-            self.src.seek(pos, 0)
-
-        except (AttributeError, IOError, io.UnsupportedOperation):
-            # Stream returned by urllib should have size information.
-            if hasattr(self.src, 'headers') and 'content-length' in self.src.headers:
-                self.size = int(self.src.headers['content-length'])
-            else:
-                self.size = pos
-
-        # Assume the position is what was passed to the constructor.
-        self.pos = pos
-        
-        self.last_line = None
-
-    def next(self):
-        line = next(self.src)
-        self.pos += len(line)
-        self.last_line = line
-        return line
-
-    def __next__(self):
-        return self.next()
-
-    def __iter__(self):
-        return self
-
-    def close(self) -> None:
-        self.src.close()
-
-    def seek(self, pos: int, ref: int) -> None:
-
-        # If we are seeking to end, we can emulate it usually. As explained above,
-        # we cannot be too specific with the except clause due to differences
-        # between Python2 and 3. Yet another reason to drop Python 2 soon!
-        try:
-            self.src.seek(pos, ref)
-        except:
-            if ref == 2:
-                self.src.read()
-            else:
-                raise
-
-        if ref == 0:
-            self.pos = pos
-        if ref == 1:
-            self.pos += pos
-        if ref == 2 and hasattr(self, 'size'):
-            self.pos = self.size
-
-
-def logerror(error):
-    """
-    Log a unicode decode/encode error to the logger and return a replacement character.
-    """
-    logging.warning(str(error))
-    
-    # Return type is a tuple.
-    # First item is a replacement character. Second is the position to continue from.
-    return (u'', error.start +1)
-    
-codecs.register_error('logerror', logerror)
-
-
-def opencompressedfile(filename: str, mode: str = "r", encoding: str = "utf-8", errors: str = "logerror", fileobject: typing.Optional[typing.IO] = None, wrap: bool = False) -> typing.IO:
-    """
-    Open a possibly compressed file.
-    
-    Fileobject is an option, existing and open file-like object which will be decoded and wrapped appropriately.
-    If wrap is True and file is a 'normal' file, wrap it in a FileWrapper object
-    """
-    
-    extension = os.path.splitext(filename)[1]
-
-    if extension == ".gz":
-        fileobject = io.TextIOWrapper(gzip.GzipFile(filename, mode, fileobj=fileobject), encoding = encoding, errors = errors)
-
-    elif extension == ".zip":
-        zip = zipfile.ZipFile(fileobject if fileobject else filename, mode)
-        assert len(zip.namelist()) == 1, "ERROR: Zip file contains more than 1 file"
-        fileobject = io.StringIO(zip.read(zip.namelist()[0]).decode(encoding, errors))
-
-    elif extension in ['.bz', '.bz2']:
-        # Module 'bz2' is not always importable.
-        assert bz2 is not None, "ERROR: module bz2 cannot be imported"
-        fileobject = io.TextIOWrapper(bz2.BZ2File(fileobject if fileobject else filename, mode), encoding = encoding, errors = errors)
-
-    elif fileobject is not None:
-        # Assuming that object is text file encoded in utf-8
-        fileobject = io.StringIO(fileobject.decode(encoding, errors))
-        
-    else:
-        # Normal text file.
-        
-        fileobject = open(filename, mode, encoding = encoding, errors = errors)
-        
-        if wrap:
-            fileobject = FileWrapper(fileobject)
-
-    # Ideally, all returned objects would be wrapped with FileWrapper (or none of them would be).
-    # This is not done because type-checking is done elsewhere in the code, which this could
-    # interfere with.
-    return fileobject
-
-
-def openlogfile(filename: Union[str, List[str]], object=None):
-    """Return a file object given a filename or if object specified decompresses it
-    if needed and wrap it up.
-
-    Given the filename or file object of a log file or a gzipped, zipped, or bzipped
-    log file, this function returns a file-like object.
-
-    Given a list of filenames, this function returns a FileInput object,
-    which can be used for seamless iteration without concatenation.
-    """
-    
-    # If there is a single string argument given.
-    if isinstance(filename, str):
-        return opencompressedfile(filename, fileobject = object, wrap = True)
-
-    elif hasattr(filename, "__iter__"):
-
-        # This is needed, because fileinput will assume stdin when filename is empty.
-        if len(filename) == 0:
-            return None
-        
-        # The 'errors' argument of fileinput.FileInput() looks like it should do what we want here,
-        # but it's only available in python3.10 and even then doesn't work properly in conjunction with openhook...
-        return FileWrapper(fileinput.FileInput(filename, openhook = opencompressedfile))
+logging.logMultiprocessing = 0    
 
 
 class Logfile(ABC):
@@ -187,7 +33,7 @@ class Logfile(ABC):
         NWChem, ORCA, Psi, Q-Chem
     """
 
-    def __init__(self, source: Union[str, Iterable[str], fileinput.FileInput], loglevel: int = logging.ERROR, logname: str = "Log",
+    def __init__(self, source, loglevel: int = logging.ERROR, logname: str = "Log",
                  logstream=sys.stderr, datatype=ccData_optdone_bool, **kwds):
         """Initialise the Logfile object.
 
@@ -200,27 +46,14 @@ class Logfile(ABC):
             logstream - where to output the logging information
             datatype - class to use for gathering data attributes
         """
-
-        # Set the filename to source if it is a string or a list of strings, which are
-        # assumed to be filenames. Otherwise, assume the source is a file-like object
-        # if it has a read method, and we will try to use it like a stream.
-        self.isfileinput = False
-        if isinstance(source, str) or \
-            (isinstance(source, list) and all([isinstance(s, str) for s in source])):
-            # 'Source' is actually just a (list of) filename(s).
-            self.filename = source
-            self.isstream = False
-        
-        elif isinstance(source, fileinput.FileInput):
-            self.filename = source
-            self.isstream = False
-            self.isfileinput = True
-        elif hasattr(source, "read"):
-            self.filename = f"stream {str(type(source))}"
-            self.isstream = True
-            self.stream = source
-        else:
-            raise ValueError("Unexpected source type.")
+        if not isinstance(source, FileWrapper):
+            source = FileWrapper(source)
+            # Probably the wrong type given.
+            #raise TypeError("Source does not have an 'input_files' attribute, are you sure it inherits from FileWrapper?") from None
+            
+        self.inputfile = source
+        # If our parser needs a certain file ordering, set that now.
+        self.inputfile.input_files = self.sort_input(self.inputfile.input_files)
 
         # Set up the logger.
         # Note that calling logging.getLogger() with one name always returns the same instance.
@@ -228,7 +61,7 @@ class Logfile(ABC):
         #   which means that care needs to be taken not to duplicate handlers.
         self.loglevel = loglevel
         self.logname = logname
-        self.logger = logging.getLogger(f"{self.logname} {self.filename}")
+        self.logger = logging.getLogger(f"{self.logname} {self.inputfile.file_name}")
         self.logger.setLevel(self.loglevel)
         if len(self.logger.handlers) == 0:
             handler = logging.StreamHandler(logstream)
@@ -259,6 +92,16 @@ class Logfile(ABC):
             self.datatype = ccData
         # Parsing of Natural Orbitals and Natural Spin Orbtials into one attribute
         self.unified_no_nso = kwds.get("future",False)
+        
+    @property
+    def filename(self):
+        return self.inputfile.file_name
+        
+    def sort_input(self, file_objects):
+        """
+        If this parser expects multiple files to appear in a certain order, return that ordering.
+        """
+        return file_objects
 
     def __setattr__(self, name, value):
 
@@ -297,59 +140,38 @@ class Logfile(ABC):
         # The dict of self should be the same after parsing.
         _nodelete = list(set(self.__dict__.keys()))
 
-        # Initiate the FileInput object for the input files.
-        # Remember that self.filename can be a list of files.
-        inputfile = None
-        try:
-            if not self.isstream:
-                if not self.isfileinput:
-                    inputfile = openlogfile(self.filename)
-                else:
-                    inputfile = self.filename
-            else:
-                inputfile = FileWrapper(self.stream)
-    
-            # Intialize self.progress
-            # Not sure why we wouldn't want to keep track of progress just because we're reading
-            # from an archive?
-            #is_compressed = isinstance(inputfile, myGzipFile) or isinstance(inputfile, myBZ2File)
-            is_compressed = False
-            if progress and not (is_compressed):
-                self.progress = progress
-                self.progress.initialize(inputfile.size)
-                self.progress.step = 0
-            self.fupdate = fupdate
-            self.cupdate = cupdate
-    
-            # Maybe the sub-class has something to do before parsing.
-            self.before_parsing()
-    
-            # Loop over lines in the file object and call extract().
-            # This is where the actual parsing is done.
-            for line in inputfile:
-                self.updateprogress(inputfile, "Unsupported information", cupdate)
-    
-                # This call should check if the line begins a section of extracted data.
-                # If it does, it parses some lines and sets the relevant attributes (to self).
-                # Any attributes can be freely set and used across calls, however only those
-                #   in data._attrlist will be moved to final data object that is returned.
-                try:
-                    self.extract(inputfile, line)
-                except StopIteration:
-                    self.logger.error("Unexpectedly encountered end of logfile.")
-                    break
-                except Exception as e:
-                    self.logger.error("Encountered error when parsing.")
-                    
-                    # Not all input files support last_line.
-                    if hasattr(inputfile, "last_line"):
-                        self.logger.error(f"Last line read: {inputfile.last_line}")
-                    raise
-        
-        finally:
-            # Close input file object.
-            if not self.isstream and inputfile is not None:
-                inputfile.close()
+        # Intialize self.progress
+        if progress:
+            self.progress = progress
+            self.progress.initialize(self.inputfile.size)
+            self.progress.step = 0
+        self.fupdate = fupdate
+        self.cupdate = cupdate
+
+        # Maybe the sub-class has something to do before parsing.
+        self.before_parsing()
+
+        # Loop over lines in the file object and call extract().
+        # This is where the actual parsing is done.
+        for line in self.inputfile:
+            self.updateprogress(self.inputfile, "Unsupported information", cupdate)
+
+            # This call should check if the line begins a section of extracted data.
+            # If it does, it parses some lines and sets the relevant attributes (to self).
+            # Any attributes can be freely set and used across calls, however only those
+            #   in data._attrlist will be moved to final data object that is returned.
+            try:
+                self.extract(self.inputfile, line)
+            except StopIteration:
+                self.logger.error("Unexpectedly encountered end of logfile.")
+                break
+            except Exception as e:
+                self.logger.error("Encountered error when parsing.")
+                
+                # Not all input files support last_line.
+                if hasattr(self.inputfile, "last_line"):
+                    self.logger.error(f"Last line read: {self.inputfile.last_line}")
+                raise
 
         # Maybe the sub-class has something to do after parsing.
         self.after_parsing()
@@ -393,7 +215,7 @@ class Logfile(ABC):
 
         # Update self.progress as done.
         if hasattr(self, "progress"):
-            self.progress.update(inputfile.size, "Done")
+            self.progress.update(self.inputfile.size, "Done")
 
         return data
 

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -12,6 +12,7 @@ import random
 import sys
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Optional
+import typing
 
 import numpy
 
@@ -38,8 +39,13 @@ class Logfile(ABC):
         NWChem, ORCA, Psi, Q-Chem
     """
 
-    def __init__(self, source, loglevel: int = logging.ERROR, logname: str = "Log",
-                 logstream=sys.stderr, datatype=ccData_optdone_bool, **kwds):
+    def __init__(self,
+        source: typing.Union[str, typing.IO, FileWrapper, typing.List[typing.Union[str, typing.IO]]],
+        loglevel: int = logging.ERROR,
+        logname: str = "Log",
+        logstream=sys.stderr,
+        datatype=ccData_optdone_bool,
+        **kwds):
         """Initialise the Logfile object.
 
         This should be called by a subclass in its own __init__ method.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -109,7 +109,7 @@ class Logfile(ABC):
         return self.inputfile.file_name
     
     @classmethod
-    def sort_input(self, file_names: typing.List(str)) -> typing.List:
+    def sort_input(self, file_names: typing.List[str]) -> typing.List:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -47,7 +47,7 @@ class Logfile(ABC):
         Inputs:
             source - a logfile, list of logfiles, or stream with at least a read method
             loglevel - integer corresponding to a log level from the logging module
-            logname - name of the source logfile passed to this constructor
+            logname - name of the logging object to use for this parser
             logstream - where to output the logging information
             datatype - class to use for gathering data attributes
         """

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -1,0 +1,201 @@
+# TOOD: This file belongs in cclib.io, but circular dependency issues mean it can't go there just now.
+
+import bz2
+import gzip
+import zipfile
+import pathlib
+from tempfile import NamedTemporaryFile
+from urllib.request import urlopen
+from urllib.error import URLError
+import collections
+import typing
+import re
+import io
+import logging
+import codecs
+
+
+# Regular expression for validating URLs
+URL_PATTERN = re.compile(
+
+    r'^(?:http|ftp)s?://'  # http:// or https://
+    r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
+    r'localhost|'  # localhost...
+    r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
+    r'(?::\d+)?'  # optional port
+    r'(?:/?|[/?]\S+)$', re.IGNORECASE
+
+)
+
+
+def logerror(error):
+    """
+    Log a unicode decode/encode error to the logger and return a replacement character.
+    """
+    logging.warning(str(error))
+    
+    # Return type is a tuple.
+    # First item is a replacement character. Second is the position to continue from.
+    return (u'', error.start +1)
+    
+codecs.register_error('logerror', logerror)
+
+class FileWrapper:
+    """Wrap any supported input file type."""
+
+    def __init__(self, *sources) -> None:
+        # Each source can be a lot of different things, go through and process them now.
+        self.input_files = {}
+        self.file_pointer = 0
+        
+        # First, check if we were given an unpacked list for backwards compatibility.
+        expanded_sources = []
+        for source in sources:
+            if isinstance(source, list):
+                expanded_sources.extend(source)
+            
+            else:
+                expanded_sources.append(source)
+        
+        for source in expanded_sources:
+            # What are you?
+            if isinstance(source, str) and URL_PATTERN.match(source):
+                # This file is a URL.
+                try:
+                    # Cache the file to a temp location.
+                    response = urlopen(source)
+                    tfile = NamedTemporaryFile(delete = True)
+                    tfile.write(response.read())
+                    
+                    fileobject = tfile
+                    filename = source
+                    
+                except (ValueError, URLError) as error:
+                    # Maybe no need to raise a different exception?
+                    raise ValueError(
+                        "Encountered an error processing the URL '{}'".format(source)
+                    ) from error
+                
+            elif hasattr(source, "read") or hasattr(source, "readline"):
+                # This file is a file.
+                # We don't need to do anything.
+                fileobject = source
+                # Not sure what we're supposed to do if we don't have an available file name,
+                # probably ok.
+                filename = getattr(source, "name", f"stream {str(type(source))}")
+                
+            else:
+                fileobject = None
+                filename = source
+                
+            # Now 'open' the file. If the file is compressed, this function will uncompress it.
+            # Likewise, appropriate decoding and error handling will be applied.
+            #
+            # If no file has been opened yet (source is a string-like), open it.
+            self.input_files[filename] = self.open_log_file(filename, fileobject = fileobject)
+        
+        # TODO: Implement this for progress updating.
+        self.size = None
+        
+        # A short buffer of previously read lines.
+        # This permits primitive 'look-behind' functionality in some parsers (see Turbomole).
+        # Init with 10 empty strings (empty lines).
+        self.last_lines = collections.deque([""] * 10, 10)
+        
+    @property
+    def file_name(self):
+        return ", ".join(self.input_files)
+    
+    @classmethod
+    def open_log_file(
+            self,
+            filename: str,
+            mode: str = "r",
+            encoding: str = "utf-8",
+            errors: str = "logerror",
+            fileobject: typing.Optional[typing.IO] = None
+        ) -> typing.IO:
+        """
+        Open a possibly compressed file.
+        """
+        filename = pathlib.Path(filename)
+        extension = filename.suffix
+    
+        if extension == ".gz":
+            fileobject = io.TextIOWrapper(gzip.GzipFile(filename, mode, fileobj = fileobject), encoding = encoding, errors = errors)
+    
+        elif extension == ".zip":
+            fileobject = zipfile.ZipFile(fileobject if fileobject else filename, mode)
+            # TODO: Need to check that we're not leaving any open file objects here...
+            # TODO: We should be able to handle multiple files...
+            assert len(fileobject.namelist()) == 1, "ERROR: Zip file contains more than 1 file"
+            
+            fileobject = io.TextIOWrapper(
+                fileobject.open(fileobject.namelist()[0]),
+                encoding = encoding, errors = errors
+            )
+    
+        elif extension in ['.bz', '.bz2']:
+            # Module 'bz2' is not always importable.
+            assert bz2 is not None, "ERROR: module bz2 cannot be imported"
+            fileobject = io.TextIOWrapper(bz2.BZ2File(fileobject if fileobject else filename, mode), encoding = encoding, errors = errors)
+    
+        elif fileobject is not None:
+            # Assuming that object is text file encoded in utf-8
+            #fileobject = io.StringIO(fileobject.decode(encoding, errors))
+            fileobject = io.TextIOWrapper(fileobject, encoding = encoding, errors = errors)
+            
+        else:
+            # Normal text file.
+            
+            fileobject = open(filename, mode, encoding = encoding, errors = errors)
+        
+        return fileobject
+
+    def next(self):
+        try:
+            # TODO: Wasteful to make a list each iteration here...
+            try:
+                return next(list(self.input_files.values())[self.file_pointer])
+            
+            except StopIteration:
+                self.file_pointer += 1
+                return self.next()
+            
+        except IndexError:
+            raise StopIteration()
+    
+    @property
+    def last_line(self):
+        return self.last_lines[-1]
+
+    def __next__(self):
+        return self.next()
+
+    def __iter__(self):
+        return self
+        # This works great, but means we loose support for next() on this class.
+#         for file in self.input_files:
+#             for line in file:
+#                 self.last_lines.append(line)        
+#                 yield line
+
+    def close(self) -> None:
+        for input_file in self.input_files:
+            input_file.close()
+
+    def seek(self, pos: int, ref: int) -> None:
+        raise NotImplementedError("FileWrapper does not support seek()")
+    
+    def reset(self):
+        # Equivalent to seeking to 0 for all our files.
+        for file in self.input_files.values():
+            file.seek(0,0)
+            
+        self.file_pointer = 0
+    
+#     def peek_ahead(self):
+#         """
+#         Acquire a copy of this file object to read lines without advancing
+#         the file pointer of the original object. 
+#         """

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -67,6 +67,7 @@ class FileWrapper:
                     response = urlopen(source)
                     tfile = NamedTemporaryFile(delete = True)
                     tfile.write(response.read())
+                    tfile.seek(0,0)
                     
                     fileobject = tfile
                     filename = source

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -144,8 +144,8 @@ class FileWrapper:
     
         elif fileobject is not None:
             # Assuming that object is text file encoded in utf-8
-            #fileobject = io.StringIO(fileobject.decode(encoding, errors))
-            fileobject = io.TextIOWrapper(fileobject, encoding = encoding, errors = errors)
+            # If the file/stream has already been opened, we have no ability to handle decoding errors.
+            pass
             
         else:
             # Normal text file.
@@ -161,7 +161,8 @@ class FileWrapper:
         try:
             # TODO: Wasteful to make a list each iteration here...
             try:
-                line = next(list(self.input_files.values())[self.file_pointer])
+                file_list = list(self.input_files.values())
+                line = next(file_list[self.file_pointer])
                 self.last_lines.append(line)
                 return line
             

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -105,7 +105,7 @@ class FileWrapper:
         self.last_lines = collections.deque([""] * 10, 10)
         
     @property
-    def file_name(self):
+    def file_name(self) -> str:
         return ", ".join(self.input_files)
     
     @classmethod
@@ -154,7 +154,10 @@ class FileWrapper:
         
         return fileobject
 
-    def next(self):
+    def next(self) -> str:
+        """
+        Get the next line from this log file.
+        """
         try:
             # TODO: Wasteful to make a list each iteration here...
             try:
@@ -170,7 +173,10 @@ class FileWrapper:
             raise StopIteration()
     
     @property
-    def last_line(self):
+    def last_line(self) -> str:
+        """
+        Return the last line read by this parser.
+        """
         return self.last_lines[-1]
 
     def __next__(self):
@@ -178,11 +184,6 @@ class FileWrapper:
 
     def __iter__(self):
         return self
-        # This works great, but means we loose support for next() on this class.
-#         for file in self.input_files:
-#             for line in file:
-#                 self.last_lines.append(line)        
-#                 yield line
 
     def readline(self) -> str:
         """
@@ -199,8 +200,20 @@ class FileWrapper:
         return "".join(list(self))
 
     def close(self) -> None:
-        for input_file in self.input_files:
+        """
+        Close all open files.
+        """
+        for input_file in self.input_files.values():
             input_file.close()
+            
+    def __del__(self) -> None:
+        """
+        Make sure to close any open files when we go out of scope.
+        
+        Note that there is no guarantee when or if this function will get called;
+        user's should ensure to close their own files once they are finished with.
+        """
+        self.close()
 
     def seek(self, pos: int, ref: int) -> None:
         raise NotImplementedError("FileWrapper does not support seek()")

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -40,6 +40,7 @@ def logerror(error):
     
 codecs.register_error('logerror', logerror)
 
+
 class FileWrapper:
     """Wrap any supported input file type."""
 

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -157,7 +157,9 @@ class FileWrapper:
         try:
             # TODO: Wasteful to make a list each iteration here...
             try:
-                return next(list(self.input_files.values())[self.file_pointer])
+                line = next(list(self.input_files.values())[self.file_pointer])
+                self.last_lines.append(line)
+                return line
             
             except StopIteration:
                 self.file_pointer += 1

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
 # TOOD: This file belongs in cclib.io, but circular dependency issues mean it can't go there just now.
 
 import bz2

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -39,7 +39,7 @@ def logerror(error):
     """
     Log a unicode decode/encode error to the logger and return a replacement character.
     """
-    logging.warning(str(error))
+    logging.getLogger("cclib").warning(str(error))
     
     # Return type is a tuple.
     # First item is a replacement character. Second is the position to continue from.

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -181,6 +181,20 @@ class FileWrapper:
 #                 self.last_lines.append(line)        
 #                 yield line
 
+    def readline(self) -> str:
+        """
+        Read one line from this file.
+        """
+        return next(self)
+    
+    def read(self) -> str:
+        """
+        Read everything from this file.
+        
+        Be aware that this function will load the entire file into a single string.
+        """
+        return "".join(list(self))
+
     def close(self) -> None:
         for input_file in self.input_files:
             input_file.close()

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 
 import re
 import typing
+from pathlib import Path
 
 import numpy
 
@@ -85,19 +86,20 @@ class Turbomole(logfileparser.Logfile):
         known_files = []
         unknown_files = []
         sorted_list = []
-        for file_name in file_names:
+        for file in file_names:
+            file_name = Path(file).name
             if file_name in sorting_order:
-                known_files.append([file_name, sorting_order[file_name]])
+                known_files.append([file, sorting_order[file_name]])
                 
             elif re.match(r"^job\.[0-9]+$", file_name):
                 # Calling 'jobex -keep' will also write job.n files, where n ranges from 0 to inf.
                 # Numbered job files are inserted before job.last.
                 job_number = int(file_name[4:]) +1
                 job_order = float(f"{sorting_order['job.last'] - 1}.{job_number}")
-                known_files.append([file_name, job_order])
+                known_files.append([file, job_order])
             
             else:
-                unknown_files.append(file_name)
+                unknown_files.append(file)
             
         for i in sorted(known_files, key=lambda x: x[1]):
             sorted_list.append(i[0])

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 """Parser for Turbomole output files."""
 
 import re
+import typing
 
 import numpy
 
@@ -63,8 +64,9 @@ class Turbomole(logfileparser.Logfile):
         self.hours_regex = re.compile(r"([0-9.]*) hours")
         self.minutes_regex = re.compile(r"([0-9.]*) minutes")
         self.seconds_regex = re.compile(r"([0-9.]*) seconds")
-        
-    def sort_input(self, file_names: list) -> list:
+    
+    @classmethod
+    def sort_input(self, file_names: typing.List(str)) -> typing.List:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -66,7 +66,7 @@ class Turbomole(logfileparser.Logfile):
         self.seconds_regex = re.compile(r"([0-9.]*) seconds")
     
     @classmethod
-    def sort_input(self, file_names: typing.List(str)) -> typing.List:
+    def sort_input(self, file_names: typing.List[str]) -> typing.List:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -69,7 +69,7 @@ class Turbomole(logfileparser.Logfile):
         # A list of previous lines to allow look-behind functionality.
         self.last_lines = collections.deque([""] * 10, 10)
         
-    def sort_input(self, file_objects):
+    def sort_input(self, file_names: list) -> list:
         """
         If this parser expects multiple files to appear in a certain order, return that ordering.
         """
@@ -86,29 +86,29 @@ class Turbomole(logfileparser.Logfile):
         }
         
         known_files = []
-        unknown_files = {}
-        sorted_dict = {}
-        for file_name, file_object in file_objects.items():            
+        unknown_files = []
+        sorted_list = []
+        for file_name in file_names:
             if file_name in sorting_order:
-                known_files.append([file_object, sorting_order[file_name]])
+                known_files.append([file_name, sorting_order[file_name]])
                 
             elif re.match(r"^job\.[0-9]+$", file_name):
                 # Calling 'jobex -keep' will also write job.n files, where n ranges from 0 to inf.
                 # Numbered job files are inserted before job.last.
                 job_number = int(file_name[4:]) +1
                 job_order = float(f"{sorting_order['job.last'] - 1}.{job_number}")
-                known_files.append([file_object, job_order])
+                known_files.append([file_name, job_order])
             
             else:
-                unknown_files[file_name] = file_object
+                unknown_files.append(file_name)
             
         for i in sorted(known_files, key=lambda x: x[1]):
-            sorted_dict[i[0]] = file_objects[i[0]]
+            sorted_list.append(i[0])
             
         if unknown_files:
-            sorted_dict.update(unknown_files)
+            sorted_list.extend(unknown_files)
         
-        return sorted_dict
+        return sorted_list
         
 
     def __str__(self):

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -4,10 +4,8 @@
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
-import collections
 import scipy.constants
 from datetime import timedelta
-import pathlib
 
 """Parser for Turbomole output files."""
 
@@ -65,9 +63,6 @@ class Turbomole(logfileparser.Logfile):
         self.hours_regex = re.compile(r"([0-9.]*) hours")
         self.minutes_regex = re.compile(r"([0-9.]*) minutes")
         self.seconds_regex = re.compile(r"([0-9.]*) seconds")
-
-        # A list of previous lines to allow look-behind functionality.
-        self.last_lines = collections.deque([""] * 10, 10)
         
     def sort_input(self, file_names: list) -> list:
         """
@@ -1006,10 +1001,10 @@ class Turbomole(logfileparser.Logfile):
         ## For UHF:
         #       occ. orbital   energy / eV   virt. orbital     energy / eV   |coeff.|^2*100
         #         7 a   alpha          -15.12     12 a   alpha            4.74       24.5
-        #         7 a   beta           -15.12     12 a   beta             4.74       24.5        
-        if "Excitation energy:" in line and "excitation" in self.last_lines[-5].split():
+        #         7 a   beta           -15.12     12 a   beta             4.74       24.5
+        if "Excitation energy:" in line and "excitation" in self.inputfile.last_lines[-6].split():
             # The irrep of the state is a few lines back.
-            symm_parts = self.last_lines[-5].split()
+            symm_parts = self.inputfile.last_lines[-6].split()
             # We don't always have the multiplicity available.
             if len(symm_parts) < 4:
                 # No mult.
@@ -1285,8 +1280,6 @@ class Turbomole(logfileparser.Logfile):
             self.metadata['wall_time'].append(self.duration_to_timedelta(line))
         
         # All done for this loop.
-        # Keep track of last lines.
-        self.last_lines.append(line)
             
         if ": all done  ****" in line:
             # End of module, set success flag.

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -114,7 +114,7 @@ def ccget() -> None:
             fuzzy_attr = difflib.get_close_matches(arg, ccData._attrlist, n=1, cutoff=0.85)
             if len(fuzzy_attr) > 0:
                 fuzzy_attr = fuzzy_attr[0]
-                logging.warning(
+                logging.getLogger("cclib").warning(
                     f"Attribute '{arg}' not found, but attribute '{fuzzy_attr}' is close. "
                     f"Using '{fuzzy_attr}' instead."
                 )

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -159,6 +159,11 @@ def ccget() -> None:
             name = f"{', '.join(filename[:-1])} and {filename[-1]}"
         else:
             name = filename
+        
+        # Set custom handles so we can actually change log-levels.
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("[%(name)s %(levelname)s] %(message)s"))
+        logging.getLogger("cclib").addHandler(handler)
 
         # The keyword dictionary are not used so much. but could be useful for
         # passing options downstream. For example, we might use --future for
@@ -166,9 +171,12 @@ def ccget() -> None:
         kwargs = {}
         if verbose:
             kwargs['loglevel'] = logging.INFO
+            logging.getLogger("cclib").setLevel(logging.INFO)
+        
         else:
             # TODO: Are we sure we want to ignore warnings by default?
             kwargs['loglevel'] = logging.ERROR
+            logging.getLogger("cclib").setLevel(logging.WARNING)
         
         if future:
             kwargs['future'] = True

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -165,13 +165,14 @@ def ccget() -> None:
         # triggering experimental or alternative behavior (as with optdone).
         kwargs = {}
         if verbose:
-            kwargs['verbose'] = True
             kwargs['loglevel'] = logging.INFO
         else:
-            kwargs['verbose'] = False
+            # TODO: Are we sure we want to ignore warnings by default?
             kwargs['loglevel'] = logging.ERROR
+        
         if future:
             kwargs['future'] = True
+        
         if cjsonfile:
             kwargs['cjson'] = True
 

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -22,7 +22,8 @@ import sys
 import numpy
 
 from cclib.parser import ccData
-from cclib.io import ccread, URL_PATTERN
+from cclib.parser.logfilewrapper import URL_PATTERN
+from cclib.io import ccread
 
 
 # Set up options for pretty-printing output.

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -175,7 +175,7 @@ def ccget() -> None:
         
         else:
             # TODO: Are we sure we want to ignore warnings by default?
-            kwargs['loglevel'] = logging.ERROR
+            kwargs['loglevel'] = logging.WARNING
             logging.getLogger("cclib").setLevel(logging.WARNING)
         
         if future:

--- a/test/io/testccio.py
+++ b/test/io/testccio.py
@@ -96,17 +96,17 @@ class ccopenTest(unittest.TestCase):
         base_url = "https://raw.githubusercontent.com/cclib/cclib/master/data/"
         filenames = ["QChem/basicQChem5.1/dvb_td.out", "Molpro/basicMolpro2012/h2o_mp2.out"]
         for fname in filenames:
-            assert self.ccopen(os.path.join(fpath, fname), quiet=True).parse().getattributes(tolists=True) == \
-                             self.ccopen(base_url + fname, quiet=True).parse().getattributes(tolists=True)
+            assert self.ccopen(os.path.join(fpath, fname)).parse().getattributes(tolists=True) == \
+                             self.ccopen(base_url + fname).parse().getattributes(tolists=True)
 
     def test_multi_url_io(self):
         """Does the function works with multiple URLs such good as with multiple filenames?"""
         fpath = os.path.join(__datadir__, "data")
         base_url = "https://raw.githubusercontent.com/cclib/cclib/master/data/"
         filenames = ["Molpro/basicMolpro2012/dvb_gopt.out", "Molpro/basicMolpro2012/dvb_gopt.log"]
-        assert self.ccopen([os.path.join(fpath, fname) for fname in filenames], quiet=True) \
+        assert self.ccopen([os.path.join(fpath, fname) for fname in filenames]) \
                 .parse().getattributes(tolists=True) == \
-            self.ccopen([base_url + fname for fname in filenames], quiet=True) \
+            self.ccopen([base_url + fname for fname in filenames]) \
                 .parse().getattributes(tolists=True)
 
     @unittest.skip("This should also work if cjsonreader supported streams.")

--- a/test/io/testcjsonreader.py
+++ b/test/io/testcjsonreader.py
@@ -40,8 +40,7 @@ class CJSONReaderTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w') as fp:
             fp.write(cjson_data)
             fp.flush()
-            cjson_reader = cclib.io.cjsonreader.CJSON(fp.name)
-            read_cjson_data = cjson_reader.parse()
+            read_cjson_data = cclib.io.ccread(fp.name, cjson = True)
         assert read_cjson_data is not None, "The CJSON reader failed to read attributes"
 
         # The attribute values read by the CJSON reader will be a subset of the

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -54,7 +54,7 @@ class ccgetTest(unittest.TestCase):
         ccread_call_args, ccread_call_kwargs = mock_ccread.call_args
         assert ccread_call_args[0] == INPUT_FILE
 
-    @mock.patch("logging.warning")
+    @mock.patch("logging.Logger.warning")
     @mock.patch(
         "cclib.scripts.ccget.sys.argv",
         ["ccget", "atomcoord", INPUT_FILE]

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -62,32 +62,35 @@ class FileWrapperTest(unittest.TestCase):
 
     def test_stdin_seek(self):
         """We shouldn't be able to seek anywhere in standard input."""
-        wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
-        with pytest.raises(IOError):
-            wrapper.seek(0, 0)
-        with pytest.raises(IOError):
-            wrapper.seek(0, 1)
+        # stdin is disabled by pytest, not sure if there's a way around this.
+#         wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
+#         with pytest.raises(IOError):
+#             wrapper.seek(0, 0)
+#         with pytest.raises(IOError):
+#             wrapper.seek(0, 1)
 
     def test_data_stdin(self):
         """Check that the same attributes are parsed when a file is piped through standard input."""
-        logfiles = [
-            "data/ADF/basicADF2007.01/dvb_gopt.adfout",
-            "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out",
-        ]
-        get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
-        for lf in logfiles:
-            path = f"{__datadir__}/{lf}"
-            expected_attributes = get_attributes(cclib.io.ccread(path))
-            with open(path) as handle:
-                contents = handle.read()
-            # This is fix strings not being unicode in Python2.
-            try:
-                stdin = io.StringIO(contents)
-            except TypeError:
-                stdin = io.StringIO(unicode(contents))
-            stdin.seek = sys.stdin.seek
-            data = cclib.io.ccread(stdin)
-            assert get_attributes(data) == expected_attributes
+#         logfiles = [
+#             "data/ADF/basicADF2007.01/dvb_gopt.adfout",
+#             "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out",
+#         ]
+#         get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
+#         for lf in logfiles:
+#             path = f"{__datadir__}/{lf}"
+#             expected_attributes = get_attributes(cclib.io.ccread(path))
+#             with open(path) as handle:
+#                 contents = handle.read()
+#             # This is fix strings not being unicode in Python2.
+#             try:
+#                 stdin = io.StringIO(contents)
+#             except TypeError:
+#                 stdin = io.StringIO(unicode(contents))
+#             
+#             # Can't do this either, stdin is disabled.
+#             stdin.seek = sys.stdin.seek
+#             data = cclib.io.ccread(stdin)
+#             assert get_attributes(data) == expected_attributes
 
 
 class LogfileTest(unittest.TestCase):

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -17,6 +17,7 @@ from urllib.request import urlopen
 
 import cclib
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 
 __filedir__ = os.path.dirname(__file__)
@@ -62,7 +63,13 @@ class FileWrapperTest(unittest.TestCase):
 
     def test_stdin_seek(self):
         """We shouldn't be able to seek anywhere in standard input."""
-        # stdin is disabled by pytest, not sure if there's a way around this.
+        # stdin is disabled by pytest.
+        # the recommended way of emulating stdin is by doing this
+        monkeypatch = MonkeyPatch()
+        monkeypatch.setattr('sys.stdin', io.StringIO())
+        #
+        # but StringIO does support seeking, so doesn't work for our purposes.
+        
 #         wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
 #         with pytest.raises(IOError):
 #             wrapper.seek(0, 0)
@@ -71,26 +78,23 @@ class FileWrapperTest(unittest.TestCase):
 
     def test_data_stdin(self):
         """Check that the same attributes are parsed when a file is piped through standard input."""
-#         logfiles = [
-#             "data/ADF/basicADF2007.01/dvb_gopt.adfout",
-#             "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out",
-#         ]
-#         get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
-#         for lf in logfiles:
-#             path = f"{__datadir__}/{lf}"
-#             expected_attributes = get_attributes(cclib.io.ccread(path))
-#             with open(path) as handle:
-#                 contents = handle.read()
-#             # This is fix strings not being unicode in Python2.
-#             try:
-#                 stdin = io.StringIO(contents)
-#             except TypeError:
-#                 stdin = io.StringIO(unicode(contents))
-#             
-#             # Can't do this either, stdin is disabled.
-#             stdin.seek = sys.stdin.seek
-#             data = cclib.io.ccread(stdin)
-#             assert get_attributes(data) == expected_attributes
+        logfiles = [
+            "data/ADF/basicADF2007.01/dvb_gopt.adfout",
+            "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out",
+        ]
+        get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
+        for lf in logfiles:
+            path = f"{__datadir__}/{lf}"
+            expected_attributes = get_attributes(cclib.io.ccread(path))
+            with open(path) as handle:
+                contents = handle.read()
+
+            # stdin emulation
+            monkeypatch = MonkeyPatch()
+            monkeypatch.setattr('sys.stdin', io.StringIO(contents))
+            
+            data = cclib.io.ccread(sys.stdin)
+            assert get_attributes(data) == expected_attributes
 
 
 class LogfileTest(unittest.TestCase):

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -26,17 +26,29 @@ __datadir__ = os.path.join(__filepath__, "..", "..")
 
 class FileWrapperTest(unittest.TestCase):
 
+    def check_seek(self, wrapper):
+        """Check that a FileWrapper can seek properly"""
+        wrapper.seek(0, 2)
+        assert wrapper.pos == wrapper.size        
+        
+        wrapper.seek(0, 0)
+        assert wrapper.pos == 0
+        
+        with pytest.raises(NotImplementedError):
+            wrapper.seek(0, 1)
+
     def test_file_seek(self):
         """Can we seek anywhere in a file object?"""
         fpath = os.path.join(__datadir__,"data/ADF/basicADF2007.01/dvb_gopt.adfout")
         with open(fpath, 'r') as fobject:
             wrapper = cclib.parser.logfileparser.FileWrapper(fobject)
-            wrapper.seek(0, 0)
-            assert wrapper.pos == 0
-            wrapper.seek(10, 0)
-            assert wrapper.pos == 10
-            wrapper.seek(0, 2)
-            assert wrapper.pos == wrapper.size
+            self.check_seek(wrapper)
+#             wrapper.seek(0, 0)
+#             assert wrapper.pos == 0
+#             wrapper.seek(10, 0)
+#             assert wrapper.pos == 10
+#             wrapper.seek(0, 2)
+#             assert wrapper.pos == wrapper.size
 
     def test_url_seek(self):
         """Can we seek only to the end of an url stream?"""
@@ -44,22 +56,24 @@ class FileWrapperTest(unittest.TestCase):
         url = "https://raw.githubusercontent.com/cclib/cclib/master/data/ADF/basicADF2007.01/dvb_gopt.adfout"
         stream = urlopen(url)
         wrapper = cclib.parser.logfileparser.FileWrapper(stream)
+        
+        self.check_seek(wrapper)
 
-        # Unfortunately, the behavior of this wrapper differs between Python 2 and 3,
-        # so we need to diverge the assertions. We should try to keep the code as
-        # consistent as possible, but the Errors raised are actually different.
-        wrapper.seek(0, 2)
-        assert wrapper.pos == wrapper.size
-        if sys.version_info[0] == 2:
-            with pytest.raises(AttributeError):
-                wrapper.seek(0, 0)
-            with pytest.raises(AttributeError):
-                wrapper.seek(0, 1)
-        else:
-            with pytest.raises(io.UnsupportedOperation):
-                wrapper.seek(0, 0)
-            with pytest.raises(io.UnsupportedOperation):
-                wrapper.seek(0, 1)
+#         # Unfortunately, the behavior of this wrapper differs between Python 2 and 3,
+#         # so we need to diverge the assertions. We should try to keep the code as
+#         # consistent as possible, but the Errors raised are actually different.
+#         wrapper.seek(0, 2)
+#         assert wrapper.pos == wrapper.size
+#         if sys.version_info[0] == 2:
+#             with pytest.raises(AttributeError):
+#                 wrapper.seek(0, 0)
+#             with pytest.raises(AttributeError):
+#                 wrapper.seek(0, 1)
+#         else:
+#             with pytest.raises(io.UnsupportedOperation):
+#                 wrapper.seek(0, 0)
+#             with pytest.raises(io.UnsupportedOperation):
+#                 wrapper.seek(0, 1)
 
     def test_stdin_seek(self):
         """We shouldn't be able to seek anywhere in standard input."""
@@ -67,10 +81,9 @@ class FileWrapperTest(unittest.TestCase):
         # the recommended way of emulating stdin is by doing this
         monkeypatch = MonkeyPatch()
         monkeypatch.setattr('sys.stdin', io.StringIO())
-        #
-        # but StringIO does support seeking, so doesn't work for our purposes.
         
-#         wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
+        wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
+        self.check_seek(wrapper)
 #         with pytest.raises(IOError):
 #             wrapper.seek(0, 0)
 #         with pytest.raises(IOError):

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -43,12 +43,6 @@ class FileWrapperTest(unittest.TestCase):
         with open(fpath, 'r') as fobject:
             wrapper = cclib.parser.logfileparser.FileWrapper(fobject)
             self.check_seek(wrapper)
-#             wrapper.seek(0, 0)
-#             assert wrapper.pos == 0
-#             wrapper.seek(10, 0)
-#             assert wrapper.pos == 10
-#             wrapper.seek(0, 2)
-#             assert wrapper.pos == wrapper.size
 
     def test_url_seek(self):
         """Can we seek only to the end of an url stream?"""
@@ -59,22 +53,6 @@ class FileWrapperTest(unittest.TestCase):
         
         self.check_seek(wrapper)
 
-#         # Unfortunately, the behavior of this wrapper differs between Python 2 and 3,
-#         # so we need to diverge the assertions. We should try to keep the code as
-#         # consistent as possible, but the Errors raised are actually different.
-#         wrapper.seek(0, 2)
-#         assert wrapper.pos == wrapper.size
-#         if sys.version_info[0] == 2:
-#             with pytest.raises(AttributeError):
-#                 wrapper.seek(0, 0)
-#             with pytest.raises(AttributeError):
-#                 wrapper.seek(0, 1)
-#         else:
-#             with pytest.raises(io.UnsupportedOperation):
-#                 wrapper.seek(0, 0)
-#             with pytest.raises(io.UnsupportedOperation):
-#                 wrapper.seek(0, 1)
-
     def test_stdin_seek(self):
         """We shouldn't be able to seek anywhere in standard input."""
         # stdin is disabled by pytest.
@@ -84,10 +62,6 @@ class FileWrapperTest(unittest.TestCase):
         
         wrapper = cclib.parser.logfileparser.FileWrapper(sys.stdin)
         self.check_seek(wrapper)
-#         with pytest.raises(IOError):
-#             wrapper.seek(0, 0)
-#         with pytest.raises(IOError):
-#             wrapper.seek(0, 1)
 
     def test_data_stdin(self):
         """Check that the same attributes are parsed when a file is piped through standard input."""

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -17,7 +17,7 @@ from urllib.request import urlopen
 
 import cclib
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 
 __filedir__ = os.path.dirname(__file__)

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -7,6 +7,7 @@
 
 """Unit tests for specific parser behaviors, such as overriden methods."""
 
+import io
 import unittest
 
 
@@ -16,63 +17,63 @@ class NormalisesymTest(unittest.TestCase):
 
     def test_normalisesym_adf(self):
         from cclib.parser.adfparser import ADF
-        sym = ADF("dummyfile").normalisesym
+        sym = ADF(io.StringIO("dummyfile")).normalisesym
         labels = ['A', 's', 'A1', 'A1.g', 'Sigma', 'Pi', 'Delta', 'Phi', 'Sigma.g', 'A.g', 'AA', 'AAA', 'EE1', 'EEE1']
         ref = ['A', 's', 'A1', 'A1g', 'sigma', 'pi', 'delta', 'phi', 'sigma.g', 'Ag', "A'", 'A"', "E1'", 'E1"']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_gamess(self):
         from cclib.parser.gamessparser import GAMESS
-        sym = GAMESS("dummyfile").normalisesym
+        sym = GAMESS(io.StringIO("dummyfile")).normalisesym
         labels = ['A', 'A1', 'A1G', "A'", "A''", "AG"]
         ref = ['A', 'A1', 'A1g', "A'", 'A"', 'Ag']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_gamessuk(self):
         from cclib.parser.gamessukparser import GAMESSUK
-        sym = GAMESSUK("dummyfile.txt").normalisesym
+        sym = GAMESSUK(io.StringIO("dummyfile")).normalisesym
         labels = ['a', 'a1', 'ag', "a'", 'a"', "a''", "a1''", 'a1"', "e1+", "e1-"]
         ref = ['A', 'A1', 'Ag', "A'", 'A"', 'A"', 'A1"', 'A1"', 'E1', 'E1']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_gaussian(self):
         from cclib.parser.gaussianparser import Gaussian
-        sym = Gaussian("dummyfile").normalisesym
+        sym = Gaussian(io.StringIO("dummyfile")).normalisesym
         labels = ['A1', 'AG', 'A1G', "SG", "PI", "PHI", "DLTA", 'DLTU', 'SGG']
         ref = ['A1', 'Ag', 'A1g', 'sigma', 'pi', 'phi', 'delta', 'delta.u', 'sigma.g']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_jaguar(self):
         from cclib.parser.jaguarparser import Jaguar
-        sym = Jaguar("dummyfile").normalisesym
+        sym = Jaguar(io.StringIO("dummyfile")).normalisesym
         labels = ['A', 'A1', 'Ag', 'Ap', 'App', "A1p", "A1pp", "E1pp/Ap"]
         ref = ['A', 'A1', 'Ag', "A'", 'A"', "A1'", 'A1"', 'E1"']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_molcas(self):
         from cclib.parser.molcasparser import Molcas
-        sym = Molcas("dummyfile").normalisesym
+        sym = Molcas(io.StringIO("dummyfile")).normalisesym
         labels = ["a", "a1", "ag"]
         ref = ["A", "A1", "Ag"]
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_molpro(self):
         from cclib.parser.molproparser import Molpro
-        sym = Molpro("dummyfile").normalisesym
+        sym = Molpro(io.StringIO("dummyfile")).normalisesym
         labels = ["A`", "A``"]
         ref = ["A'", "A''"]
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_psi4(self):
         from cclib.parser.psi4parser import Psi4
-        sym = Psi4("dummyfile").normalisesym
+        sym = Psi4(io.StringIO("dummyfile")).normalisesym
         labels = ["Ap", "App"]
         ref = ["A'", 'A"']
         assert list(map(sym, labels)) == ref
 
     def test_normalisesym_turbomole(self):
         from cclib.parser.turbomoleparser import Turbomole
-        sym = Turbomole("dummyfile").normalisesym
+        sym = Turbomole(io.StringIO("dummyfile")).normalisesym
         labels = ["a", "a1", "ag"]
         ref = ["A", "A1", "Ag"]
         assert list(map(sym, labels)) == ref


### PR DESCRIPTION
Parser now checks before accessing `last_line` in case it's not available, and `fileinput.FileInput` is now correctly wrapped with `FileWrapper` (so it now does have `last_line`)

In theory, we probably want all input types to be wrapped with FileWrapper, but I didn't make this change because 1) there's a weird amount of IO boilerplate code and I don't understand what a lot of it is doing and 2) I'm not sure how well covered by tests IO is...