### PR TITLE
regression: remove skip on testQChem_QChem5_1_old_final_print_1_out

### DIFF
--- a/test/regression.py
+++ b/test/regression.py
@@ -2743,7 +2743,6 @@ def testQChem_QChem5_0_Si_out(logfile):
     assert logfile.data.mocoeffs[0][0, 0] == 1.00042
 
 
-@unittest.skip("orphaned test functions are no longer allowed")
 def testQChem_QChem5_1_old_final_print_1_out(logfile):
     """This job has was run from a development version."""
     assert logfile.data.metadata["legacy_package_version"] == "5.1.0"


### PR DESCRIPTION
See https://github.com/cclib/cclib-data/pull/180.  This was associated with #732.

The cclib-data PR must be merged first.