### PR TITLE
makeopenbabel: atomcoords or atomnos can be optional

### DIFF
--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -95,18 +95,29 @@ class Writer(ABC):
 
     def _make_openbabel_from_ccdata(self):
         """Create Open Babel and Pybel molecules from ccData."""
+        logger = logging.getLogger("cclib")
+        if not hasattr(self.ccdata, "atomcoords"):
+            logger.warning("ccdata object does not have atomic coordinates, setting to None")
+            _atomcoords = None
+        else:
+            _atomcoords = self.ccdata.atomcoords
+        if not hasattr(self.ccdata, "atomnos"):
+            logger.warning("ccdata object does not have atomic numbers, setting to None")
+            _atomnos = None
+        else:
+            _atomnos = self.ccdata.atomnos
         if not hasattr(self.ccdata, 'charge'):
-            logging.getLogger("cclib").warning("ccdata object does not have charge, setting to 0")
+            logger.warning("ccdata object does not have charge, setting to 0")
             _charge = 0
         else:
             _charge = self.ccdata.charge
         if not hasattr(self.ccdata, 'mult'):
-            logging.getLogger("cclib").warning("ccdata object does not have spin multiplicity, setting to 1")
+            logger.warning("ccdata object does not have spin multiplicity, setting to 1")
             _mult = 1
         else:
             _mult = self.ccdata.mult
-        obmol = makeopenbabel(self.ccdata.atomcoords,
-                              self.ccdata.atomnos,
+        obmol = makeopenbabel(atomcoords=_atomcoords,
+                              atomnos=_atomnos,
                               charge=_charge,
                               mult=_mult)
         if self.jobfilename is not None:

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -26,7 +26,7 @@ class OpenbabelTest(unittest.TestCase):
             import openbabel
         atomnos = numpy.array([1, 8, 1], "i")
         atomcoords = numpy.array([[[-1., 1., 0.], [0., 0., 0.], [1., 1., 0.]]])
-        obmol = cclib2openbabel.makeopenbabel(atomcoords, atomnos)
+        obmol = cclib2openbabel.makeopenbabel(atomcoords=atomcoords, atomnos=atomnos)
         obconversion = openbabel.OBConversion()
         formatok = obconversion.SetOutFormat("inchi")
         assert obconversion.WriteString(obmol).strip() == "InChI=1S/H2O/h1H2"
@@ -37,13 +37,13 @@ class OpenbabelTest(unittest.TestCase):
         atomcoords = numpy.array([[[-1., 1., 0.], [0., 0., 0.], [1., 1., 0.]]])
 
         # makecclib(makeopenbabel(...))
-        obmol = cclib2openbabel.makeopenbabel(atomcoords, atomnos)
+        obmol = cclib2openbabel.makeopenbabel(atomcoords=atomcoords, atomnos=atomnos)
         data = cclib2openbabel.makecclib(obmol)
         numpy.testing.assert_allclose(data.atomcoords, atomcoords)
         numpy.testing.assert_allclose(data.atomnos, atomnos)
 
         # makeopenbabel(makecclib(...))
-        obmol = cclib2openbabel.makeopenbabel(data.atomcoords, data.atomnos)
+        obmol = cclib2openbabel.makeopenbabel(atomcoords=data.atomcoords, atomnos=data.atomnos)
         data = cclib2openbabel.makecclib(obmol)  # this line is just to make the test easier
         numpy.testing.assert_allclose(data.atomcoords, atomcoords)
         numpy.testing.assert_allclose(data.atomnos, atomnos)


### PR DESCRIPTION
Closes #641

This also forces `makeopenbabel` to take keyword arguments for safety.