### PR TITLE
allow assigned occupancy to be skipped if present

### DIFF
--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1056,8 +1056,16 @@ class GAMESS(logfileparser.Logfile):
                 self.aonames = []
                 readatombasis = True
 
-            self.skip_line(inputfile, 'dashes')
-
+            if line.strip("INITIAL GUESS ORBITALS"):
+              self.skip_line(inputfile, ['dashes','blank','ASSIGNED OCCUPANCIES'])
+              line = next(inputfile)
+              line = next(inputfile)
+              # Skipping assigned occupancies as no object exists to hold this information for MOs
+              if line.strip() == 'ASSIGNED OCCUPANCIES':
+                line = next(inputfile)
+                for i in range(int(numpy.ceil(self.nmo/5.))):
+                    next(inputfile)
+                    
             for base in range(0, self.nmo, 5):
                 self.updateprogress(inputfile, "Coefficients")
 


### PR DESCRIPTION
This helps fix a secondary bug discovered while parsing the file provided in https://github.com/cclib/cclib/issues/1009. 

In the problem file (https://github.com/cclib/cclib-data/pull/177), the parsing failed due to the presence of an ASSIGNED OCCUPANCY block that set the MO occupations. This fix will simply skip this block if it is present allowing the file to be parsed. 