### PR TITLE
Gamess overlap bug fix. 

### DIFF
--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1362,15 +1362,16 @@ class GAMESS(logfileparser.Logfile):
 
                 for i in range(self.nbasis - base):  # Fewer lines each time
                     line = next(inputfile)
-                    temp = line.split()
-                    if len(temp[1]) == 4:
-                        element = temp[1][0:2]
-                        number = temp[1][2:]
-                        temp[1] = element
-                        temp.insert(2, number)
-                    for j in range(4, len(temp)):
-                        self.aooverlaps[base + j - 4, i + base] = float(temp[j])
-                        self.aooverlaps[i + base, base + j - 4] = float(temp[j])
+                    ovlp_line = line.split()
+                    # handle case of merged columns of two-character symbol and index
+                    if len(ovlp_line[1]) == 4:
+                        element = ovlp_line[1][0:2]
+                        number = ovlp_line[1][2:]
+                        ovlp_line[1] = element
+                        ovlp_line.insert(2, number)
+                    for j in range(4, len(ovlp_line)):
+                        self.aooverlaps[base + j - 4, i + base] = float(ovlp_line[j])
+                        self.aooverlaps[i + base, base + j - 4] = float(ovlp_line[j])
                 base += 5
 
         # ECP Pseudopotential information

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1363,6 +1363,11 @@ class GAMESS(logfileparser.Logfile):
                 for i in range(self.nbasis - base):  # Fewer lines each time
                     line = next(inputfile)
                     temp = line.split()
+                    if len(temp[1]) == 4:
+                        element = temp[1][0:2]
+                        number = temp[1][2:]
+                        temp[1] = element
+                        temp.insert(2, number)
                     for j in range(4, len(temp)):
                         self.aooverlaps[base + j - 4, i + base] = float(temp[j])
                         self.aooverlaps[i + base, base + j - 4] = float(temp[j])


### PR DESCRIPTION
closes #1009 

The parsing was incorrect when the atom symbol was two letters and the atom index was also two letters. In this case, the length of the temporary line was one too short in these cases as gamess output was `CU12` instead of expected `CU 12`. 
 
 
 A note:
 The output file provided in this issue will present another problem if parsed with current master branch.  The occupancies were manually set, which breaks parsing due to the changes in [this commit](https://github.com/cclib/cclib/commit/ef4bd5efe493425c8407b3bb8d29a9c3616a5a67). I can document this in a separate issue if that's okay.