### PR TITLE
Changed SCF target parsing for ORCA to be more robust

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2798,14 +2798,14 @@ Dispersion correction           -0.016199959
         # among other things.
         while not "Last Energy change" in line:
             line = next(inputfile)
-        
+
         deltaE_value = float(line.split()[4])
         deltaE_target = float(line.split()[7])
         maxDP_value = None
         rmsDP_value = None
         maxDP_target = None
         rmsDP_target = None
-        
+
         line = next(inputfile)
         if "Last MAX-Density change" in line:
             maxDP_value = float(line.split()[4])
@@ -2817,7 +2817,7 @@ Dispersion correction           -0.016199959
             else:
                 rmsDP_value = None
                 rmsDP_target = None
-                
+
         self.scfvalues[-1].append([deltaE_value, maxDP_value, rmsDP_value])
         self.scftargets.append([deltaE_target, maxDP_target, rmsDP_target])
 

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2793,14 +2793,19 @@ Dispersion correction           -0.016199959
     # end of parse_scf_expanded_format
 
     def _append_scfvalues_scftargets(self, inputfile, line):
-        # The SCF convergence targets are always printed after this, but apparently
-        # not all of them always -- for example the RMS Density is missing for geometry
-        # optimization steps. So, assume the previous value is still valid if it is
-        # not found. For additional certainty, assert that the other targets are unchanged.
+        # The SCF convergence targets are always printed in this next section
+        # but which targets are available depends on the SCF method in use,
+        # among other things.
         while not "Last Energy change" in line:
             line = next(inputfile)
+        
         deltaE_value = float(line.split()[4])
         deltaE_target = float(line.split()[7])
+        maxDP_value = None
+        rmsDP_value = None
+        maxDP_target = None
+        rmsDP_target = None
+        
         line = next(inputfile)
         if "Last MAX-Density change" in line:
             maxDP_value = float(line.split()[4])
@@ -2810,12 +2815,11 @@ Dispersion correction           -0.016199959
                 rmsDP_value = float(line.split()[4])
                 rmsDP_target = float(line.split()[7])
             else:
-                rmsDP_value = self.scfvalues[-1][-1][2]
-                rmsDP_target = self.scftargets[-1][2]
-                assert deltaE_target == self.scftargets[-1][0]
-                assert maxDP_target == self.scftargets[-1][1]
-            self.scfvalues[-1].append([deltaE_value, maxDP_value, rmsDP_value])
-            self.scftargets.append([deltaE_target, maxDP_target, rmsDP_target])
+                rmsDP_value = None
+                rmsDP_target = None
+                
+        self.scfvalues[-1].append([deltaE_value, maxDP_value, rmsDP_value])
+        self.scftargets.append([deltaE_target, maxDP_target, rmsDP_target])
 
 
 _METHODS_SEMIEMPIRICAL = {"AM1", "MNDO", "PM3", "ZINDO/1", "ZINDO/S"}


### PR DESCRIPTION
This change was inspired by a log file that failed to parse, but the structure is private so I cannot share I'm afraid. The error is also difficult to reproduce, it probably requires a structure that has a very difficult to converge SCF.

I'll annotate the changes to explain them, hopefully the logic makes sense on its own without a regression test.