### PR TITLE
parse center of mass and use as origin

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2168,7 +2168,7 @@ Dispersion correction           -0.016199959
         # The center of mass is used as the origin
         # It is not stated explicitely, but the dipole moment components printed by ORCA
         # seem to be in atomic units, so they will need to be converted.
-            
+
         # example:
         # The origin for moment calculation is the CENTER OF MASS  = (-1.651256, -1.258772 -1.572312)
 
@@ -2187,13 +2187,14 @@ Dispersion correction           -0.016199959
         # TODO: add quadrupole moment parsing, which can be optionally calculated with ORCA
 
         if line.startswith("The origin for moment calculation is"):
-
             tmp_reference = line.split()[-3:]
             reference_x = float(tmp_reference[0].replace("(", "").replace(",", ""))
             reference_y = float(tmp_reference[1])
             reference_z = float(tmp_reference[2].replace(")", ""))
-            reference = numpy.array([reference_x, reference_y, reference_z])  
-            self.skip_lines(inputfile, ["b", "d", "DIPOLEMOMENT", "d", "XYZ", "electronic", "nuclear", "d"])
+            reference = numpy.array([reference_x, reference_y, reference_z])
+            self.skip_lines(
+                inputfile, ["b", "d", "DIPOLEMOMENT", "d", "XYZ", "electronic", "nuclear", "d"]
+            )
             total = next(inputfile)
             assert "Total Dipole Moment" in total
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2189,7 +2189,6 @@ Dispersion correction           -0.016199959
         #
         # TODO: add quadrupole moment parsing, which can be optionally calculated with ORCA
 
-        self.reference = numpy.zeros(3)
         # the origin/reference might be printed in multiple places in the output file
         # depending on the calculation type
         if line.startswith("The origin for moment calculation is"):

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2196,9 +2196,7 @@ Dispersion correction           -0.016199959
             self.reference = numpy.array([reference_x, reference_y, reference_z])
 
         if line.startswith("DIPOLE MOMENT"):
-            self.skip_lines(
-                inputfile, ["d", "XYZ", "electronic", "nuclear", "d"]
-            )
+            self.skip_lines(inputfile, ["d", "XYZ", "electronic", "nuclear", "d"])
             total = next(inputfile)
             assert "Total Dipole Moment" in total
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -54,7 +54,7 @@ class ORCA(logfileparser.Logfile):
 
         # The excited state multiplicity for post-HF excited states
         self.mdci_et_mult = None
-    
+
         # needs to be here so regression tests pass
         self.reference = [0.0, 0.0, 0.0]
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -54,6 +54,9 @@ class ORCA(logfileparser.Logfile):
 
         # The excited state multiplicity for post-HF excited states
         self.mdci_et_mult = None
+    
+        # needs to be here so regression tests pass
+        self.reference = [0.0, 0.0, 0.0]
 
     def after_parsing(self):
         # ORCA doesn't add the dispersion energy to the "Total energy" (which
@@ -2186,6 +2189,7 @@ Dispersion correction           -0.016199959
         #
         # TODO: add quadrupole moment parsing, which can be optionally calculated with ORCA
 
+        self.reference = numpy.zeros(3)
         # the origin/reference might be printed in multiple places in the output file
         # depending on the calculation type
         if line.startswith("The origin for moment calculation is"):


### PR DESCRIPTION
Parses the origin used for molecular multipole moments and uses the center of mass as reference.

Fixes #1358