### PR TITLE
Remove URL-based requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ bridges = [
     "pandas",
     "pyquante2 @ git+https://github.com/cclib/pyquante2.git@github-actions-ci",
     "pyscf",
-    "qc-iodata @ git+https://github.com/theochem/iodata.git@1.0.0a2",
+    "qc-iodata>=1.0.0a2",
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ bridges = [
     "biopython",
     "openbabel",
     "pandas",
-    "pyquante2 @ git+https://github.com/cclib/pyquante2.git@github-actions-ci",
     "pyscf",
     "qc-iodata>=1.0.0a2",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pyquante2 @ git+https://github.com/cclib/pyquante2.git@github-actions-ci


### PR DESCRIPTION
As seen in https://github.com/cclib/cclib/issues/1321#issuecomment-1975246199, direct URLs of any kind are not allowed to be present for PyPI uploads (https://github.com/pypa/pip/issues/6301). `python -m twine check dist/*` doesn't catch this yet (https://github.com/pypa/twine/issues/430).