### PR TITLE
unpin pyscf and biopython optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ cda = "cclib.scripts.cda:main"
 [project.optional-dependencies]
 bridges = [
     "ase>=3.21",
-    "biopython==1.76",
+    "biopython",
     "openbabel",
     "pandas",
     "pyquante2 @ git+https://github.com/cclib/pyquante2.git@github-actions-ci",
-    "pyscf<2.3",
+    "pyscf",
     "qc-iodata @ git+https://github.com/theochem/iodata.git@1.0.0a2",
 ]
 docs = [

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -19,8 +19,8 @@ class PyscfTest(unittest.TestCase):
         super(PyscfTest, self).setUp()
         if not find_package("pyscf"):
             raise ImportError("Must install pyscf to run this test")
-        self.data, self.logfile = getdatafile("GAMESS", "basicGAMESS-US2018", ["dvb_sp.out"])
-        self.udata, self.ulogfile = getdatafile("GAMESS", "basicGAMESS-US2018", ["dvb_un_sp.out"])
+        self.data, self.logfile = getdatafile("Gaussian", "basicGaussian16", ["dvb_sp.out"])
+        self.udata, self.ulogfile = getdatafile("Gaussian", "basicGaussian16", ["dvb_un_sp.log"])
 
     def test_makepyscf(self) -> None:
         import pyscf


### PR DESCRIPTION
- Pinning should happen in a requirements.txt, not pyproject.toml.
- PySCF changed their B3LYP recipe to Gaussian, and older versions are incompatible with SciPy 1.11 (https://github.com/pyscf/pyscf/issues/1783).