### PR TITLE
docs push requires secret inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/test_and_package.yml
   docs:
     uses: ./.github/workflows/docs.yml
+    secrets: inherit
   publish:
     needs: [nix, unit-tests, docs]
     uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
Closes #1392

The CI rework introduced reusable workflows, but those triggered by `workflow_dispatch` do not automatically get access to the parent workflow's secrets.  See https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow for the two solutions.  Since the docs build and push workflow isn't truly reusable, implicitly inheriting all secrets is easier.