### PR TITLE
Improve detection of XYZ files, fix calling fallback mechanism

### DIFF
--- a/.github/scripts/run_pytest.bash
+++ b/.github/scripts/run_pytest.bash
@@ -10,3 +10,4 @@ pushd data
 bash ./regression_download.sh
 popd
 python -m pytest -v --capture=no --cov=cclib --cov-report=term --cov-report=xml:coverage-regression.xml --cov-append -k test_regression test/regression.py
+python -m pytest -v -s --cov=cclib --cov-report=term --cov-report=xml:coverage-regression.xml --cov-append test/regression_io.py

--- a/.github/scripts/run_unittest.bash
+++ b/.github/scripts/run_unittest.bash
@@ -11,4 +11,5 @@ python -m test.test_parser &&
 python -m test.test_utils &&
 python -m test.test_data --terse &&
 cd data && bash regression_download.sh &&
-cd .. && python -m test.regression --traceback
+cd .. && python -m test.regression --traceback &&
+python -m test.regression_io

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -124,10 +124,10 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     """Try to guess the filetype by searching for trigger strings."""
     filetype = None
     logger = logging.getLogger("cclib")
-    if is_xyz(inputfile):
-        logger.info("Found XYZ file based on file extension")
-        return filetype
     try:
+        if isinstance(inputfile, FileWrapper) and is_xyz(inputfile):
+            logger.info("Found XYZ file based on file extension")
+            return filetype
         for line in inputfile:
             for parser, phrases, do_break in triggers:
                 if all([line.lower().find(p.lower()) >= 0 for p in phrases]):

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -110,10 +110,23 @@ class UnknownOutputFormatError(Exception):
     """Raised when an unknown output format is encountered."""
 
 
+def is_xyz(inputfile: FileWrapper) -> bool:
+    """Is the given inputfile actually an XYZ file?
+
+    The only way to determine this without reading the entire file is to
+    inspect the file extension.
+    """
+    return len(inputfile.filenames) == 1 and \
+        os.path.splitext(inputfile.filenames[0])[1].lower() == ".xyz"
+
+
 def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
     """Try to guess the filetype by searching for trigger strings."""
-
     filetype = None
+    logger = logging.getLogger("cclib")
+    if is_xyz(inputfile):
+        logger.info("Found XYZ file based on file extension")
+        return filetype
     try:
         for line in inputfile:
             for parser, phrases, do_break in triggers:
@@ -123,7 +136,7 @@ def guess_filetype(inputfile) -> Optional[logfileparser.Logfile]:
                         return filetype
     except Exception:
         # guess_filetype() is expected to be quiet by default...
-        logging.getLogger("cclib").error("Failed to determine log file type", exc_info = True)
+        logger.error("Failed to determine log file type", exc_info = True)
     
     return filetype
 
@@ -168,12 +181,13 @@ def ccread(
     log = None
     try:
         log = ccopen(source, *args, **kwargs)
+        logger = logging.getLogger("cclib")
         if log:
-            logging.getLogger("cclib").info("Identified logfile to be in {} format".format(type(log).__name__))
+            logger.info("Identified logfile to be in {} format".format(type(log).__name__))
 
             return log.parse()
         else:
-            logging.getLogger("cclib").info('Attempting to use fallback mechanism to read file')
+            logger.info('Attempting to use fallback mechanism to read file')
             return fallback(source)
     
     finally:
@@ -204,6 +218,8 @@ def ccopen(
         source = [source]
         
     inputfile = None
+
+    logger = logging.getLogger("cclib")
         
     try:
         # Wrap our input with custom file object.
@@ -240,8 +256,10 @@ def ccopen(
             # Stop us closing twice in the except block.
             inputfile = None
             
-        # If we get here, we've failed to identify the log file type.
-        raise ValueError("Unable to determine the type of logfile {}".format(source))
+        logger.warning(
+            "Unable to determine the type of logfile %s, try the fallback mechanism",
+            source
+        )
             
     except Exception:
         if inputfile is not None:
@@ -252,7 +270,7 @@ def ccopen(
         
         # We're going to swallow this exception if quiet is True.
         # This can hide a lot of errors, so we'll make sure to log it.
-        logging.getLogger("cclib").error("Failed to open logfile", exc_info = True)
+        logger.error("Failed to open logfile", exc_info = True)
 
 
 def fallback(source):

--- a/test/regression_io.py
+++ b/test/regression_io.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+from pathlib import Path
+
+import unittest
+
+import cclib
+
+
+__filedir__ = Path(__file__).parent
+__filepath__ = Path(__filedir__).resolve()
+__regdir__ = (__filepath__ / ".." / "data" / "regression").resolve()
+
+
+class XYZRegressionTests(unittest.TestCase):
+
+    def test_xyz_not_turbomole(self):
+        """Ensure XYZ file isn't misrecognized as a Turbomole file.
+
+        From https://github.com/cclib/cclib/issues/1207.
+        """
+        fpath = __regdir__ / "io" / "xyz" / "1207.xyz"
+        # ccopen assumes something is a parsable logfile and doesn't try any
+        # fallback mechanisms.
+        logfile = cclib.io.ccopen(str(fpath))
+        assert logfile is None
+        # ccread tries alternative file reading mechanisms.
+        data = cclib.io.ccread(str(fpath))
+        assert set(data.getattributes().keys()) == {
+            "atomcoords", "atommasses", "atomnos", "natom"
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1207

The output from the command line:
```
$ ccget --verbose --list turbomole.xyz
Attempting to read turbomole.xyz
[cclib INFO] Found XYZ file based on file extension
[cclib WARNING] Unable to determine the type of logfile ['turbomole.xyz'], try the fallback mechanism
[cclib INFO] Attempting to use fallback mechanism to read file
cclib can parse the following attributes from turbomole.xyz:
  atomcoords
  atommasses
  atomnos
  natom
```

Test script:
```python
import logging

from cclib.io import ccopen, ccread

# lf = ccopen("turbomole.xyz", loglevel=logging.DEBUG, verbose=True)
# print(lf)
# data = lf.parse()
data = ccread("turbomole.xyz", loglevel=logging.DEBUG, verbose=True)
print(type(data))
```

From `ccread`:
```
$ python test_turbomole_xyz.py
Unable to determine the type of logfile ['turbomole.xyz'], try the fallback mechanism
<class 'cclib.parser.data.ccData'>
```

From `ccopen`:
```
$ python test_turbomole_xyz.py
Unable to determine the type of logfile ['turbomole.xyz'], try the fallback mechanism
None
Traceback (most recent call last):
  File "/home/eric/development/cclib_berquist/test_turbomole_xyz.py", line 7, in <module>
    data = lf.parse()
AttributeError: 'NoneType' object has no attribute 'parse'
```