### PR TITLE
Update copyright years to 2024 with pre-commit enforcement

### DIFF
--- a/.github/license_header.txt
+++ b/.github/license_header.txt
@@ -1,0 +1,4 @@
+Copyright (c) 2024, the cclib development team
+
+This file is part of cclib (http://cclib.github.io) and is distributed under
+the terms of the BSD 3-Clause License.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,3 +152,13 @@ repos:
   #         # - scipy
   #         - types-setuptools
   #       args: []
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath
+          - .github/license_header.txt
+          - --use-current-year
+          - --no-extra-eol

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, the cclib development team
+Copyright (c) 2024, the cclib development team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cclib/__init__.py
+++ b/cclib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2ase.py
+++ b/cclib/bridge/cclib2ase.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2biopython.py
+++ b/cclib/bridge/cclib2biopython.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2horton.py
+++ b/cclib/bridge/cclib2horton.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2psi4.py
+++ b/cclib/bridge/cclib2psi4.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/__init__.py
+++ b/cclib/io/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cjsonreader.py
+++ b/cclib/io/cjsonreader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cjsonwriter.py
+++ b/cclib/io/cjsonwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/cmlwriter.py
+++ b/cclib/io/cmlwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/filereader.py
+++ b/cclib/io/filereader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/xyzreader.py
+++ b/cclib/io/xyzreader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/io/xyzwriter.py
+++ b/cclib/io/xyzwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/bader.py
+++ b/cclib/method/bader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/bickelhaupt.py
+++ b/cclib/method/bickelhaupt.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/cm5.py
+++ b/cclib/method/cm5.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/density.py
+++ b/cclib/method/density.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/lpa.py
+++ b/cclib/method/lpa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/mbo.py
+++ b/cclib/method/mbo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/mpa.py
+++ b/cclib/method/mpa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/orbitals.py
+++ b/cclib/method/orbitals.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/stockholder.py
+++ b/cclib/method/stockholder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/__init__.py
+++ b/cclib/parser/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -1,6 +1,6 @@
 ## -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/gamessdatparser.py
+++ b/cclib/parser/gamessdatparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/nboparser.py
+++ b/cclib/parser/nboparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/psi3parser.py
+++ b/cclib/parser/psi3parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
 import re
 from datetime import timedelta
 from typing import List, Optional, Tuple

--- a/cclib/progress/__init__.py
+++ b/cclib/progress/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/progress/textprogress.py
+++ b/cclib/progress/textprogress.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/__init__.py
+++ b/cclib/scripts/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccframe.py
+++ b/cclib/scripts/ccframe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/ccwrite.py
+++ b/cclib/scripts/ccwrite.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/cclib/scripts/cda.py
+++ b/cclib/scripts/cda.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/doc/sphinx/attributes.py
+++ b/doc/sphinx/attributes.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 """Generate the attributes.rst and attributes_dev.rst files from the
 ccData docstring that describes attributes."""

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
 #
 # cclib documentation build configuration file, created by
 # sphinx-quickstart on Thu Jan 30 14:44:27 2014.
@@ -49,7 +54,7 @@ master_doc = "contents"
 
 # General information about the project.
 project = "cclib"
-copyright = "2014-2021, cclib Development Team"
+copyright = "2014-2024, cclib Development Team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/sphinx/coverage.py
+++ b/doc/sphinx/coverage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/doc/sphinx/docs_common.py
+++ b/doc/sphinx/docs_common.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
 
 import os
 import sys

--- a/manifest.py
+++ b/manifest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/__init__.py
+++ b/test/bridge/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.

--- a/test/bridge/testase.py
+++ b/test/bridge/testase.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testbiopython.py
+++ b/test/bridge/testbiopython.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testhorton.py
+++ b/test/bridge/testhorton.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testpsi4.py
+++ b/test/bridge/testpsi4.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testpyquante.py
+++ b/test/bridge/testpyquante.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/bridge/testpyscf.py
+++ b/test/bridge/testpyscf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
 """test/conftest.py: dynamic testing configuration for pytest
 
 See the pytest documentation for more details:

--- a/test/data/__init__.py
+++ b/test/data/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/common.py
+++ b/test/data/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/skip.py
+++ b/test/data/skip.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testBOMD.py
+++ b/test/data/testBOMD.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testBasis.py
+++ b/test/data/testBasis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCC.py
+++ b/test/data/testCC.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCI.py
+++ b/test/data/testCI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testCore.py
+++ b/test/data/testCore.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testNMR.py
+++ b/test/data/testNMR.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testPolar.py
+++ b/test/data/testPolar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testScan.py
+++ b/test/data/testScan.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testTDun.py
+++ b/test/data/testTDun.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/__init__.py
+++ b/test/io/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.

--- a/test/io/testccio.py
+++ b/test/io/testccio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testcjsonreader.py
+++ b/test/io/testcjsonreader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testcjsonwriter.py
+++ b/test/io/testcjsonwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testfilewriter.py
+++ b/test/io/testfilewriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testscripts.py
+++ b/test/io/testscripts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testwfxwriter.py
+++ b/test/io/testwfxwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testxyzreader.py
+++ b/test/io/testxyzreader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/io/testxyzwriter.py
+++ b/test/io/testxyzwriter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/__init__.py
+++ b/test/method/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.

--- a/test/method/testbader.py
+++ b/test/method/testbader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testcda.py
+++ b/test/method/testcda.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testcm5.py
+++ b/test/method/testcm5.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testelectrons.py
+++ b/test/method/testelectrons.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testmbo.py
+++ b/test/method/testmbo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testmoments.py
+++ b/test/method/testmoments.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testnuclear.py
+++ b/test/method/testnuclear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/__init__.py
+++ b/test/parser/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.

--- a/test/parser/testdata.py
+++ b/test/parser/testdata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/parser/testutils.py
+++ b/test/parser/testutils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/regression.py
+++ b/test/regression.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/regression_io.py
+++ b/test/regression_io.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, the cclib development team
+# Copyright (c) 2024, the cclib development team
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.


### PR DESCRIPTION
There were a few Python files missing the header outright (`__init__.py`, xTB).