### PR TITLE
Ignore revisions from #1307 in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+## https://github.com/cclib/cclib/pull/1307
+# remove trailing whitespace
+37740d43064bc13445b19ff2d3c5f1154f202896
+# fix end of file
+8f3fbf7d1fc060a3c8522343dd103604bd946e5d
+# fix line endings to be LF
+7b2e8701dcb1a1a6c437919b185be78a35c3e2a5
+# ruff for all but cclib/parser
+e986fd9bb37ca0113707f88f6fea7f2318671cdd
+# ruff for cclib/parser
+04b3e4694e001e4b91457674a490b723e17af2b7
+# isort
+3c499da3e44e4a8ae983407c0f07c71996d202d8
+06e54bd1eb663dd948973037f336d5190f4734ce


### PR DESCRIPTION
Closes #1122

I did everything as outlined in https://www.michaelheap.com/git-ignore-rev/, though one may not want to set a global file:
```bash
git config [--global] blame.ignoreRevsFile .git-blame-ignore-revs
# Mark any lines that have had a commit skipped using --ignore-rev with a `?`
git config --global blame.markIgnoredLines true
# Mark any lines that were added in a skipped commit and can not be attributed with a `*`
git config --global blame.markUnblamableLines true
```

And here are some examples of the output:
```
*06e54bd1 cclib/__init__.py     (Eric Berquist    2023-12-02 09:29:14 -0500 24) # isort: off
?4d22f3a2 src/cclib/__init__.py (Eric Berquist    2017-12-12 11:33:08 -0500 25) from cclib import parser, progress, method, bridge, io
*06e54bd1 cclib/__init__.py     (Eric Berquist    2023-12-02 09:29:14 -0500 26) # isort: on
```
where I think the isort directives show as `*` because they are _only_ from an ignored commit.  The same appears for lines with isolated parens that were not previously on their own lines (see `qchemparser.py` and grep for `2023-12`).

A slightly more confusing case is `adfparser.py`, but the lines from that date are all whitespace and correspond to the CRLF -> LF commit, and those changes seem to constitute a complete change rather than reuse whatever empty line was there before.  But, they're not code lines.