### PR TITLE
NWChem: thermochemistry parsing cleanup

### DIFF
--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1230,7 +1230,7 @@ class NWChem(logfileparser.Logfile):
 
         # extract vibrational frequencies (in cm-1)
         if line.strip() == "Normal Eigenvalue ||           Projected Infra Red Intensities":
-            self.skip_lines(inputfile, ["units", "d"])  # units, dashes
+            self.skip_lines(inputfile, ["units", "dashes and pipes"])
             line = next(inputfile)  # first line of data
             vibfreqs = []
             while set(line.strip()) != {"-"}:

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1184,9 +1184,9 @@ class NWChem(logfileparser.Logfile):
         # - Rotational                     =    2.979 cal/mol-K
         # - Vibrational                    =   97.716 cal/mol-K
         if line[1:12] == "Temperature":
-            self.set_attribute("temperature", utils.float(line.split()[2][:-1]))
+            self.set_attribute("temperature", float(line.split()[2][:-1]))
         if line[1:28] == "frequency scaling parameter":
-            self.set_attribute("pressure", utils.float(line.split()[4]))
+            self.set_attribute("pressure", float(line.split()[4]))
         if line[1:31] == "Thermal correction to Enthalpy" and hasattr(self, "scfenergies"):
             self.set_attribute(
                 "enthalpy",
@@ -1203,8 +1203,7 @@ class NWChem(logfileparser.Logfile):
             )
         if line[1:14] == "Total Entropy":
             self.set_attribute(
-                "entropy",
-                utils.convertor(1e-3 * utils.float(line.split()[3]), "kcal/mol", "hartree"),
+                "entropy", utils.convertor(1e-3 * float(line.split()[3]), "kcal/mol", "hartree")
             )
 
         if line.strip() == "(Projected Frequencies expressed in cm-1)":
@@ -1234,10 +1233,11 @@ class NWChem(logfileparser.Logfile):
             self.skip_lines(inputfile, ["units", "d"])  # units, dashes
             line = next(inputfile)  # first line of data
             vibfreqs = []
-            while set(line.strip()[:-1]) != {"-"}:
-                vibfreqs.append(float(line.split()[1]))
-                self.append_attribute("vibirs", float(line.split()[5]))
-                line = next(inputfile)  # next line
+            while set(line.strip()) != {"-"}:
+                tokens = line.split()
+                vibfreqs.append(float(tokens[1]))
+                self.append_attribute("vibirs", float(tokens[5]))
+                line = next(inputfile)
             self.set_attribute("vibfreqs", vibfreqs)
         # NWChem TD-DFT excited states transitions
         #

--- a/data/NWChem/basicNWChem7.0/dvb_ir.in
+++ b/data/NWChem/basicNWChem7.0/dvb_ir.in
@@ -1,4 +1,3 @@
-start dvb
 title "Divinylbenzene in STO-3G basis set"
 
 geometry units angstroms
@@ -42,6 +41,5 @@ DFT
    iterations 120
    mult 1
    direct
-   print none
 END
 task DFT FREQUENCIES

--- a/data/NWChem/basicNWChem7.0/dvb_ir.out
+++ b/data/NWChem/basicNWChem7.0/dvb_ir.out
@@ -1,26 +1,26 @@
  argument  1 = dvb_ir.in
                                          
                                          
- 
- 
-             Northwest Computational Chemistry Package (NWChem) 7.0.0
+
+
+             Northwest Computational Chemistry Package (NWChem) 7.0.2
              --------------------------------------------------------
- 
- 
+
+
                     Environmental Molecular Sciences Laboratory
                        Pacific Northwest National Laboratory
                                 Richland, WA 99352
- 
-                              Copyright (c) 1994-2019
+
+                              Copyright (c) 1994-2020
                        Pacific Northwest National Laboratory
                             Battelle Memorial Institute
- 
+
              NWChem is an open-source computational chemistry package
                         distributed under the terms of the
                       Educational Community License (ECL) 2.0
              A copy of the license is included with this distribution
                               in the LICENSE.TXT file
- 
+
                                   ACKNOWLEDGMENT
                                   --------------
 
@@ -36,21 +36,21 @@
            Job information
            ---------------
 
-    hostname        = smp-n17.sam.pitt.edu
-    program         = /ihome/kjordan/shu8/software/source/nwchem/nwchem-7.0.0/bin/LINUX64/nwchem
-    date            = Tue Sep 20 18:21:21 2022
+    hostname        = osmium
+    program         = nwchem
+    date            = Mon Apr 22 10:21:07 2024
 
-    compiled        = Wed_May_13_13:33:26_2020
-    source          = /ihome/kjordan/shu8/software/source/nwchem/nwchem-7.0.0
-    nwchem branch   = 7.0.0
-    nwchem revision = N/A
-    ga revision     = 5.7.1
-    use scalapack   = F
+    compiled        = Thu_Apr_18_01:42:41_2024
+    source          = /tmp/eric/spack-stage/spack-stage-nwchem-7.0.2-lowou4v7g63zvpdqahcnmgyq4hulgbsn/spack-src
+    nwchem branch   = 7.0.2
+    nwchem revision = b9985dfa
+    ga revision     = 5.7.2
+    use scalapack   = T
     input           = dvb_ir.in
-    prefix          = dvb.
-    data base       = ./dvb.db
+    prefix          = dvb_ir.
+    data base       = ./dvb_ir.db
     status          = startup
-    nproc           =        4
+    nproc           =        1
     time left       =     -1s
 
 
@@ -68,17 +68,17 @@
 
            Directory information
            ---------------------
- 
+
   0 permanent = .
   0 scratch   = .
- 
- 
- 
- 
+
+
+
+
                                 NWChem Input Module
                                 -------------------
- 
- 
+
+
                         Divinylbenzene in STO-3G basis set
                         ----------------------------------
 
@@ -90,15 +90,15 @@
           ------
           auto-z
           ------
-  no constraints, skipping   0.000000000000000E+000
-  no constraints, skipping   0.000000000000000E+000
- 
- 
+  no constraints, skipping    0.0000000000000000     
+  no constraints, skipping    0.0000000000000000     
+
+
                              Geometry "geometry" -> ""
                              -------------------------
- 
+
  Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
- 
+
   No.       Tag          Charge          X              Y              Z
  ---- ---------------- ---------- -------------- -------------- --------------
     1 C                    6.0000     0.23680554     1.41416660     0.00000000
@@ -121,13 +121,13 @@
    18 H                    1.0000    -1.44522900     3.70144241     0.00000000
    19 H                    1.0000     0.04815351    -4.93192286     0.00000000
    20 H                    1.0000    -0.04815351     4.93192286     0.00000000
- 
+
       Atomic Mass 
       ----------- 
- 
+
       C                 12.000000
       H                  1.007825
- 
+
 
  Effective nuclear repulsion energy (a.u.)     445.9370121674
 
@@ -136,26 +136,26 @@
         X                 Y               Z
  ---------------- ---------------- ----------------
      0.0000000000     0.0000000000     0.0000000000
- 
+
       Symmetry information
       --------------------
- 
+
  Group name             C2h       
  Group number             21
  Group order               4
  No. of unique centers    10
- 
+
       Symmetry unique atoms
- 
+
      1    3    5    7    9   11   13   15   17   19
- 
+
 
 
                                 Z-matrix (autoz)
                                 -------- 
 
  Units are Angstrom for bonds and degrees for angles
- 
+
       Type          Name      I     J     K     L     M      Value
       ----------- --------  ----- ----- ----- ----- ----- ----------
     1 Stretch                  1     3                       1.42204
@@ -228,7 +228,7 @@
    68 Torsion                  4     2    11    13           0.00000
    69 Torsion                  4     2    11    15         180.00000
    70 Torsion                  4     6     1    12         180.00000
-   71 Torsion                  5     2     4     6           0.00000
+   71 Torsion                  5     2     4     6          -0.00000
    72 Torsion                  5     2     4     8         180.00000
    73 Torsion                  5     2    11    13         180.00000
    74 Torsion                  5     2    11    15           0.00000
@@ -238,18 +238,18 @@
    78 Torsion                  6     1    12    14         180.00000
    79 Torsion                  6     1    12    16           0.00000
    80 Torsion                  6     4     2    11         180.00000
-   81 Torsion                  7     3     1    12           0.00000
+   81 Torsion                  7     3     1    12          -0.00000
    82 Torsion                  7     3     5     9           0.00000
-   83 Torsion                  8     4     2    11           0.00000
+   83 Torsion                  8     4     2    11          -0.00000
    84 Torsion                  8     4     6    10           0.00000
    85 Torsion                  9     5     2    11           0.00000
    86 Torsion                 10     6     1    12           0.00000
    87 Torsion                 13    11    15    17         180.00000
-   88 Torsion                 13    11    15    19           0.00000
+   88 Torsion                 13    11    15    19          -0.00000
    89 Torsion                 14    12    16    18         180.00000
-   90 Torsion                 14    12    16    20           0.00000
- 
- 
+   90 Torsion                 14    12    16    20          -0.00000
+
+
             XYZ format geometry
             -------------------
     20
@@ -274,7 +274,7 @@
  H                    -1.44522900     3.70144241     0.00000000
  H                     0.04815351    -4.93192286     0.00000000
  H                    -0.04815351     4.93192286     0.00000000
- 
+
  ==============================================================================
                                 internuclear distances
  ------------------------------------------------------------------------------
@@ -347,6 +347,9 @@
 
 
 
+  library name resolved from: environment
+  library file name is: </home/eric/data/spack/opt/spack/linux-archrolling-zen/gcc-13.2.1/nwchem-7.0.2-lowou4v7g63zvpdqahcnmgyq4hulgbsn/share/nwchem/libraries/>
+  
 
 
  Summary of "ao basis" -> "" (cartesian)
@@ -356,42 +359,50 @@
  *                           sto-3g                   on all atoms 
 
 
- 
- 
+
+
                    NWChem Nuclear Hessian and Frequency Analysis
                    ---------------------------------------------
- 
- 
- 
+
+
+
                               NWChem Analytic Hessian
                               -----------------------
- 
+
+
+                                 NWChem DFT Module
+                                 -----------------
+
+
+                        Divinylbenzene in STO-3G basis set
+
+
                       Basis "ao basis" -> "ao basis" (cartesian)
                       -----
   C (Carbon)
   ----------
             Exponent  Coefficients 
        -------------- ---------------------------------------------------------
-  1 S  7.16168370E+01  0.154329
-  1 S  1.30450960E+01  0.535328
-  1 S  3.53051220E+00  0.444635
- 
-  2 S  2.94124940E+00 -0.099967
-  2 S  6.83483100E-01  0.399513
-  2 S  2.22289900E-01  0.700115
- 
-  3 P  2.94124940E+00  0.155916
-  3 P  6.83483100E-01  0.607684
-  3 P  2.22289900E-01  0.391957
- 
+  1 S  7.16168374E+01  0.154329
+  1 S  1.30450963E+01  0.535328
+  1 S  3.53051216E+00  0.444635
+
+  2 S  2.94124936E+00 -0.099967
+  2 S  6.83483096E-01  0.399513
+  2 S  2.22289916E-01  0.700115
+
+  3 P  2.94124936E+00  0.155916
+  3 P  6.83483096E-01  0.607684
+  3 P  2.22289916E-01  0.391957
+
   H (Hydrogen)
   ------------
             Exponent  Coefficients 
        -------------- ---------------------------------------------------------
   1 S  3.42525091E+00  0.154329
   1 S  6.23913730E-01  0.535328
-  1 S  1.68855400E-01  0.444635
- 
+  1 S  1.68855404E-01  0.444635
+
 
 
  Summary of "ao basis" -> "ao basis" (cartesian)
@@ -402,25 +413,771 @@
  H                           sto-3g                  1        1   1s
 
 
+
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ C                           sto-3g                  3        5   2s1p
+ H                           sto-3g                  1        1   1s
+
+
+  Caching 1-el integrals 
+
+            General Information
+            -------------------
+          SCF calculation type: DFT
+          Wavefunction type:  closed shell.
+          No. of atoms     :    20
+          No. of electrons :    70
+           Alpha electrons :    35
+            Beta electrons :    35
+          Charge           :     0
+          Spin multiplicity:     1
+          Use of symmetry is: off; symmetry adaption is: off
+          Maximum number of iterations: 120
+          This is a Direct SCF calculation.
+          AO basis - number of functions:    60
+                     number of shells:    40
+          Convergence on energy requested:  1.00D-07
+          Convergence on density requested:  1.00D-05
+          Convergence on gradient requested:  1.00D-06
+
+              XC Information
+              --------------
+                         B3LYP Method XC Potential
+                     Hartree-Fock (Exact) Exchange  0.200          
+                        Slater Exchange Functional  0.800 local    
+                    Becke 1988 Exchange Functional  0.720 non-local
+              Lee-Yang-Parr Correlation Functional  0.810          
+                  VWN I RPA Correlation Functional  0.190 local    
+
+             Grid Information
+             ----------------
+          Grid used for XC integration:  fine      
+          Radial quadrature: Mura-Knowles        
+          Angular quadrature: Lebedev. 
+          Tag              B.-S. Rad. Rad. Pts. Rad. Cut. Ang. Pts.
+          ---              ---------- --------- --------- ---------
+          C                   0.70       70          14.0       590
+          H                   0.35       60          14.0       590
+          Grid pruning is: on 
+          Number of quadrature shells:  1300
+          Spatial weights used:  Erf1
+
+          Convergence Information
+          -----------------------
+          Convergence aids based upon iterative change in 
+          total energy or number of iterations. 
+          Levelshifting, if invoked, occurs when the 
+          HOMO/LUMO gap drops below (HL_TOL):  1.00D-02
+          DIIS, if invoked, will attempt to extrapolate 
+          using up to (NFOCK): 10 stored Fock matrices.
+
+                    Damping( 0%)  Levelshifting(0.5)       DIIS
+                  --------------- ------------------- ---------------
+          dE  on:    start            ASAP                start   
+          dE off:    2 iters        120 iters           120 iters 
+
+
+      Screening Tolerance Information
+      -------------------------------
+          Density screening/tol_rho:  1.00D-11
+          AO Gaussian exp screening on grid/accAOfunc:  16
+          CD Gaussian exp screening on grid/accCDfunc:  20
+          XC Gaussian exp screening on grid/accXCfunc:  20
+          Schwarz screening/accCoul:  1.00D-12
+
+
+      Superposition of Atomic Density Guess
+      -------------------------------------
+
+ Sum of atomic energies:        -376.44825159
+
+      Non-variational initial energy
+      ------------------------------
+
+ Total energy =    -379.429466
+ 1-e energy   =   -1401.451098
+ 2-e energy   =     576.084620
+ HOMO         =      -0.037644
+ LUMO         =       0.163723
+
+   Time after variat. SCF:      0.3
+   Time prior to 1st pass:      0.3
+
+ Grid_pts file          = ./dvb_ir.gridpts.0
+ Record size in doubles =  12289        No. of grid_pts per rec  =   3070
+ Max. records in memory =    276        Max. recs in file   = *********
+
+ Grid integrated density:      69.999985459107
+ Requested integration accuracy:   0.10E-13
+
+           Memory utilization after 1st SCF pass: 
+           Heap Space remaining (MW):       77.19            77194190
+          Stack Space remaining (MW):      134.22           134216804
+
+   convergence    iter        energy       DeltaE   RMS-Dens  Diis-err    time
+ ---------------- ----- ----------------- --------- --------- ---------  ------
+ d= 0,ls=0.0,diis     1   -382.2544149666 -8.28D+02  1.42D-02  3.78D-01     2.8
+ Grid integrated density:      69.999985238240
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     2   -382.3017136267 -4.73D-02  6.99D-03  3.82D-02     4.3
+ Grid integrated density:      69.999985788972
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     3   -382.2954321517  6.28D-03  4.21D-03  7.96D-02     6.4
+ Grid integrated density:      69.999985864504
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     4   -382.3080977816 -1.27D-02  5.18D-04  8.80D-04     8.5
+ Grid integrated density:      69.999985868593
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     5   -382.3082341232 -1.36D-04  1.18D-04  4.46D-05    10.6
+ Grid integrated density:      69.999985865101
+ Requested integration accuracy:   0.10E-13
   Resetting Diis
+ d= 0,ls=0.0,diis     6   -382.3082402604 -6.14D-06  3.19D-05  3.09D-06    12.7
+ Grid integrated density:      69.999985865508
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     7   -382.3082407372 -4.77D-07  1.42D-05  1.61D-07    14.8
+ Grid integrated density:      69.999985865596
+ Requested integration accuracy:   0.10E-13
+ d= 0,ls=0.0,diis     8   -382.3082407346  2.58D-09  7.55D-06  1.77D-07    16.9
+
+
+         Total DFT energy =     -382.308240734642
+      One electron energy =    -1400.645117385019
+           Coulomb energy =      630.242757474958
+    Exchange-Corr. energy =      -57.842892992027
+ Nuclear repulsion energy =      445.937012167446
+
+ Numeric. integr. density =       69.999985865596
+
+     Total iterative time =     16.6s
+
+
+
+                       DFT Final Molecular Orbital Analysis
+                       ------------------------------------
+
+ Vector    1  Occ=2.000000D+00  E=-1.002024D+01
+              MO Center= -3.6D-07, -2.1D-06,  4.9D-14, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.699304   1 C  s                 6     -0.699305   2 C  s         
+     2      0.031560   1 C  s                 7     -0.031560   2 C  s         
+    35      0.026965  11 C  s                40     -0.026965  12 C  s         
+
+ Vector    2  Occ=2.000000D+00  E=-1.002019D+01
+              MO Center=  3.6D-07,  2.1D-06,  5.0D-14, r^2= 2.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     1      0.699301   1 C  s                 6      0.699300   2 C  s         
+     2      0.031352   1 C  s                 7      0.031352   2 C  s         
+    35     -0.027328  11 C  s                40     -0.027328  12 C  s         
+
+ Vector    3  Occ=2.000000D+00  E=-1.000793D+01
+              MO Center= -3.2D-04, -1.7D-03,  3.2D-13, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    35      0.699989  11 C  s                40     -0.699570  12 C  s         
+    36      0.030790  11 C  s                41     -0.030771  12 C  s         
+     1     -0.027410   1 C  s                 6      0.027426   2 C  s         
+
+ Vector    4  Occ=2.000000D+00  E=-1.000793D+01
+              MO Center=  3.2D-04,  1.7D-03,  3.2D-13, r^2= 8.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    35      0.699486  11 C  s                40      0.699905  12 C  s         
+    36      0.030753  11 C  s                41      0.030772  12 C  s         
+     1      0.027659   1 C  s                 6      0.027643   2 C  s         
+
+ Vector    5  Occ=2.000000D+00  E=-1.000689D+01
+              MO Center= -8.8D-04,  2.8D-04,  6.2D-14, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.546283   5 C  s                26      0.546700   6 C  s         
+    11     -0.437254   3 C  s                16     -0.437572   4 C  s         
+    22      0.028143   5 C  s                27      0.028165   6 C  s         
+
+ Vector    6  Occ=2.000000D+00  E=-1.000688D+01
+              MO Center=  8.8D-04, -2.8D-04,  8.5D-14, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    21      0.556177   5 C  s                26     -0.555768   6 C  s         
+    11     -0.424363   3 C  s                16      0.424035   4 C  s         
+     1     -0.028676   1 C  s                 6      0.028679   2 C  s         
+    22      0.028665   5 C  s                27     -0.028644   6 C  s         
+
+ Vector    7  Occ=2.000000D+00  E=-1.000624D+01
+              MO Center= -7.9D-06, -4.4D-07, -4.8D-14, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.556941   3 C  s                16     -0.556945   4 C  s         
+    21      0.425509   5 C  s                26     -0.425511   6 C  s         
+
+ Vector    8  Occ=2.000000D+00  E=-1.000609D+01
+              MO Center=  7.7D-06, -8.2D-07, -2.3D-14, r^2= 2.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    11      0.546603   3 C  s                16      0.546600   4 C  s         
+    21      0.437649   5 C  s                26      0.437646   6 C  s         
+     1      0.029442   1 C  s                 6      0.029442   2 C  s         
+
+ Vector    9  Occ=2.000000D+00  E=-9.992164D+00
+              MO Center=  3.5D-03, -3.7D-02,  2.9D-13, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    47      0.703798  15 C  s                52     -0.697144  16 C  s         
+    48      0.031006  15 C  s                53     -0.030713  16 C  s         
+
+ Vector   10  Occ=2.000000D+00  E=-9.992163D+00
+              MO Center= -3.5D-03,  3.7D-02,  2.9D-13, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    52      0.703797  16 C  s                47      0.697144  15 C  s         
+    53      0.031006  16 C  s                48      0.030713  15 C  s         
+
+ Vector   11  Occ=2.000000D+00  E=-8.094662D-01
+              MO Center= -7.3D-09, -8.7D-09,  3.1D-12, r^2= 3.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.274703   1 C  s                 7      0.274703   2 C  s         
+    12      0.247016   3 C  s                17      0.247016   4 C  s         
+    22      0.246689   5 C  s                27      0.246689   6 C  s         
+    36      0.127807  11 C  s                41      0.127807  12 C  s         
+     1     -0.107859   1 C  s                 6     -0.107859   2 C  s         
+
+ Vector   12  Occ=2.000000D+00  E=-7.539348D-01
+              MO Center= -1.4D-09, -2.9D-08,  2.2D-10, r^2= 7.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36     -0.297169  11 C  s                41      0.297169  12 C  s         
+     2      0.273787   1 C  s                 7     -0.273787   2 C  s         
+    48     -0.209312  15 C  s                53      0.209312  16 C  s         
+    35      0.113817  11 C  s                40     -0.113817  12 C  s         
+    22     -0.112555   5 C  s                27      0.112555   6 C  s         
+
+ Vector   13  Occ=2.000000D+00  E=-7.178614D-01
+              MO Center= -3.5D-09,  8.9D-09,  2.8D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36      0.314817  11 C  s                41      0.314817  12 C  s         
+    48      0.309767  15 C  s                53      0.309767  16 C  s         
+    12     -0.121456   3 C  s                17     -0.121456   4 C  s         
+    35     -0.119239  11 C  s                40     -0.119239  12 C  s         
+    47     -0.117464  15 C  s                52     -0.117464  16 C  s         
+
+ Vector   14  Occ=2.000000D+00  E=-6.999224D-01
+              MO Center=  6.9D-09,  3.4D-10, -1.8D-11, r^2= 3.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.357134   3 C  s                17     -0.357134   4 C  s         
+    22      0.323905   5 C  s                27     -0.323905   6 C  s         
+    11     -0.132324   3 C  s                16      0.132324   4 C  s         
+     3      0.124986   1 C  px                8      0.124986   2 C  px        
+    21     -0.120093   5 C  s                26      0.120093   6 C  s         
+
+ Vector   15  Occ=2.000000D+00  E=-6.673152D-01
+              MO Center= -3.2D-09,  1.9D-08, -1.1D-11, r^2= 9.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.299508  15 C  s                53     -0.299508  16 C  s         
+     2      0.274066   1 C  s                 7     -0.274066   2 C  s         
+    22     -0.202279   5 C  s                27      0.202279   6 C  s         
+    36      0.136845  11 C  s                41     -0.136846  12 C  s         
+    38     -0.129053  11 C  py               43     -0.129053  12 C  py        
+
+ Vector   16  Occ=2.000000D+00  E=-5.885093D-01
+              MO Center=  9.3D-10, -1.3D-08, -1.8D-12, r^2= 8.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.241407  15 C  s                53      0.241407  16 C  s         
+    22      0.233815   5 C  s                27      0.233815   6 C  s         
+     2     -0.206378   1 C  s                 7     -0.206378   2 C  s         
+    14     -0.160007   3 C  py               19      0.160007   4 C  py        
+    36     -0.159613  11 C  s                41     -0.159613  12 C  s         
+
+ Vector   17  Occ=2.000000D+00  E=-5.591516D-01
+              MO Center= -4.5D-09, -6.6D-09, -6.9D-11, r^2= 5.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.326033   3 C  s                17      0.326033   4 C  s         
+     3      0.184865   1 C  px                8     -0.184865   2 C  px        
+    22     -0.170745   5 C  s                24      0.170444   5 C  py        
+    27     -0.170745   6 C  s                29     -0.170444   6 C  py        
+    31      0.169234   7 H  s                32      0.169234   8 H  s         
+
+ Vector   18  Occ=2.000000D+00  E=-5.314208D-01
+              MO Center=  1.7D-10, -1.3D-08,  8.4D-11, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36      0.302766  11 C  s                41     -0.302766  12 C  s         
+    48     -0.249165  15 C  s                53      0.249165  16 C  s         
+    45      0.170519  13 H  s                46     -0.170519  14 H  s         
+    57     -0.160626  17 H  s                58      0.160626  18 H  s         
+    12      0.154466   3 C  s                17     -0.154466   4 C  s         
+
+ Vector   19  Occ=2.000000D+00  E=-5.099374D-01
+              MO Center= -6.4D-10,  2.3D-08,  4.8D-11, r^2= 7.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.201895   5 C  px               28     -0.201895   6 C  px        
+    13      0.184492   3 C  px               18     -0.184492   4 C  px        
+    36      0.180760  11 C  s                41      0.180760  12 C  s         
+    33      0.169278   9 H  s                34      0.169278  10 H  s         
+    22      0.166023   5 C  s                27      0.166023   6 C  s         
+
+ Vector   20  Occ=2.000000D+00  E=-4.575994D-01
+              MO Center= -4.2D-09, -2.3D-08, -1.8D-11, r^2= 9.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      0.212730  15 C  px               54     -0.212730  16 C  px        
+    38      0.184649  11 C  py               43     -0.184649  12 C  py        
+    57      0.179110  17 H  s                58      0.179110  18 H  s         
+    45     -0.153094  13 H  s                46     -0.153094  14 H  s         
+    14      0.141384   3 C  py               19     -0.141384   4 C  py        
+
+ Vector   21  Occ=2.000000D+00  E=-4.391971D-01
+              MO Center= -2.9D-09, -3.1D-08,  2.0D-11, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    37      0.219233  11 C  px               42      0.219233  12 C  px        
+    50      0.210291  15 C  py               55      0.210291  16 C  py        
+    14      0.184960   3 C  py               19      0.184960   4 C  py        
+    59     -0.178127  19 H  s                60      0.178127  20 H  s         
+    45     -0.155495  13 H  s                46      0.155495  14 H  s         
+
+ Vector   22  Occ=2.000000D+00  E=-4.110182D-01
+              MO Center= -8.4D-09, -1.8D-08, -3.9D-11, r^2= 6.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.235310   1 C  s                 7     -0.235310   2 C  s         
+    33      0.230467   9 H  s                34     -0.230467  10 H  s         
+    31     -0.226658   7 H  s                32      0.226658   8 H  s         
+    13     -0.222261   3 C  px               18     -0.222261   4 C  px        
+    24     -0.177972   5 C  py               29     -0.177972   6 C  py        
+
+ Vector   23  Occ=2.000000D+00  E=-3.976934D-01
+              MO Center=  9.6D-10,  7.0D-09,  3.6D-12, r^2= 8.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    23      0.251235   5 C  px               28      0.251235   6 C  px        
+    49      0.250512  15 C  px               54      0.250512  16 C  px        
+     3     -0.220827   1 C  px                8     -0.220827   2 C  px        
+    57      0.215415  17 H  s                58     -0.215415  18 H  s         
+    38      0.181487  11 C  py               43      0.181487  12 C  py        
+
+ Vector   24  Occ=2.000000D+00  E=-3.959385D-01
+              MO Center=  9.8D-09,  3.4D-08,  8.3D-12, r^2= 1.5D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    50      0.338998  15 C  py               55     -0.338998  16 C  py        
+    59     -0.262595  19 H  s                60     -0.262595  20 H  s         
+    37      0.251492  11 C  px               42     -0.251492  12 C  px        
+    45     -0.145063  13 H  s                46     -0.145063  14 H  s         
+    24      0.136713   5 C  py               29     -0.136713   6 C  py        
+
+ Vector   25  Occ=2.000000D+00  E=-3.744297D-01
+              MO Center= -3.7D-09,  2.2D-09, -2.1D-12, r^2= 4.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      0.307585   3 C  px               18      0.307585   4 C  px        
+    31      0.252268   7 H  s                32     -0.252268   8 H  s         
+    24     -0.226087   5 C  py               29     -0.226087   6 C  py        
+    33      0.218183   9 H  s                34     -0.218183  10 H  s         
+    23      0.188063   5 C  px               28      0.188063   6 C  px        
+
+ Vector   26  Occ=2.000000D+00  E=-3.509367D-01
+              MO Center= -3.1D-08, -3.2D-08,  1.4D-11, r^2= 9.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    50     -0.245677  15 C  py               55     -0.245677  16 C  py        
+    14      0.224344   3 C  py               19      0.224344   4 C  py        
+    37     -0.201678  11 C  px               42     -0.201678  12 C  px        
+    24     -0.193258   5 C  py               29     -0.193258   6 C  py        
+    38      0.187745  11 C  py               43      0.187745  12 C  py        
+
+ Vector   27  Occ=2.000000D+00  E=-3.470152D-01
+              MO Center=  3.6D-08,  1.9D-08,  2.7D-11, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    49      0.295189  15 C  px               54     -0.295189  16 C  px        
+    57      0.268012  17 H  s                58      0.268012  18 H  s         
+    37     -0.208878  11 C  px               42      0.208878  12 C  px        
+    45      0.200233  13 H  s                46      0.200233  14 H  s         
+    31     -0.156471   7 H  s                32     -0.156471   8 H  s         
+
+ Vector   28  Occ=2.000000D+00  E=-3.244703D-01
+              MO Center= -5.5D-09, -8.7D-09,  1.7D-11, r^2= 3.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.337608   1 C  pz               10      0.337608   2 C  pz        
+    15      0.297979   3 C  pz               20      0.297979   4 C  pz        
+    25      0.297169   5 C  pz               30      0.297169   6 C  pz        
+    39      0.173946  11 C  pz               44      0.173946  12 C  pz        
+    51      0.092442  15 C  pz               56      0.092442  16 C  pz        
+
+ Vector   29  Occ=2.000000D+00  E=-3.110647D-01
+              MO Center= -2.3D-10, -2.6D-09, -1.5D-11, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    45      0.259102  13 H  s                46     -0.259102  14 H  s         
+     4      0.241973   1 C  py                9      0.241973   2 C  py        
+    57      0.231030  17 H  s                58     -0.231030  18 H  s         
+    37     -0.217251  11 C  px               42     -0.217251  12 C  px        
+    59     -0.212334  19 H  s                60      0.212334  20 H  s         
+
+ Vector   30  Occ=2.000000D+00  E=-2.929833D-01
+              MO Center=  7.8D-09,  3.8D-08, -1.1D-11, r^2= 6.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14     -0.278185   3 C  py               19      0.278185   4 C  py        
+     4      0.268399   1 C  py                9     -0.268399   2 C  py        
+    38      0.248142  11 C  py               43     -0.248142  12 C  py        
+    33     -0.240410   9 H  s                34     -0.240410  10 H  s         
+    24      0.234450   5 C  py               29     -0.234450   6 C  py        
+
+ Vector   31  Occ=2.000000D+00  E=-2.874966D-01
+              MO Center=  7.1D-09,  2.4D-08, -8.8D-12, r^2= 6.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.295856   1 C  px                8     -0.295856   2 C  px        
+    23      0.280599   5 C  px               28     -0.280599   6 C  px        
+    31     -0.258071   7 H  s                32     -0.258071   8 H  s         
+    13     -0.222117   3 C  px               18      0.222117   4 C  px        
+    45     -0.182739  13 H  s                46     -0.182739  14 H  s         
+
+ Vector   32  Occ=2.000000D+00  E=-2.634557D-01
+              MO Center= -8.0D-12, -1.3D-08, -1.9D-10, r^2= 7.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    39     -0.376480  11 C  pz               44      0.376480  12 C  pz        
+     5      0.348964   1 C  pz               10     -0.348964   2 C  pz        
+    51     -0.271399  15 C  pz               56      0.271399  16 C  pz        
+    15      0.131647   3 C  pz               20     -0.131647   4 C  pz        
+    25     -0.132107   5 C  pz               30      0.132107   6 C  pz        
+
+ Vector   33  Occ=2.000000D+00  E=-2.123364D-01
+              MO Center= -7.2D-09,  4.0D-09, -2.1D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    51      0.417961  15 C  pz               56      0.417961  16 C  pz        
+    39      0.413781  11 C  pz               44      0.413781  12 C  pz        
+    15     -0.179205   3 C  pz               20     -0.179205   4 C  pz        
+    25     -0.176633   5 C  pz               30     -0.176633   6 C  pz        
+
+ Vector   34  Occ=2.000000D+00  E=-1.951682D-01
+              MO Center=  1.2D-08, -1.6D-09, -3.2D-11, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.463626   3 C  pz               20     -0.463626   4 C  pz        
+    25      0.457537   5 C  pz               30     -0.457537   6 C  pz        
+
+ Vector   35  Occ=2.000000D+00  E=-1.529966D-01
+              MO Center= -9.4D-10,  2.0D-08,  6.1D-11, r^2= 8.1D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    51      0.397372  15 C  pz               56     -0.397372  16 C  pz        
+     5      0.387554   1 C  pz               10     -0.387554   2 C  pz        
+    25     -0.230744   5 C  pz               30      0.230744   6 C  pz        
+    39      0.223675  11 C  pz               44     -0.223675  12 C  pz        
+    15      0.215068   3 C  pz               20     -0.215068   4 C  pz        
+
+ Vector   36  Occ=0.000000D+00  E= 3.750916D-02
+              MO Center=  2.8D-10, -1.6D-08, -5.6D-11, r^2= 8.0D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    51     -0.449614  15 C  pz               56     -0.449614  16 C  pz        
+     5      0.442670   1 C  pz               10      0.442670   2 C  pz        
+    25     -0.277553   5 C  pz               30     -0.277553   6 C  pz        
+    39      0.256133  11 C  pz               44      0.256133  12 C  pz        
+    15     -0.232265   3 C  pz               20     -0.232265   4 C  pz        
+
+ Vector   37  Occ=0.000000D+00  E= 9.011732D-02
+              MO Center= -9.7D-09,  1.0D-09,  2.2D-11, r^2= 2.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    15      0.582692   3 C  pz               20      0.582692   4 C  pz        
+    25     -0.553237   5 C  pz               30     -0.553237   6 C  pz        
+     5     -0.031922   1 C  pz               10     -0.031922   2 C  pz        
+
+ Vector   38  Occ=0.000000D+00  E= 1.107280D-01
+              MO Center=  7.2D-09, -1.0D-09,  2.1D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    39      0.522167  11 C  pz               44     -0.522167  12 C  pz        
+    51     -0.523103  15 C  pz               56      0.523103  16 C  pz        
+    15      0.240693   3 C  pz               20     -0.240693   4 C  pz        
+    25     -0.232246   5 C  pz               30      0.232246   6 C  pz        
+
+ Vector   39  Occ=0.000000D+00  E= 1.822016D-01
+              MO Center=  2.3D-10,  1.1D-08,  4.1D-10, r^2= 7.9D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    39     -0.529134  11 C  pz               44     -0.529134  12 C  pz        
+     5      0.497218   1 C  pz               10      0.497218   2 C  pz        
+    51      0.379694  15 C  pz               56      0.379694  16 C  pz        
+    25     -0.199198   5 C  pz               30     -0.199198   6 C  pz        
+    15     -0.166739   3 C  pz               20     -0.166739   4 C  pz        
+
+ Vector   40  Occ=0.000000D+00  E= 2.723015D-01
+              MO Center=  3.5D-09,  4.7D-09, -1.7D-10, r^2= 3.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     5      0.543477   1 C  pz               10     -0.543477   2 C  pz        
+    25      0.466878   5 C  pz               30     -0.466878   6 C  pz        
+    15     -0.464184   3 C  pz               20      0.464184   4 C  pz        
+    39      0.287732  11 C  pz               44     -0.287732  12 C  pz        
+    51     -0.156154  15 C  pz               56      0.156154  16 C  pz        
+
+ Vector   41  Occ=0.000000D+00  E= 3.324848D-01
+              MO Center= -7.7D-08, -1.6D-07, -8.5D-11, r^2= 8.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    33     -0.423790   9 H  s                34     -0.423790  10 H  s         
+    31     -0.413779   7 H  s                32     -0.413779   8 H  s         
+     2      0.401568   1 C  s                 7      0.401568   2 C  s         
+    59     -0.358543  19 H  s                60     -0.358543  20 H  s         
+    38     -0.338104  11 C  py               43      0.338104  12 C  py        
+
+ Vector   42  Occ=0.000000D+00  E= 3.406448D-01
+              MO Center=  7.6D-08,  1.1D-07, -4.4D-11, r^2= 1.0D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    45      0.433827  13 H  s                46     -0.433827  14 H  s         
+    13      0.355436   3 C  px               18      0.355436   4 C  px        
+    37      0.344559  11 C  px               42      0.344559  12 C  px        
+    31     -0.321888   7 H  s                32      0.321888   8 H  s         
+    57     -0.323134  17 H  s                58      0.323134  18 H  s         
+
+ Vector   43  Occ=0.000000D+00  E= 3.795219D-01
+              MO Center=  7.1D-09,  7.9D-09,  6.4D-11, r^2= 7.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    36      0.546115  11 C  s                41     -0.546115  12 C  s         
+     4      0.461529   1 C  py                9      0.461529   2 C  py        
+    33      0.405573   9 H  s                34     -0.405573  10 H  s         
+    59      0.351696  19 H  s                60     -0.351696  20 H  s         
+     2      0.338375   1 C  s                 7     -0.338375   2 C  s         
+
+ Vector   44  Occ=0.000000D+00  E= 3.812902D-01
+              MO Center= -2.9D-08, -3.8D-09,  4.2D-11, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    45      0.579606  13 H  s                46      0.579606  14 H  s         
+    12      0.393525   3 C  s                17      0.393525   4 C  s         
+    57     -0.391440  17 H  s                58     -0.391440  18 H  s         
+    36     -0.382167  11 C  s                41     -0.382167  12 C  s         
+    37      0.338368  11 C  px               42     -0.338368  12 C  px        
+
+ Vector   45  Occ=0.000000D+00  E= 4.103420D-01
+              MO Center= -2.0D-07,  4.6D-07, -2.3D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.647348  15 C  s                53      0.647348  16 C  s         
+    22      0.620078   5 C  s                27      0.620078   6 C  s         
+    57     -0.513314  17 H  s                58     -0.513314  18 H  s         
+    12     -0.443653   3 C  s                17     -0.443653   4 C  s         
+    59     -0.320793  19 H  s                60     -0.320793  20 H  s         
+
+ Vector   46  Occ=0.000000D+00  E= 4.112338D-01
+              MO Center=  1.6D-07, -5.3D-07, -5.5D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    22      0.613158   5 C  s                27     -0.613158   6 C  s         
+    48      0.539737  15 C  s                53     -0.539737  16 C  s         
+     2      0.476221   1 C  s                 7     -0.476221   2 C  s         
+    57     -0.447816  17 H  s                58      0.447816  18 H  s         
+    12     -0.440666   3 C  s                17      0.440666   4 C  s         
+
+ Vector   47  Occ=0.000000D+00  E= 4.258026D-01
+              MO Center=  2.9D-08,  5.7D-08, -1.8D-12, r^2= 9.2D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    31      0.603107   7 H  s                32     -0.603107   8 H  s         
+    36     -0.446800  11 C  s                41      0.446800  12 C  s         
+    45      0.437141  13 H  s                46     -0.437141  14 H  s         
+    12     -0.368675   3 C  s                17      0.368675   4 C  s         
+    59      0.337703  19 H  s                60     -0.337703  20 H  s         
+
+ Vector   48  Occ=0.000000D+00  E= 4.393595D-01
+              MO Center=  1.3D-08, -3.3D-08, -3.6D-10, r^2= 7.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.782305   1 C  s                 7      0.782305   2 C  s         
+    36     -0.556792  11 C  s                41     -0.556792  12 C  s         
+    12     -0.499659   3 C  s                17     -0.499659   4 C  s         
+    22     -0.411568   5 C  s                27     -0.411568   6 C  s         
+    48      0.409886  15 C  s                53      0.409886  16 C  s         
+
+ Vector   49  Occ=0.000000D+00  E= 4.537211D-01
+              MO Center=  1.1D-08,  3.3D-08,  4.4D-10, r^2= 1.2D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    48      0.706722  15 C  s                53     -0.706722  16 C  s         
+    57     -0.525555  17 H  s                58      0.525555  18 H  s         
+    33      0.477113   9 H  s                34     -0.477113  10 H  s         
+    36     -0.429001  11 C  s                41      0.429001  12 C  s         
+    22     -0.407169   5 C  s                27      0.407169   6 C  s         
+
+ Vector   50  Occ=0.000000D+00  E= 4.783353D-01
+              MO Center= -7.9D-09,  2.7D-08,  2.3D-10, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.706217   3 C  s                17      0.706217   4 C  s         
+    22     -0.619401   5 C  s                27     -0.619401   6 C  s         
+    59     -0.475187  19 H  s                60     -0.475187  20 H  s         
+    48      0.415042  15 C  s                53      0.415042  16 C  s         
+    50     -0.382621  15 C  py               55      0.382621  16 C  py        
+
+ Vector   51  Occ=0.000000D+00  E= 5.255620D-01
+              MO Center=  3.0D-09, -1.5D-08, -1.6D-11, r^2= 6.5D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.601872   1 C  py                9     -0.601872   2 C  py        
+    36     -0.491669  11 C  s                41     -0.491669  12 C  s         
+    13     -0.452502   3 C  px               18      0.452502   4 C  px        
+     2     -0.448702   1 C  s                 7     -0.448702   2 C  s         
+    49     -0.342028  15 C  px               54      0.342028  16 C  px        
+
+ Vector   52  Occ=0.000000D+00  E= 5.463507D-01
+              MO Center=  4.6D-09,  2.2D-08,  6.2D-11, r^2= 7.7D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    12      0.647802   3 C  s                17     -0.647802   4 C  s         
+     3     -0.560732   1 C  px                8     -0.560732   2 C  px        
+    50      0.483438  15 C  py               55      0.483438  16 C  py        
+    24     -0.478220   5 C  py               29     -0.478220   6 C  py        
+    59      0.356004  19 H  s                60     -0.356004  20 H  s         
+
+ Vector   53  Occ=0.000000D+00  E= 5.764357D-01
+              MO Center= -2.8D-09,  1.8D-09, -3.4D-11, r^2= 5.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    13      0.537124   3 C  px               18     -0.537124   4 C  px        
+    23     -0.522141   5 C  px               28      0.522141   6 C  px        
+    33      0.519104   9 H  s                34      0.519104  10 H  s         
+    31     -0.448313   7 H  s                32     -0.448313   8 H  s         
+    24      0.400193   5 C  py               29     -0.400193   6 C  py        
+
+ Vector   54  Occ=0.000000D+00  E= 5.984380D-01
+              MO Center= -3.6D-09, -4.2D-09, -3.2D-11, r^2= 4.8D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    14      0.723029   3 C  py               19      0.723029   4 C  py        
+    22      0.599919   5 C  s                27     -0.599919   6 C  s         
+    36     -0.415409  11 C  s                41      0.415409  12 C  s         
+     2     -0.405912   1 C  s                 7      0.405912   2 C  s         
+    24      0.394227   5 C  py               29      0.394227   6 C  py        
+
+ Vector   55  Occ=0.000000D+00  E= 6.248973D-01
+              MO Center=  1.0D-09, -6.2D-08,  3.3D-13, r^2= 1.1D+01
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     2      0.608534   1 C  s                 7     -0.608534   2 C  s         
+    49     -0.528892  15 C  px               54     -0.528892  16 C  px        
+    38      0.480661  11 C  py               43      0.480661  12 C  py        
+    23     -0.365994   5 C  px               28     -0.365994   6 C  px        
+    57      0.363289  17 H  s                58     -0.363289  18 H  s         
+
+ Vector   56  Occ=0.000000D+00  E= 6.398332D-01
+              MO Center=  5.2D-09,  6.1D-08,  1.2D-11, r^2= 9.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    37      0.549269  11 C  px               42     -0.549269  12 C  px        
+    50     -0.534300  15 C  py               55      0.534300  16 C  py        
+    14      0.383478   3 C  py               19     -0.383478   4 C  py        
+     4     -0.364575   1 C  py                9      0.364575   2 C  py        
+    59     -0.330751  19 H  s                60     -0.330751  20 H  s         
+
+ Vector   57  Occ=0.000000D+00  E= 6.828367D-01
+              MO Center=  2.3D-09, -1.3D-09,  1.3D-11, r^2= 9.3D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    38      0.663093  11 C  py               43     -0.663093  12 C  py        
+    49     -0.580412  15 C  px               54      0.580412  16 C  px        
+    24     -0.449230   5 C  py               29      0.449230   6 C  py        
+    14     -0.392087   3 C  py               19      0.392087   4 C  py        
+     4     -0.381670   1 C  py                9      0.381670   2 C  py        
+
+ Vector   58  Occ=0.000000D+00  E= 7.173573D-01
+              MO Center= -4.0D-10,  8.6D-09, -8.2D-11, r^2= 9.6D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+    37      0.608025  11 C  px               42      0.608025  12 C  px        
+    48     -0.538018  15 C  s                50     -0.540484  15 C  py        
+    53      0.538018  16 C  s                55     -0.540484  16 C  py        
+    36      0.466540  11 C  s                38     -0.464867  11 C  py        
+    41     -0.466540  12 C  s                43     -0.464867  12 C  py        
+
+ Vector   59  Occ=0.000000D+00  E= 7.790412D-01
+              MO Center=  4.0D-09,  2.0D-08,  4.8D-12, r^2= 5.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     3      0.702432   1 C  px                8     -0.702432   2 C  px        
+    14     -0.534059   3 C  py               19      0.534059   4 C  py        
+    23     -0.435986   5 C  px               28      0.435986   6 C  px        
+    37      0.429836  11 C  px               42     -0.429836  12 C  px        
+    24     -0.411037   5 C  py               29      0.411037   6 C  py        
+
+ Vector   60  Occ=0.000000D+00  E= 7.942624D-01
+              MO Center=  3.4D-09, -1.8D-09,  1.2D-11, r^2= 3.4D+00
+   Bfn.  Coefficient  Atom+Function         Bfn.  Coefficient  Atom+Function  
+  ----- ------------  ---------------      ----- ------------  ---------------
+     4      0.657693   1 C  py                9      0.657693   2 C  py        
+    13     -0.568325   3 C  px               18     -0.568325   4 C  px        
+    23      0.496519   5 C  px               28      0.496519   6 C  px        
+    22     -0.413797   5 C  s                27      0.413797   6 C  s         
+    24     -0.395895   5 C  py               29     -0.395895   6 C  py        
+
+
+ center of mass
+ --------------
+ x =   0.00000000 y =   0.00000000 z =   0.00000000
+
+ moments of inertia (a.u.)
+ ------------------
+        2631.731379210404           0.000000000000           0.000000000000
+           0.000000000000         390.819001468288           0.000000000000
+           0.000000000000           0.000000000000        3022.550380678692
+
+     Multipole analysis of the density
+     ---------------------------------
+
+     L   x y z        total         alpha         beta         nuclear
+     -   - - -        -----         -----         ----         -------
+     0   0 0 0     -0.000000    -35.000000    -35.000000     70.000000
+
+     1   1 0 0      0.000000      0.000000      0.000000      0.000000
+     1   0 1 0      0.000000      0.000000      0.000000      0.000000
+     1   0 0 1     -0.000000     -0.000000     -0.000000      0.000000
+
+     2   2 0 0    -37.347173   -141.071523   -141.071523    244.795872
+     2   1 1 0      0.066525      2.848776      2.848776     -5.631027
+     2   1 0 1     -0.000000     -0.000000     -0.000000      0.000000
+     2   0 2 0    -37.714769   -767.339035   -767.339035   1496.963300
+     2   0 1 1     -0.000000     -0.000000     -0.000000      0.000000
+     2   0 0 2    -43.587343    -21.793672    -21.793672      0.000000
+
 
  HESSIAN: the one electron contributions are done in       0.3s
 
 
- HESSIAN: 2-el 1st deriv. term done in                     2.3s
+ HESSIAN: 2-el 1st deriv. term done in                     1.6s
 
 
- HESSIAN: 2-el 2nd deriv. term done in                     3.4s
+ HESSIAN: 2-el 2nd deriv. term done in                     5.4s
 
-  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb.hess
- stpr_wrt_fd_dipole: overwrite of existing file./dvb.fd_ddipole
+  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb_ir.hess
+ stpr_wrt_fd_dipole: overwrite of existing file./dvb_ir.fd_ddipole
 
- HESSIAN: the two electron contributions are done in      25.0s
+ HESSIAN: the two electron contributions are done in      36.8s
 
                                 NWChem CPHF Module
                                 ------------------
- 
- 
+
+
   scftype          =     RHF 
   nclosed          =       35
   nopen            =        0
@@ -431,9 +1188,9 @@
   max iterations   =       50
   max subspace     =      600
 
- Grid integrated density:      69.999985865642
+ Grid integrated density:      69.999985865528
  Requested integration accuracy:   0.10E-13
- SCF residual:   9.863227145154007E-005
+ SCF residual:    9.8629695379582672E-005
 
 
 Iterative solution of linear equations
@@ -442,18 +1199,18 @@ Iterative solution of linear equations
   Maximum subspace      600
         Iterations       50
        Convergence  1.0D-04
-        Start time     77.8
+        Start time     99.7
 
 
    iter   nsub   residual    time
    ----  ------  --------  ---------
-     1     60    1.02D-01     114.1
-     2    120    3.14D-02     150.4
-     3    180    3.42D-04     186.6
-     4    240    9.07D-06     222.8
+     1     60    1.02D-01     146.5
+     2    120    3.15D-02     193.5
+     3    180    3.42D-04     240.6
+     4    240    9.07D-06     287.9
  HESSIAN: the CPHF contributions are done
-  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb.hess
- stpr_wrt_fd_dipole: overwrite of existing file./dvb.fd_ddipole
+  stpr_wrt_fd_from_sq: overwrite of existing file:./dvb_ir.hess
+ stpr_wrt_fd_dipole: overwrite of existing file./dvb_ir.fd_ddipole
 
  Derivative Dipole
 
@@ -462,31 +1219,31 @@ Iterative solution of linear equations
  X vector of derivative dipole (au) [debye/angstrom]
  d_dipole_x/<atom=   1,x> =    -0.1510     [   -0.7254]
  d_dipole_x/<atom=   1,y> =    -0.0021     [   -0.0102]
- d_dipole_x/<atom=   1,z> =     0.0000     [    0.0000]
+ d_dipole_x/<atom=   1,z> =    -0.0000     [   -0.0000]
  d_dipole_x/<atom=   2,x> =    -0.1510     [   -0.7254]
  d_dipole_x/<atom=   2,y> =    -0.0021     [   -0.0102]
- d_dipole_x/<atom=   2,z> =     0.0000     [    0.0000]
+ d_dipole_x/<atom=   2,z> =    -0.0000     [   -0.0000]
  d_dipole_x/<atom=   3,x> =     0.0275     [    0.1322]
  d_dipole_x/<atom=   3,y> =     0.0823     [    0.3954]
- d_dipole_x/<atom=   3,z> =     0.0000     [    0.0000]
+ d_dipole_x/<atom=   3,z> =    -0.0000     [   -0.0000]
  d_dipole_x/<atom=   4,x> =     0.0275     [    0.1322]
  d_dipole_x/<atom=   4,y> =     0.0823     [    0.3954]
- d_dipole_x/<atom=   4,z> =     0.0000     [    0.0000]
+ d_dipole_x/<atom=   4,z> =    -0.0000     [   -0.0000]
  d_dipole_x/<atom=   5,x> =    -0.0413     [   -0.1984]
  d_dipole_x/<atom=   5,y> =    -0.0967     [   -0.4647]
- d_dipole_x/<atom=   5,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=   5,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=   6,x> =    -0.0413     [   -0.1984]
  d_dipole_x/<atom=   6,y> =    -0.0967     [   -0.4647]
- d_dipole_x/<atom=   6,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=   6,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=   7,x> =     0.0609     [    0.2926]
  d_dipole_x/<atom=   7,y> =    -0.0124     [   -0.0597]
- d_dipole_x/<atom=   7,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=   7,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=   8,x> =     0.0609     [    0.2926]
  d_dipole_x/<atom=   8,y> =    -0.0124     [   -0.0597]
  d_dipole_x/<atom=   8,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=   9,x> =     0.0625     [    0.3002]
  d_dipole_x/<atom=   9,y> =     0.0105     [    0.0506]
- d_dipole_x/<atom=   9,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=   9,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  10,x> =     0.0625     [    0.3002]
  d_dipole_x/<atom=  10,y> =     0.0105     [    0.0506]
  d_dipole_x/<atom=  10,z> =     0.0000     [    0.0000]
@@ -498,130 +1255,130 @@ Iterative solution of linear equations
  d_dipole_x/<atom=  12,z> =    -0.0000     [   -0.0000]
  d_dipole_x/<atom=  13,x> =     0.0199     [    0.0955]
  d_dipole_x/<atom=  13,y> =     0.0196     [    0.0940]
- d_dipole_x/<atom=  13,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  13,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  14,x> =     0.0199     [    0.0955]
  d_dipole_x/<atom=  14,y> =     0.0196     [    0.0940]
- d_dipole_x/<atom=  14,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  14,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  15,x> =    -0.0385     [   -0.1851]
  d_dipole_x/<atom=  15,y> =     0.0441     [    0.2116]
- d_dipole_x/<atom=  15,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  15,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  16,x> =    -0.0385     [   -0.1851]
  d_dipole_x/<atom=  16,y> =     0.0441     [    0.2116]
- d_dipole_x/<atom=  16,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  16,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  17,x> =     0.0371     [    0.1782]
  d_dipole_x/<atom=  17,y> =    -0.0203     [   -0.0974]
- d_dipole_x/<atom=  17,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  17,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  18,x> =     0.0371     [    0.1782]
  d_dipole_x/<atom=  18,y> =    -0.0203     [   -0.0974]
- d_dipole_x/<atom=  18,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  18,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  19,x> =     0.0271     [    0.1300]
  d_dipole_x/<atom=  19,y> =    -0.0431     [   -0.2070]
- d_dipole_x/<atom=  19,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  19,z> =     0.0000     [    0.0000]
  d_dipole_x/<atom=  20,x> =     0.0271     [    0.1300]
  d_dipole_x/<atom=  20,y> =    -0.0431     [   -0.2070]
- d_dipole_x/<atom=  20,z> =    -0.0000     [   -0.0000]
+ d_dipole_x/<atom=  20,z> =     0.0000     [    0.0000]
   
  Y vector of derivative dipole (au) [debye/angstrom]
  d_dipole_y/<atom=   1,x> =    -0.0718     [   -0.3449]
  d_dipole_y/<atom=   1,y> =     0.1873     [    0.8998]
- d_dipole_y/<atom=   1,z> =    -0.0000     [   -0.0000]
+ d_dipole_y/<atom=   1,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   2,x> =    -0.0718     [   -0.3449]
  d_dipole_y/<atom=   2,y> =     0.1873     [    0.8998]
- d_dipole_y/<atom=   2,z> =    -0.0000     [   -0.0000]
+ d_dipole_y/<atom=   2,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   3,x> =     0.0751     [    0.3606]
  d_dipole_y/<atom=   3,y> =    -0.1833     [   -0.8803]
- d_dipole_y/<atom=   3,z> =    -0.0000     [   -0.0000]
+ d_dipole_y/<atom=   3,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   4,x> =     0.0751     [    0.3606]
  d_dipole_y/<atom=   4,y> =    -0.1833     [   -0.8803]
- d_dipole_y/<atom=   4,z> =    -0.0000     [   -0.0000]
+ d_dipole_y/<atom=   4,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   5,x> =    -0.1113     [   -0.5348]
  d_dipole_y/<atom=   5,y> =    -0.1166     [   -0.5601]
- d_dipole_y/<atom=   5,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=   5,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=   6,x> =    -0.1113     [   -0.5348]
  d_dipole_y/<atom=   6,y> =    -0.1166     [   -0.5601]
- d_dipole_y/<atom=   6,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=   6,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=   7,x> =    -0.0187     [   -0.0899]
  d_dipole_y/<atom=   7,y> =     0.0366     [    0.1759]
  d_dipole_y/<atom=   7,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   8,x> =    -0.0187     [   -0.0899]
  d_dipole_y/<atom=   8,y> =     0.0366     [    0.1759]
- d_dipole_y/<atom=   8,z> =    -0.0000     [   -0.0000]
+ d_dipole_y/<atom=   8,z> =     0.0000     [    0.0000]
  d_dipole_y/<atom=   9,x> =     0.0101     [    0.0484]
  d_dipole_y/<atom=   9,y> =     0.0357     [    0.1716]
- d_dipole_y/<atom=   9,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=   9,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  10,x> =     0.0101     [    0.0484]
  d_dipole_y/<atom=  10,y> =     0.0357     [    0.1716]
- d_dipole_y/<atom=  10,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  10,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  11,x> =     0.3359     [    1.6134]
  d_dipole_y/<atom=  11,y> =     0.1973     [    0.9477]
  d_dipole_y/<atom=  11,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  12,x> =     0.3359     [    1.6134]
  d_dipole_y/<atom=  12,y> =     0.1973     [    0.9477]
- d_dipole_y/<atom=  12,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  12,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  13,x> =    -0.0650     [   -0.3123]
  d_dipole_y/<atom=  13,y> =    -0.0308     [   -0.1477]
- d_dipole_y/<atom=  13,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  13,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  14,x> =    -0.0650     [   -0.3123]
  d_dipole_y/<atom=  14,y> =    -0.0308     [   -0.1477]
- d_dipole_y/<atom=  14,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  14,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  15,x> =    -0.0545     [   -0.2615]
  d_dipole_y/<atom=  15,y> =    -0.2571     [   -1.2349]
- d_dipole_y/<atom=  15,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  15,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  16,x> =    -0.0545     [   -0.2615]
  d_dipole_y/<atom=  16,y> =    -0.2571     [   -1.2349]
- d_dipole_y/<atom=  16,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  16,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  17,x> =    -0.1556     [   -0.7472]
  d_dipole_y/<atom=  17,y> =     0.0151     [    0.0724]
- d_dipole_y/<atom=  17,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  17,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  18,x> =    -0.1556     [   -0.7472]
  d_dipole_y/<atom=  18,y> =     0.0151     [    0.0724]
- d_dipole_y/<atom=  18,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  18,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  19,x> =     0.0558     [    0.2682]
  d_dipole_y/<atom=  19,y> =     0.1157     [    0.5557]
- d_dipole_y/<atom=  19,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  19,z> =    -0.0000     [   -0.0000]
  d_dipole_y/<atom=  20,x> =     0.0558     [    0.2682]
  d_dipole_y/<atom=  20,y> =     0.1157     [    0.5557]
- d_dipole_y/<atom=  20,z> =     0.0000     [    0.0000]
+ d_dipole_y/<atom=  20,z> =    -0.0000     [   -0.0000]
   
  Z vector of derivative dipole (au) [debye/angstrom]
- d_dipole_z/<atom=   1,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   1,x> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   1,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   1,z> =     0.0274     [    0.1315]
- d_dipole_z/<atom=   2,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   2,x> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   2,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   2,z> =     0.0274     [    0.1315]
  d_dipole_z/<atom=   3,x> =     0.0000     [    0.0000]
- d_dipole_z/<atom=   3,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=   3,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=   3,z> =    -0.0909     [   -0.4365]
- d_dipole_z/<atom=   4,x> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=   4,x> =     0.0000     [    0.0000]
  d_dipole_z/<atom=   4,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=   4,z> =    -0.0909     [   -0.4365]
- d_dipole_z/<atom=   5,x> =     0.0000     [    0.0000]
- d_dipole_z/<atom=   5,y> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   5,x> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=   5,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   5,z> =    -0.0830     [   -0.3988]
  d_dipole_z/<atom=   6,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=   6,y> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   6,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   6,z> =    -0.0830     [   -0.3988]
  d_dipole_z/<atom=   7,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=   7,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=   7,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=   7,z> =     0.0780     [    0.3747]
- d_dipole_z/<atom=   8,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=   8,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=   8,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   8,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=   8,z> =     0.0780     [    0.3747]
- d_dipole_z/<atom=   9,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=   9,y> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   9,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=   9,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=   9,z> =     0.0792     [    0.3802]
  d_dipole_z/<atom=  10,x> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  10,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  10,z> =     0.0792     [    0.3802]
- d_dipole_z/<atom=  11,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=  11,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=  11,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=  11,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  11,z> =    -0.0790     [   -0.3794]
- d_dipole_z/<atom=  12,x> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=  12,x> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  12,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  12,z> =    -0.0790     [   -0.3794]
- d_dipole_z/<atom=  13,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=  13,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=  13,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=  13,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  13,z> =     0.0804     [    0.3860]
  d_dipole_z/<atom=  14,x> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  14,y> =     0.0000     [    0.0000]
@@ -629,34 +1386,34 @@ Iterative solution of linear equations
  d_dipole_z/<atom=  15,x> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  15,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  15,z> =    -0.2049     [   -0.9840]
- d_dipole_z/<atom=  16,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=  16,y> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=  16,x> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=  16,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  16,z> =    -0.2049     [   -0.9840]
  d_dipole_z/<atom=  17,x> =     0.0000     [    0.0000]
- d_dipole_z/<atom=  17,y> =     0.0000     [    0.0000]
+ d_dipole_z/<atom=  17,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  17,z> =     0.0985     [    0.4731]
  d_dipole_z/<atom=  18,x> =     0.0000     [    0.0000]
- d_dipole_z/<atom=  18,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=  18,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  18,z> =     0.0985     [    0.4731]
  d_dipole_z/<atom=  19,x> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  19,y> =    -0.0000     [   -0.0000]
  d_dipole_z/<atom=  19,z> =     0.0944     [    0.4532]
  d_dipole_z/<atom=  20,x> =    -0.0000     [   -0.0000]
- d_dipole_z/<atom=  20,y> =    -0.0000     [   -0.0000]
+ d_dipole_z/<atom=  20,y> =     0.0000     [    0.0000]
  d_dipole_z/<atom=  20,z> =     0.0944     [    0.4532]
   
   
  HESSIAN: the Hessian is done
- 
- 
+
+
   Vibrational analysis via the FX method 
- 
+
   See chapter 2 in "Molecular Vibrations" by Wilson, Decius and Cross
- 
+
   Vib: Default input used 
- 
+
   Nuclear Hessian passed symmetry test 
- 
+
 
 
  ---------------------------- Atom information ----------------------------
@@ -696,234 +1453,234 @@ Iterative solution of linear equations
    ----- ----- ----- ----- -----
     1    6.04374D+01
     2    1.45018D-01  5.88029D+01
-    3   -1.01759D-07  8.67625D-08  1.31742D+01
-    4   -7.00926D+00  1.31541D+00  5.06182D-08  6.04374D+01
-    5    1.31542D+00  8.54330D-01 -6.28673D-08  1.45018D-01  5.88029D+01
-    6    8.89542D-09  1.01108D-07 -7.46925D-01  3.01185D-07 -1.40403D-08  1.31742D+01
-    7   -2.21704D+01  1.15478D+01  5.34921D-08  1.76196D+00 -3.07972D+00  3.39112D-08  6.86237D+01
-    8    4.45975D+00 -1.74172D+01 -1.06132D-07 -9.06161D+00 -1.31707D+00 -9.90267D-08  4.62166D+00  6.31127D+01
-    9   -4.07185D-08  1.84672D-07 -5.54021D+00  2.20927D-07 -7.95314D-08  5.76233D-01 -1.70335D-07  2.40533D-07  1.17734D+01
-   10    1.76196D+00 -3.07972D+00 -9.30751D-09 -2.21704D+01  1.15478D+01 -2.05926D-08 -6.73487D-01  2.26194D+00 -4.89953D-08  6.86237D+01
-   11   -9.06161D+00 -1.31707D+00  2.68781D-08  4.45975D+00 -1.74172D+01  3.08689D-08  2.26195D+00 -6.38059D+00  2.05366D-08  4.62166D+00
-   12    6.34194D-09  1.71933D-07  5.76233D-01  2.72029D-07 -1.01047D-07 -5.54021D+00  4.46303D-08  2.15980D-07 -5.95434D-01 -9.72610D-08
-   13    5.11191D+00  8.53445D-01  4.74728D-08 -2.64808D+01 -8.05824D+00  6.33954D-08 -1.28548D+01  1.13600D+00  9.23092D-08 -4.97375D+00
-   14    6.70446D+00 -4.60701D+00  1.56169D-07 -1.29238D+00 -1.28898D+01  2.17131D-08 -7.41516D+00 -3.14755D+01 -2.95456D-08 -4.89514D-01
-   15    1.04744D-08 -1.76274D-07  5.86589D-01 -3.27066D-07  6.74654D-08 -5.64465D+00 -4.57122D-08 -2.57226D-07 -5.20434D+00  1.37723D-07
-   16   -2.64808D+01 -8.05824D+00 -2.86665D-08  5.11191D+00  8.53444D-01 -1.63900D-08 -4.97375D+00  4.43989D+00  3.13243D-08 -1.28548D+01
-   17   -1.29238D+00 -1.28898D+01  8.67731D-08  6.70446D+00 -4.60701D+00 -4.65405D-08 -4.89514D-01  6.23001D+00 -1.01118D-07 -7.41516D+00
-   18    6.50486D-08 -1.64151D-07 -5.64465D+00 -2.76160D-07  7.94932D-08  5.86589D-01 -1.50272D-08 -2.39083D-07  5.39339D-01  1.63476D-07
-   19   -4.19870D+00 -3.86491D+00 -2.75171D-07  3.51247D-01  1.09607D-02  5.32204D-08 -1.05255D+02 -3.16207D+01  2.83560D-07  3.00426D-01
-   20    6.73079D+00  2.87479D+00 -1.06482D-07  4.26936D-01 -1.50726D+00 -1.47491D-08 -3.16260D+01 -3.05529D+01  7.42656D-08  1.72458D-01
-   21    7.78676D-09  1.41771D-07  6.90143D-01 -4.48206D-08 -5.79436D-08  2.53483D+00 -1.22126D-08 -1.79682D-08 -1.14697D+01  1.88305D-08
-   22    3.51247D-01  1.09605D-02 -1.94653D-07 -4.19869D+00 -3.86491D+00  1.44070D-07  3.00426D-01  2.26315D-01  3.28257D-07 -1.05255D+02
-   23    4.26936D-01 -1.50726D+00 -2.02920D-08  6.73079D+00  2.87479D+00  5.81736D-08  1.72458D-01 -1.44168D-01  9.29675D-08 -3.16260D+01
-   24    5.26687D-08  1.03635D-07  2.53483D+00 -2.40633D-09 -1.03700D-07  6.90143D-01  1.29049D-08  1.29598D-08 -2.58701D-01  3.29730D-08
-   25    4.30850D-02 -5.24135D-01  6.18793D-08 -4.33608D+00  6.47247D+00 -1.12505D-07  2.61180D+00 -3.25970D+00 -1.80234D-07 -1.07006D+00
-   26   -9.70327D-01 -1.15601D+00  1.28795D-08 -4.02162D+00  3.68357D+00  1.10907D-07  8.13453D+00 -3.85907D+00  1.00162D-07 -7.35417D-01
-   27   -2.87176D-08  2.50723D-09  2.54252D+00 -1.54920D-07 -6.67134D-08  8.13590D-01 -2.18800D-08 -1.70279D-07  1.04353D+00  1.22434D-07
-   28   -4.33608D+00  6.47247D+00  2.56430D-07  4.30847D-02 -5.24134D-01  7.25002D-08 -1.07006D+00 -1.17384D+00 -6.93950D-09  2.61180D+00
-   29   -4.02162D+00  3.68357D+00 -1.68942D-07 -9.70327D-01 -1.15601D+00 -7.13052D-08 -7.35417D-01 -4.41294D-01 -4.36665D-08  8.13453D+00
-   30    4.49280D-08  1.95756D-08  8.13590D-01 -7.60490D-08 -1.59421D-08  2.54252D+00 -6.73633D-08 -1.35326D-07  2.22042D+00  9.87459D-08
-   31   -1.82942D-02  1.29662D-01 -3.95311D-08 -1.02961D+01 -4.67909D+00  9.48231D-09 -5.34833D-01 -7.17946D-02  4.39636D-08  5.38827D-01
-   32   -2.84550D-02 -5.03069D-01 -5.87693D-09 -2.21548D+00 -1.97807D+01 -2.62726D-08 -1.40754D-01  8.43436D-01 -4.53976D-08  5.46599D-01
-   33    1.24288D-08 -9.68048D-08 -8.16109D-02  7.47465D-09  5.94988D-08 -5.28412D+00 -9.85701D-09 -3.34609D-10  5.74079D-01  1.51083D-08
-   34   -1.02961D+01 -4.67909D+00 -3.92145D-08 -1.82941D-02  1.29662D-01  1.10329D-08  5.38827D-01  2.66579D+00  3.51923D-08 -5.34833D-01
-   35   -2.21548D+00 -1.97807D+01  3.85676D-08 -2.84551D-02 -5.03069D-01  2.90272D-08  5.46599D-01 -3.70772D+00  6.92139D-09 -1.40754D-01
-   36   -1.93723D-08 -8.80856D-08 -5.28412D+00 -3.06725D-08  6.42729D-08 -8.16109D-02 -2.28833D-08 -2.86516D-08  3.30910D-01  7.54410D-09
-   37    5.14075D-02  1.70449D-02 -7.22088D-08 -6.98814D-01  1.07917D+00 -1.43276D-07 -4.55008D-02  4.80537D-02 -1.96351D-07  4.29264D-01
-   38    2.18956D-02  4.68804D-02  1.64502D-08 -9.13432D+00 -1.91337D+00 -8.43202D-09 -4.89753D-01  7.72668D-02 -1.34479D-08 -6.41436D-01
-   39    1.05276D-08  4.01166D-08  2.88619D-02 -7.26513D-08 -4.36002D-08  6.69725D-01  1.46455D-09 -8.11642D-08  7.31272D-04  6.10904D-09
-   40   -6.98813D-01  1.07917D+00  9.09692D-08  5.14073D-02  1.70449D-02  2.24438D-09  4.29264D-01  7.01796D-01 -7.98635D-08 -4.55009D-02
-   41   -9.13432D+00 -1.91337D+00  5.63139D-09  2.18957D-02  4.68804D-02  1.20055D-08 -6.41436D-01  5.13506D-01  1.29649D-08 -4.89753D-01
-   42    1.56631D-08  3.01215D-08  6.69725D-01 -9.39947D-08 -2.96258D-08  2.88619D-02  2.94468D-08 -2.29879D-08 -2.50496D-01  5.04937D-08
-   43    6.92600D-03 -1.62185D-01  4.73248D-08  1.44632D+00  1.09117D+00  3.85663D-08 -5.20733D-02  2.47140D-01  3.12375D-08  8.62224D-02
-   44    7.75849D-02  1.51945D-01  9.78098D-10  1.79285D+00 -4.01853D+00 -3.07052D-08  1.20646D-01 -1.41699D-01 -5.05972D-08 -5.87590D-01
-   45   -4.14527D-08 -3.75705D-08 -3.41804D-03 -4.16179D-08  2.50914D-08  4.57965D-01  9.70149D-09 -1.71781D-08 -3.83696D-02 -1.72911D-08
-   46    1.44632D+00  1.09117D+00  2.01771D-08  6.92602D-03 -1.62185D-01  1.31051D-08  8.62224D-02 -5.93068D-01 -6.61057D-09 -5.20733D-02
-   47    1.79286D+00 -4.01853D+00  4.98932D-08  7.75848D-02  1.51945D-01  1.27358D-08 -5.87590D-01  2.41124D-01 -1.21182D-08  1.20646D-01
-   48    2.33900D-08 -3.24978D-08  4.57965D-01  1.59038D-08  2.43463D-08 -3.41803D-03  1.74179D-08  2.76830D-08  1.20066D-01 -1.04050D-08
-   49   -2.26099D-02 -3.50816D-02  4.63749D-09  1.37013D-01 -3.99513D-01 -1.91128D-08  1.12157D-01 -9.90600D-03 -7.81591D-08 -3.08847D-02
-   50   -7.35211D-04 -1.25541D-02  3.53251D-10 -4.34934D-01  4.60545D-01  2.81650D-08 -7.14579D-02  5.02110D-02 -4.30681D-09 -1.70384D-02
-   51    3.14690D-08 -9.32440D-08 -2.28228D-02 -2.16744D-07  4.64271D-08 -2.36391D+00  6.37635D-10 -1.69383D-07  3.99608D-02  1.33882D-07
-   52    1.37013D-01 -3.99513D-01 -4.92252D-08 -2.26102D-02 -3.50818D-02 -5.89859D-08 -3.08847D-02 -4.38055D-02 -5.73629D-08  1.12156D-01
-   53   -4.34934D-01  4.60545D-01 -8.93073D-08 -7.35287D-04 -1.25542D-02 -7.77705D-08 -1.70384D-02  4.43980D-03 -1.02105D-07 -7.14579D-02
-   54    4.10021D-08 -9.29076D-08 -2.36391D+00 -1.78760D-07  5.09361D-08 -2.28227D-02 -4.61002D-08 -1.20662D-07  9.55484D-03  6.40508D-08
-   55    1.66513D-02 -1.82573D-02 -5.46922D-08 -9.69337D-01  3.56634D-01 -4.98776D-08  6.08733D-02 -3.16242D-03  2.60747D-08  2.28766D-01
-   56    4.54457D-02  3.47244D-02 -3.51460D-08  7.91732D-01 -9.96587D-03  2.79123D-08 -6.59743D-02  3.98604D-03  8.86278D-08 -1.42726D-01
-   57    3.93015D-08 -3.67679D-08  4.37356D-02 -1.70823D-07 -2.69229D-08  3.71014D+00 -2.38640D-08 -1.20949D-07 -9.35090D-02  6.73460D-08
-   58   -9.69337D-01  3.56634D-01  3.10303D-08  1.66514D-02 -1.82573D-02  5.02906D-08  2.28766D-01  2.65086D-01  7.79949D-08  6.08733D-02
-   59    7.91732D-01 -9.96589D-03  2.51980D-09  4.54460D-02  3.47244D-02  5.07724D-08 -1.42726D-01 -1.13195D-01  1.05303D-07 -6.59743D-02
-   60    1.45355D-08 -1.93043D-08  3.71014D+00 -2.10423D-07  1.60273D-08  4.37356D-02  7.72846D-10 -1.50739D-07  7.76722D-03  8.71704D-08
+    3    1.08330D-07  1.33518D-07  1.31742D+01
+    4   -7.00926D+00  1.31541D+00 -1.10734D-07  6.04374D+01
+    5    1.31542D+00  8.54329D-01  5.73353D-08  1.45018D-01  5.88029D+01
+    6    1.25800D-07  1.30137D-07 -7.46925D-01  4.22474D-07 -1.57816D-07  1.31742D+01
+    7   -2.21704D+01  1.15478D+01 -1.53901D-08  1.76196D+00 -3.07972D+00  3.08049D-09  6.86237D+01
+    8    4.45975D+00 -1.74172D+01  7.31879D-08 -9.06161D+00 -1.31707D+00  6.38618D-08  4.62166D+00  6.31127D+01
+    9    6.92363D-08  1.81867D-07 -5.54021D+00  3.41412D-07 -1.22872D-07  5.76233D-01 -1.52926D-07 -4.74014D-08  1.17734D+01
+   10    1.76196D+00 -3.07972D+00 -1.64396D-08 -2.21704D+01  1.15478D+01 -3.54311D-09 -6.73487D-01  2.26194D+00 -1.02472D-08  6.86237D+01
+   11   -9.06161D+00 -1.31707D+00  5.68227D-08  4.45975D+00 -1.74172D+01  4.71635D-08  2.26195D+00 -6.38059D+00  2.90518D-08  4.62166D+00
+   12    1.08522D-07  1.62659D-07  5.76233D-01  3.60751D-07 -1.20480D-07 -5.54021D+00 -1.53911D-07 -1.89823D-08 -5.95434D-01 -3.23252D-07
+   13    5.11191D+00  8.53444D-01  7.39052D-09 -2.64808D+01 -8.05824D+00 -2.65633D-08 -1.28548D+01  1.13600D+00  5.59270D-09 -4.97375D+00
+   14    6.70446D+00 -4.60701D+00 -9.03284D-08 -1.29238D+00 -1.28898D+01  2.85000D-08 -7.41516D+00 -3.14755D+01 -1.15647D-07 -4.89514D-01
+   15   -1.75543D-07 -1.78453D-07  5.86589D-01 -4.97434D-07  1.75850D-07 -5.64465D+00  1.68930D-07 -2.68303D-08 -5.20434D+00  3.42265D-07
+   16   -2.64808D+01 -8.05824D+00 -5.54289D-09  5.11191D+00  8.53444D-01 -2.79605D-08 -4.97375D+00  4.43989D+00  1.54250D-09 -1.28548D+01
+   17   -1.29238D+00 -1.28898D+01 -1.19911D-07  6.70446D+00 -4.60701D+00 -4.02095D-09 -4.89514D-01  6.23001D+00 -1.46565D-07 -7.41516D+00
+   18   -1.41099D-07 -1.89172D-07 -5.64465D+00 -4.53036D-07  1.64168D-07  5.86589D-01  1.97081D-07 -1.10276D-09  5.39339D-01  3.59031D-07
+   19   -4.19869D+00 -3.86491D+00  1.90800D-07  3.51247D-01  1.09603D-02 -1.52620D-07 -1.05255D+02 -3.16207D+01  3.08740D-07  3.00427D-01
+   20    6.73079D+00  2.87479D+00  7.29937D-08  4.26936D-01 -1.50726D+00 -3.57750D-08 -3.16260D+01 -3.05529D+01  1.09362D-07  1.72458D-01
+   21    2.72189D-09  6.84747D-08  6.90143D-01 -5.77540D-08  3.99895D-08  2.53483D+00 -5.11310D-08 -1.43485D-08 -1.14697D+01  1.04478D-09
+   22    3.51248D-01  1.09601D-02  2.90499D-07 -4.19870D+00 -3.86491D+00 -6.30649D-08  3.00425D-01  2.26314D-01  3.98309D-07 -1.05255D+02
+   23    4.26936D-01 -1.50726D+00  8.44771D-08  6.73079D+00  2.87479D+00  4.69835D-09  1.72458D-01 -1.44168D-01  1.38088D-07 -3.16260D+01
+   24   -1.41109D-08  4.49926D-08  2.53483D+00 -6.79688D-08  5.78638D-09  6.90143D-01  7.63901D-10 -4.14997D-08 -2.58701D-01  1.02199D-08
+   25    4.30843D-02 -5.24135D-01  2.99329D-08 -4.33608D+00  6.47247D+00  8.86407D-08  2.61180D+00 -3.25970D+00 -2.25435D-08 -1.07006D+00
+   26   -9.70327D-01 -1.15601D+00 -7.04945D-08 -4.02162D+00  3.68357D+00 -6.84635D-08  8.13453D+00 -3.85907D+00 -5.76487D-08 -7.35417D-01
+   27   -1.31480D-07 -4.02574D-08  2.54252D+00 -2.87148D-07  9.88442D-08  8.13590D-01  6.43284D-08 -1.93342D-09  1.04353D+00  1.78531D-07
+   28   -4.33608D+00  6.47247D+00 -1.73092D-08  4.30849D-02 -5.24134D-01  3.18320D-08 -1.07006D+00 -1.17384D+00 -9.25822D-08  2.61180D+00
+   29   -4.02162D+00  3.68357D+00 -2.32917D-08 -9.70327D-01 -1.15601D+00 -1.65548D-08 -7.35417D-01 -4.41295D-01 -1.04472D-08  8.13453D+00
+   30   -1.31796D-07 -6.15371D-08  8.13590D-01 -2.64282D-07  1.31158D-07  2.54252D+00  9.66614D-08 -3.33505D-09  2.22042D+00  1.82065D-07
+   31   -1.82941D-02  1.29662D-01  3.64385D-08 -1.02961D+01 -4.67909D+00 -9.55951D-09 -5.34833D-01 -7.17947D-02  5.13534D-08  5.38827D-01
+   32   -2.84552D-02 -5.03069D-01 -3.45391D-09 -2.21548D+00 -1.97807D+01  7.76996D-09 -1.40754D-01  8.43436D-01 -1.40735D-09  5.46599D-01
+   33   -2.96170D-08 -4.44254D-08 -8.16109D-02 -4.23222D-08  1.81399D-08 -5.28412D+00  2.06257D-08  2.70946D-08  5.74079D-01  4.70104D-08
+   34   -1.02961D+01 -4.67909D+00  2.79904D-08 -1.82942D-02  1.29662D-01 -2.18349D-08  5.38827D-01  2.66579D+00  5.03142D-08 -5.34833D-01
+   35   -2.21548D+00 -1.97807D+01  1.25295D-08 -2.84550D-02 -5.03069D-01  1.70303D-08  5.46600D-01 -3.70772D+00  1.41794D-08 -1.40754D-01
+   36   -2.69179D-08 -4.27222D-08 -5.28412D+00 -3.86181D-08  1.08695D-08 -8.16109D-02  1.36859D-08  1.51067D-08  3.30910D-01  3.63891D-08
+   37    5.14072D-02  1.70449D-02 -3.28137D-08 -6.98814D-01  1.07917D+00  2.11741D-08 -4.55006D-02  4.80539D-02 -7.01143D-08  4.29264D-01
+   38    2.18956D-02  4.68803D-02  5.04951D-08 -9.13432D+00 -1.91337D+00 -2.27874D-09 -4.89753D-01  7.72668D-02  4.41591D-08 -6.41436D-01
+   39    4.43398D-08 -3.75866D-08  2.88619D-02 -6.49025D-08  3.32673D-08  6.69725D-01  2.59598D-08  4.19492D-09  7.31280D-04  5.91176D-08
+   40   -6.98814D-01  1.07917D+00  1.54617D-08  5.14075D-02  1.70448D-02  7.88905D-08  4.29264D-01  7.01797D-01 -1.92343D-08 -4.55009D-02
+   41   -9.13432D+00 -1.91337D+00  4.71605D-08  2.18957D-02  4.68804D-02  1.32328D-08 -6.41436D-01  5.13506D-01  4.92879D-08 -4.89753D-01
+   42    7.28662D-09  2.70242D-09  6.69725D-01 -6.85404D-08 -5.49349D-09  2.88619D-02  4.32698D-08  2.93862D-08 -2.50496D-01  4.63570D-08
+   43    6.92590D-03 -1.62185D-01  5.51342D-09  1.44632D+00  1.09117D+00  7.23657D-09 -5.20733D-02  2.47140D-01  1.12228D-08  8.62224D-02
+   44    7.75848D-02  1.51945D-01 -1.89133D-08  1.79285D+00 -4.01853D+00  1.60808D-08  1.20646D-01 -1.41699D-01 -4.09958D-08 -5.87590D-01
+   45    1.74265D-08 -1.97826D-08 -3.41806D-03  1.17911D-08  9.66351D-10  4.57965D-01  2.42718D-08  1.05131D-08 -3.83696D-02  3.32146D-09
+   46    1.44632D+00  1.09117D+00  8.74039D-10  6.92601D-03 -1.62185D-01  4.18530D-09  8.62225D-02 -5.93068D-01  3.78654D-09 -5.20733D-02
+   47    1.79285D+00 -4.01853D+00 -3.11091D-08  7.75849D-02  1.51945D-01  1.01012D-08 -5.87590D-01  2.41124D-01 -3.90888D-08  1.20646D-01
+   48    2.90183D-08 -2.29527D-08  4.57965D-01  2.71222D-08  3.10658D-09 -3.41804D-03  1.44628D-08  1.08348D-08  1.20066D-01  1.22053D-08
+   49   -2.26100D-02 -3.50813D-02 -2.56335D-08  1.37013D-01 -3.99513D-01  4.36581D-08  1.12157D-01 -9.90602D-03 -7.67004D-08 -3.08847D-02
+   50   -7.35166D-04 -1.25539D-02 -4.70149D-08 -4.34934D-01  4.60545D-01 -4.22404D-09 -7.14579D-02  5.02110D-02 -4.21264D-08 -1.70384D-02
+   51   -7.83506D-08 -9.41994D-08 -2.28228D-02 -2.79648D-07  1.01622D-07 -2.36391D+00  1.03303D-07  3.65252D-09  3.99609D-02  2.27090D-07
+   52    1.37013D-01 -3.99513D-01 -4.25984D-08 -2.26100D-02 -3.50817D-02  1.59855D-08 -3.08846D-02 -4.38055D-02 -6.82302D-08  1.12156D-01
+   53   -4.34934D-01  4.60545D-01  1.83782D-08 -7.35287D-04 -1.25541D-02  2.77919D-08 -1.70384D-02  4.43973D-03 -2.19236D-08 -7.14580D-02
+   54   -4.31284D-08 -8.12998D-08 -2.36391D+00 -2.86642D-07  9.51872D-08 -2.28228D-02  9.38405D-08 -1.01739D-08  9.55488D-03  2.41729D-07
+   55    1.66516D-02 -1.82575D-02  1.84950D-08 -9.69337D-01  3.56634D-01 -3.24093D-08  6.08731D-02 -3.16256D-03  7.62443D-08  2.28766D-01
+   56    4.54460D-02  3.47242D-02  4.01179D-08  7.91732D-01 -9.96591D-03 -2.49682D-08 -6.59744D-02  3.98591D-03  1.06690D-07 -1.42726D-01
+   57    1.28611D-08 -9.13147D-08  4.37355D-02 -2.34128D-07  8.56769D-08  3.71014D+00  9.38803D-08  2.16960D-08 -9.35089D-02  1.80205D-07
+   58   -9.69337D-01  3.56634D-01  3.53696D-08  1.66513D-02 -1.82573D-02 -4.72569D-08  2.28766D-01  2.65086D-01  3.08481D-08  6.08734D-02
+   59    7.91732D-01 -9.96616D-03  6.42759D-08  4.54458D-02  3.47244D-02 -5.90102D-09 -1.42726D-01 -1.13195D-01  7.71018D-08 -6.59741D-02
+   60   -7.11413D-08 -7.26101D-08  3.71014D+00 -2.30128D-07  7.79530D-08  4.37356D-02  1.24730D-07  1.97234D-08  7.76722D-03  1.82614D-07
 
 
               11           12           13           14           15           16           17           18           19           20
    ----- ----- ----- ----- -----
    11    6.31127D+01
-   12   -2.93730D-07  1.17734D+01
-   13    4.43989D+00  1.11184D-08  6.51305D+01
-   14    6.23001D+00  1.14184D-07 -5.68229D+00  6.65665D+01
-   15    3.74441D-07  5.39339D-01  9.07568D-08 -8.17438D-08  1.17907D+01
-   16    1.13600D+00 -4.98891D-08 -2.66818D+00 -3.53321D+00  3.62315D-08  6.51305D+01
-   17   -3.14755D+01  4.07755D-08 -3.53321D+00 -4.23563D+00 -1.08579D-07 -5.68229D+00  6.65665D+01
-   18    4.00115D-07 -5.20434D+00  7.67078D-08 -1.11680D-07 -5.38108D-01  2.20586D-08  3.64421D-08  1.17907D+01
-   19    2.26315D-01 -2.06984D-07  4.79810D-01  1.79591D+00  4.43238D-07 -4.42551D-01  1.15903D+00 -2.29341D-07  3.73232D+02
-   20   -1.44168D-01 -7.00565D-08 -9.54768D+00 -1.69281D+00  1.48188D-07  7.09920D-01 -1.04303D+00 -5.25375D-08  1.13654D+02  1.06909D+02
-   21   -5.95287D-08 -2.58701D-01 -2.79959D-08  2.64490D-08  9.71427D-01  1.33574D-07 -4.14590D-08  2.12732D+00 -9.25463D-08  2.34265D-08
-   22   -3.16207D+01 -1.48793D-07 -4.42551D-01  1.15903D+00  3.78125D-07  4.79810D-01  1.79591D+00 -2.92690D-07 -1.93097D-01 -1.70854D-01
-   23   -3.05529D+01 -2.69032D-08  7.09920D-01 -1.04303D+00  9.76910D-08 -9.54768D+00 -1.69281D+00 -1.08574D-07 -1.70869D-01  1.17985D-01
-   24   -7.05960D-09 -1.14697D+01 -1.17606D-07  3.85482D-08  2.12732D+00  3.70883D-08 -2.18497D-08  9.71427D-01 -1.81008D-08  2.33839D-08
-   25   -1.17384D+00  4.02614D-08 -7.85167D+01  4.84365D+01  1.27192D-07  1.28176D-01 -3.00486D-01 -1.86401D-08  1.16134D+00  1.83771D-02
-   26   -4.41294D-01  9.45193D-09  4.81975D+01 -5.80304D+01 -1.82774D-07 -2.74557D-01  2.09582D-02  2.79036D-08  1.91132D-01  1.85778D+00
-   27    1.53830D-07  2.22042D+00  5.95075D-08 -2.36677D-08 -1.15728D+01  1.01589D-07  2.71729D-08 -2.66919D-01  3.73873D-09  3.68470D-07
-   28   -3.25970D+00  2.15570D-07  1.28176D-01 -3.00486D-01 -1.55192D-07 -7.85167D+01  4.84365D+01 -2.88995D-07 -7.95625D-01  1.12036D+00
-   29   -3.85907D+00 -1.43604D-07 -2.74556D-01  2.09583D-02  5.85755D-08  4.81975D+01 -5.80304D+01  2.60296D-07 -6.75053D-01  6.07637D-01
-   30    1.63370D-07  1.04353D+00 -3.07315D-08 -4.68360D-08 -2.66919D-01  2.16457D-08  7.53360D-09 -1.15728D+01 -5.72041D-09  3.33577D-07
-   31    2.66579D+00 -1.79156D-08  1.03842D-01 -2.78258D+00  7.74997D-08 -4.12337D-01  7.78948D-02 -4.86951D-08  2.39047D-02 -4.43949D-01
-   32   -3.70772D+00 -2.04932D-09 -1.77400D+00 -2.09789D+00  7.69970D-08  5.21244D-01  5.70082D-01 -2.44882D-08  2.32763D-02  5.96867D-02
-   33    6.10522D-08  3.30910D-01  1.59910D-08 -4.30202D-08  2.32834D-01 -2.88115D-08  8.81916D-09  6.16710D-01 -5.89445D-08  7.37337D-08
-   34   -7.17946D-02 -2.51833D-08 -4.12337D-01  7.78947D-02  7.77558D-08  1.03842D-01 -2.78258D+00 -5.23593D-08  4.46703D-01  5.83253D-01
-   35    8.43436D-01  5.08222D-08  5.21244D-01  5.70082D-01 -1.89593D-09 -1.77400D+00 -2.09789D+00 -9.67614D-08 -5.97896D-01  4.38697D-01
-   36    3.00620D-08  5.74079D-01  3.97088D-08 -2.24213D-08  6.16710D-01 -6.21797D-09  2.93753D-08  2.32834D-01 -1.66352D-08  8.54899D-08
-   37    7.01796D-01 -4.76123D-08  1.99702D-01  3.07317D-02  5.79880D-08 -3.34747D-02 -9.84295D-03  1.96812D-07  3.10703D-02 -4.64571D-02
-   38    5.13506D-01  3.17421D-09  5.21255D-01 -1.53135D+00  3.20849D-08  3.59649D-02  4.70678D-02 -3.12910D-08  1.57294D-02 -4.65384D-01
-   39    3.06600D-08 -2.50496D-01  6.20263D-09  4.85413D-08  7.02054D-01  5.88180D-08 -1.61812D-08 -7.77808D-03 -6.10932D-08  1.72836D-07
-   40    4.80536D-02  9.06954D-08 -3.34747D-02 -9.84283D-03 -1.19944D-07  1.99702D-01  3.07317D-02  2.50846D-08  8.12630D-02 -4.05676D-01
-   41    7.72667D-02  1.90706D-08  3.59648D-02  4.70678D-02  9.80758D-09  5.21255D-01 -1.53135D+00 -3.85673D-08  5.11826D-01 -1.00673D-01
-   42    4.71147D-08  7.31292D-04 -4.79943D-08  2.81878D-08 -7.77812D-03  7.87495D-10 -4.17641D-09  7.02054D-01 -2.35339D-08  4.62430D-08
-   43   -5.93068D-01  4.59260D-08 -4.21082D-01 -4.28857D-01 -3.54208D-08  1.64607D-01  1.24311D-01 -1.09270D-07 -1.52904D-03 -6.48752D-03
-   44    2.41124D-01 -7.10664D-09  5.28284D-01  3.25691D-01 -2.73533D-08 -7.32970D-02 -2.66607D-01  5.29532D-08 -3.92299D-03  1.61703D-02
-   45    2.89364D-09  1.20066D-01  3.69893D-08  1.60122D-08  3.65405D-02 -1.11545D-09  2.08147D-08 -8.79607D-03  5.41444D-08  3.40288D-08
-   46    2.47140D-01  1.33157D-08  1.64607D-01  1.24311D-01  3.63728D-08 -4.21082D-01 -4.28857D-01 -3.70681D-08  4.82115D-02 -8.51074D-02
-   47   -1.41699D-01  3.38110D-08 -7.32970D-02 -2.66607D-01 -6.64542D-08  5.28284D-01  3.25691D-01  1.90705D-08 -2.89843D-02 -1.83912D-02
-   48    4.91082D-08 -3.83696D-02 -6.58388D-09 -2.53718D-08 -8.79607D-03 -4.10328D-08 -2.65951D-08  3.65405D-02 -1.14491D-08 -1.84673D-09
-   49   -4.38055D-02 -3.32065D-08  1.43468D-01 -3.08773D-01 -1.43671D-07 -5.06452D-02  9.10414D-03  2.42916D-07  1.25777D-03 -2.61998D-02
-   50    4.43984D-03  1.55274D-08  3.79493D-01 -3.83740D-01 -8.70283D-08 -3.78815D-02  1.47714D-02  1.09123D-07 -2.35623D-02 -3.46627D-02
-   51    1.81092D-07  9.55482D-03  4.04002D-08 -3.04150D-08  5.10346D-02  3.66412D-08  2.81538D-08  7.58405D-02 -1.05167D-07  4.52188D-07
-   52   -9.90599D-03 -2.67921D-08 -5.06450D-02  9.10449D-03 -1.47982D-07  1.43468D-01 -3.08774D-01  2.33554D-07 -3.80003D-02 -2.67262D-02
-   53    5.02111D-02 -8.13015D-08 -3.78814D-02  1.47716D-02 -5.09728D-09  3.79493D-01 -3.83740D-01  1.97756D-07 -7.70161D-02  8.47712D-02
-   54    2.27444D-07  3.99608D-02  5.19654D-08 -5.67988D-08  7.58404D-02  5.65232D-08  1.24671D-08  5.10346D-02 -4.50865D-09  4.34647D-07
-   55    2.65086D-01 -2.38810D-08 -1.59510D-01 -4.43683D-02  1.66800D-07 -7.61221D-02  1.55593D-02 -9.74999D-09  6.91108D-03  4.80273D-02
-   56   -1.13195D-01 -1.49241D-08  6.34016D-02  1.36200D-01  1.48115D-07  1.21547D-01 -5.70976D-02 -1.45823D-07  1.13997D-02 -1.55428D-02
-   57    1.94206D-07  7.76719D-03  4.14708D-08 -4.20064D-08 -1.26273D-01  2.50523D-08  2.46739D-08 -2.58694D-01 -2.84619D-09  3.82189D-07
-   58   -3.16240D-03  1.56768D-08 -7.61222D-02  1.55590D-02  2.28429D-08 -1.59510D-01 -4.43681D-02 -1.62118D-07  3.66430D-02  5.06389D-04
-   59    3.98608D-03  5.63548D-10  1.21547D-01 -5.70979D-02  8.74283D-08  6.34017D-02  1.36200D-01 -2.03042D-07  8.97905D-02 -2.26049D-02
-   60    1.58878D-07 -9.35089D-02  5.64422D-08 -4.32257D-08 -2.58694D-01  3.84928D-08  4.75992D-08 -1.26273D-01  1.81554D-09  3.68262D-07
+   12    9.12846D-10  1.17734D+01
+   13    4.43989D+00 -5.49743D-08  6.51305D+01
+   14    6.23001D+00 -4.08527D-08 -5.68229D+00  6.65665D+01
+   15    2.29229D-08  5.39339D-01  1.48921D-07  2.74987D-07  1.17907D+01
+   16    1.13600D+00 -5.90274D-08 -2.66818D+00 -3.53321D+00  7.48042D-08  6.51305D+01
+   17   -3.14755D+01 -6.61976D-08 -3.53321D+00 -4.23563D+00  6.27643D-08 -5.68229D+00  6.65665D+01
+   18    5.65399D-08 -5.20434D+00  1.14453D-07  2.58062D-07 -5.38108D-01 -2.80491D-08  7.52783D-08  1.17907D+01
+   19    2.26314D-01  2.28368D-08  4.79810D-01  1.79591D+00  4.64407D-08 -4.42551D-01  1.15903D+00 -1.38078D-07  3.73232D+02
+   20   -1.44168D-01  3.40121D-08 -9.54768D+00 -1.69281D+00 -2.38655D-08  7.09920D-01 -1.04303D+00 -8.31459D-08  1.13654D+02  1.06909D+02
+   21   -9.38138D-08 -2.58701D-01  2.16614D-08  1.10284D-09  9.71427D-01  5.66338D-08 -6.30771D-09  2.12732D+00  1.61121D-07  7.36826D-08
+   22   -3.16207D+01  8.00050D-08 -4.42550D-01  1.15903D+00 -8.55208D-08  4.79809D-01  1.79591D+00 -2.32617D-07 -1.93098D-01 -1.70854D-01
+   23   -3.05529D+01  4.85019D-08  7.09920D-01 -1.04303D+00 -4.63993D-08 -9.54768D+00 -1.69281D+00 -9.42768D-08 -1.70869D-01  1.17985D-01
+   24   -8.11677D-08 -1.14697D+01  4.30643D-09  4.91213D-08  2.12732D+00  6.49325D-08  8.00309D-10  9.71427D-01  9.71898D-08  9.43778D-08
+   25   -1.17384D+00  6.84677D-08 -7.85167D+01  4.84365D+01 -1.18701D-07  1.28176D-01 -3.00486D-01 -1.26080D-07  1.16134D+00  1.83772D-02
+   26   -4.41295D-01 -6.57526D-08  4.81975D+01 -5.80304D+01  1.00886D-07 -2.74557D-01  2.09580D-02  1.47360D-07  1.91132D-01  1.85778D+00
+   27   -8.80082D-09  2.22042D+00  6.09676D-08  1.34503D-07 -1.15728D+01  2.54435D-08  2.00780D-08 -2.66919D-01  1.07552D-07  4.39710D-08
+   28   -3.25970D+00 -1.21176D-09  1.28177D-01 -3.00486D-01 -2.35271D-08 -7.85167D+01  4.84365D+01 -4.52431D-08 -7.95625D-01  1.12036D+00
+   29   -3.85907D+00 -2.28789D-08 -2.74557D-01  2.09582D-02  3.67940D-08  4.81975D+01 -5.80304D+01  8.22975D-08 -6.75052D-01  6.07637D-01
+   30    2.26806D-08  1.04353D+00  5.14998D-08  1.07424D-07 -2.66919D-01 -1.80035D-08  1.66008D-08 -1.15728D+01  6.85243D-08  1.09711D-08
+   31    2.66579D+00  1.77784D-08  1.03842D-01 -2.78258D+00 -1.96724D-08 -4.12337D-01  7.78949D-02 -3.85039D-08  2.39046D-02 -4.43949D-01
+   32   -3.70772D+00  2.40141D-08 -1.77400D+00 -2.09789D+00 -4.63850D-08  5.21244D-01  5.70082D-01 -4.97482D-08  2.32761D-02  5.96867D-02
+   33    4.11338D-08  3.30910D-01  1.30511D-08  7.57467D-09  2.32834D-01 -2.48302D-08  5.34581D-09  6.16710D-01 -2.41574D-08 -1.16560D-08
+   34   -7.17947D-02  6.96101D-09 -4.12336D-01  7.78948D-02  2.81337D-10  1.03842D-01 -2.78258D+00 -2.98961D-08  4.46703D-01  5.83253D-01
+   35    8.43436D-01  3.74507D-08  5.21244D-01  5.70082D-01 -6.98580D-08 -1.77400D+00 -2.09789D+00 -6.46945D-08 -5.97896D-01  4.38697D-01
+   36    4.68414D-08  5.74079D-01  4.56888D-09  1.48219D-08  6.16710D-01 -1.84069D-08  2.04101D-09  2.32834D-01 -3.17418D-08 -3.79720D-08
+   37    7.01797D-01  1.40335D-08  1.99702D-01  3.07314D-02 -7.10800D-09 -3.34747D-02 -9.84312D-03  8.17377D-09  3.10705D-02 -4.64571D-02
+   38    5.13506D-01  3.89920D-08  5.21255D-01 -1.53135D+00 -3.94928D-08  3.59649D-02  4.70679D-02 -5.52834D-08  1.57293D-02 -4.65384D-01
+   39   -1.46132D-08 -2.50496D-01  2.39695D-09  1.53612D-08  7.02054D-01 -2.98363D-08  1.91242D-08 -7.77807D-03 -5.18311D-08  9.56062D-08
+   40    4.80541D-02  6.31260D-08 -3.34749D-02 -9.84308D-03 -8.38023D-08  1.99702D-01  3.07314D-02 -4.00209D-08  8.12630D-02 -4.05676D-01
+   41    7.72668D-02  6.18082D-08  3.59649D-02  4.70678D-02 -4.51543D-08  5.21255D-01 -1.53135D+00 -8.12284D-08  5.11826D-01 -1.00673D-01
+   42    1.81174D-08  7.31259D-04 -1.61761D-08  2.83734D-08 -7.77809D-03  1.74311D-08 -2.32543D-08  7.02054D-01 -4.34101D-08 -3.21617D-08
+   43   -5.93068D-01  1.41789D-08 -4.21082D-01 -4.28857D-01 -2.35501D-08  1.64607D-01  1.24312D-01 -3.99761D-08 -1.52919D-03 -6.48746D-03
+   44    2.41124D-01 -1.49668D-08  5.28284D-01  3.25691D-01  8.81066D-09 -7.32970D-02 -2.66607D-01  2.43783D-08 -3.92286D-03  1.61703D-02
+   45    4.77068D-09  1.20066D-01 -9.09320D-09  1.81982D-08  3.65406D-02 -1.36170D-08  9.15496D-09 -8.79604D-03 -7.67947D-08 -4.33271D-08
+   46    2.47140D-01  5.30446D-09  1.64607D-01  1.24311D-01 -1.35406D-08 -4.21082D-01 -4.28857D-01 -1.67833D-08  4.82114D-02 -8.51074D-02
+   47   -1.41699D-01 -1.29894D-08 -7.32971D-02 -2.66607D-01  1.23270D-08  5.28284D-01  3.25691D-01  2.99113D-08 -2.89842D-02 -1.83912D-02
+   48    1.08658D-08 -3.83696D-02 -1.55716D-08  6.84614D-09 -8.79605D-03 -2.69266D-08  1.14239D-08  3.65406D-02 -6.28600D-08 -4.41567D-08
+   49   -4.38055D-02 -2.88660D-08  1.43468D-01 -3.08774D-01 -1.33558D-09 -5.06451D-02  9.10380D-03  8.99403D-08  1.25868D-03 -2.61996D-02
+   50    4.43972D-03  1.89231D-09  3.79493D-01 -3.83740D-01  2.50358D-08 -3.78814D-02  1.47712D-02  6.22617D-08 -2.35618D-02 -3.46627D-02
+   51    2.47325D-08  9.55479D-03  6.12919D-08  1.37623D-07  5.10348D-02 -1.57033D-08  2.67144D-08  7.58406D-02 -1.06053D-07 -9.89797D-08
+   52   -9.90599D-03  2.02635D-08 -5.06455D-02  9.10416D-03 -1.73528D-08  1.43468D-01 -3.08774D-01  4.21544D-08 -3.79994D-02 -2.67260D-02
+   53    5.02110D-02  4.44336D-08 -3.78816D-02  1.47714D-02 -4.98470D-08  3.79493D-01 -3.83740D-01 -2.13624D-08 -7.70156D-02  8.47714D-02
+   54    1.75083D-09  3.99608D-02  7.49790D-08  1.49188D-07  7.58406D-02 -2.97365D-08  1.64358D-08  5.10347D-02 -6.75636D-08 -1.99677D-08
+   55    2.65085D-01 -2.06039D-09 -1.59510D-01 -4.43680D-02  1.15193D-08 -7.61222D-02  1.55595D-02 -1.40344D-08  6.91060D-03  4.80272D-02
+   56   -1.13195D-01  8.83363D-09  6.34019D-02  1.36200D-01 -1.24996D-09  1.21547D-01 -5.70973D-02 -6.00119D-08  1.13989D-02 -1.55430D-02
+   57    3.66940D-08  7.76716D-03  2.03264D-08  1.07047D-07 -1.26273D-01 -1.48113D-08  8.19792D-09 -2.58694D-01 -1.17327D-07 -5.70305D-08
+   58   -3.16265D-03 -9.59617D-09 -7.61220D-02  1.55594D-02  5.82222D-08 -1.59510D-01 -4.43679D-02 -2.97073D-09  3.66424D-02  5.06166D-04
+   59    3.98580D-03 -3.03707D-09  1.21547D-01 -5.70975D-02 -1.99367D-08  6.34015D-02  1.36200D-01 -6.61654D-08  8.97897D-02 -2.26051D-02
+   60    7.63799D-09 -9.35090D-02  5.04254D-08  1.15752D-07 -2.58694D-01 -1.13846D-08  1.46847D-08 -1.26273D-01 -9.33553D-08 -3.80296D-08
 
 
               21           22           23           24           25           26           27           28           29           30
    ----- ----- ----- ----- -----
    21    2.82008D+01
-   22   -2.70523D-07  3.73232D+02
-   23   -4.15098D-08  1.13654D+02  1.06909D+02
-   24   -1.07318D+00  2.03947D-08 -1.24478D-08  2.82008D+01
-   25    4.21012D-08 -7.95626D-01  1.12036D+00 -3.79789D-08  2.76993D+02
-   26   -2.01131D-08 -6.75052D-01  6.07637D-01  1.08158D-07 -1.73688D+02  2.07214D+02
-   27   -5.06423D+00 -2.84987D-08 -1.85070D-07  1.46964D-01  1.90507D-07  1.29903D-08  2.74011D+01
-   28    1.35617D-07  1.16134D+00  1.83770D-02  4.73846D-08 -5.57550D-02  2.35550D-01 -3.69536D-07  2.76993D+02
-   29   -8.28504D-08  1.91132D-01  1.85778D+00  2.74476D-08  2.35548D-01 -1.69929D-02  2.94206D-07 -1.73688D+02  2.07214D+02
-   30    1.46964D-01 -3.32394D-08 -2.08272D-07 -5.06423D+00  2.09095D-07 -1.85726D-08 -1.16199D+00 -2.83592D-07 -5.41026D-08  2.74011D+01
-   31   -5.53276D-09  4.46703D-01  5.83253D-01 -1.16029D-07  3.57323D-01  3.19089D-01 -4.49224D-08  1.36677D-01  3.97083D-01  5.25252D-08
-   32    3.36494D-08 -5.97896D-01  4.38697D-01 -9.57050D-08  4.86503D-01 -1.06720D-02 -1.88973D-08 -6.75469D-02 -9.58895D-02  8.69418D-08
-   33    4.52615D-02  1.22758D-08 -6.50192D-08 -1.11327D+00  1.93425D-08  7.08958D-09 -1.12327D+00  2.46269D-09 -1.19327D-08  9.77928D-03
-   34    7.99119D-09  2.39048D-02 -4.43949D-01 -7.73808D-08  1.36677D-01  3.97083D-01 -2.72854D-09  3.57323D-01  3.19089D-01  6.03348D-08
-   35    1.01522D-07  2.32763D-02  5.96867D-02 -7.04195D-08 -6.75466D-02 -9.58899D-02 -1.24998D-07  4.86503D-01 -1.06717D-02  2.01835D-09
-   36   -1.11327D+00  3.93121D-08 -2.35907D-08  4.52615D-02  2.16543D-08 -1.90685D-08  9.77928D-03  4.09094D-09 -2.71899D-08 -1.12327D+00
-   37   -2.67935D-08  8.12627D-02 -4.05676D-01  5.25624D-08  1.21924D-01  4.50806D-02  2.16588D-07  8.13469D-03  2.60106D-02  1.42301D-07
-   38    4.19080D-08  5.11826D-01 -1.00673D-01 -2.24269D-08  3.27089D-03 -3.35581D-03  2.84385D-08  1.52111D-02 -1.25417D-03  3.07129D-08
-   39   -2.24143D-01  2.00499D-08 -2.01509D-08 -5.44739D-02  1.21195D-07 -8.53073D-08 -6.45514D-02 -2.25179D-07 -7.34237D-09  1.52780D-02
-   40    5.97851D-08  3.10702D-02 -4.64569D-02  1.14893D-07  8.13471D-03  2.60102D-02 -2.67662D-08  1.21924D-01  4.50810D-02 -7.95108D-08
-   41   -3.72180D-08  1.57294D-02 -4.65384D-01 -4.43575D-08  1.52112D-02 -1.25418D-03 -1.75698D-08  3.27083D-03 -3.35583D-03 -4.30458D-08
-   42   -5.44739D-02  4.51957D-08 -9.53320D-08 -2.24143D-01  2.10727D-07 -1.82332D-08  1.52780D-02 -1.14458D-07 -3.14056D-08 -6.45514D-02
-   43    5.01122D-08  4.82114D-02 -8.51074D-02 -7.16369D-09  1.25471D-02 -5.90876D-01 -8.08924D-08 -2.27057D-02 -8.71331D-02 -7.65323D-08
-   44    3.35493D-09 -2.89843D-02 -1.83911D-02  4.36294D-08  1.08875D-01 -2.98831D-01  4.79306D-08 -3.62024D-02 -1.00359D-01  2.01793D-08
-   45    7.65830D-03  3.92806D-08  2.44631D-08  3.50651D-02  3.26445D-08 -4.19564D-08  6.79232D-02  4.25963D-08 -3.18427D-08 -3.19042D-02
-   46    1.62883D-08 -1.52917D-03 -6.48761D-03 -5.96864D-08 -2.27056D-02 -8.71332D-02 -3.29145D-08  1.25470D-02 -5.90876D-01  1.43673D-09
-   47    1.42239D-08 -3.92306D-03  1.61704D-02  7.65055D-08 -3.62025D-02 -1.00359D-01 -1.70877D-08  1.08875D-01 -2.98831D-01 -4.78949D-08
-   48    3.50650D-02 -1.84454D-08 -3.38981D-08  7.65831D-03  1.78702D-08 -1.46430D-08 -3.19042D-02  2.68589D-08 -1.38658D-08  6.79232D-02
-   49   -4.91226D-08 -3.80001D-02 -2.67257D-02  1.85531D-07  5.20095D-01 -2.82899D-01  1.13785D-07 -1.47170D-03 -7.81063D-03  1.75024D-08
-   50   -1.37579D-08 -7.70159D-02  8.47716D-02  1.39293D-07 -7.21867D-01 -1.66456D+00  9.92064D-09  5.15489D-03 -1.26060D-03 -7.60781D-08
-   51    1.33085D-02  3.02016D-08 -2.49752D-07 -8.74693D-02  3.06889D-07 -6.45778D-08  3.21835D-01 -2.91957D-07 -4.04140D-08 -3.94623D-03
-   52   -2.54351D-08  1.25818D-03 -2.61991D-02  2.17026D-07 -1.47196D-03 -7.81077D-03  9.00696D-08  5.20095D-01 -2.82899D-01 -1.93066D-08
-   53   -7.59855D-08 -2.35620D-02 -3.46625D-02  4.75285D-08  5.15474D-03 -1.26055D-03  1.82185D-07 -7.21867D-01 -1.66456D+00  3.43876D-08
-   54   -8.74693D-02  6.69333D-08 -2.46807D-07  1.33086D-02  3.03592D-07 -9.45069D-08 -3.94630D-03 -3.31977D-07 -6.32713D-08  3.21835D-01
-   55   -1.20493D-07  3.66429D-02  5.06004D-04 -1.01819D-07  3.28799D-01  2.46911D-01  6.29669D-08  3.50502D-02  1.14047D-01  6.93841D-08
-   56   -7.44660D-09  8.97904D-02 -2.26054D-02 -1.56106D-07  3.10557D-02  1.24406D-01 -8.81751D-08 -3.74490D-02 -5.79718D-02  2.23467D-08
-   57    4.60018D-03  3.23775D-08 -1.87553D-07  3.25314D-01  2.60318D-07 -9.89281D-08  1.32225D-01 -2.52055D-07 -6.89426D-08  7.18773D-03
-   58   -2.03175D-08  6.91110D-03  4.80270D-02 -6.78406D-09  3.50503D-02  1.14047D-01 -7.97718D-08  3.28799D-01  2.46911D-01 -3.50781D-08
-   59    9.69811D-09  1.13995D-02 -1.55433D-02 -1.64186D-07 -3.74489D-02 -5.79715D-02 -1.00039D-07  3.10555D-02  1.24406D-01  1.73606D-08
-   60    3.25313D-01  3.88772D-08 -2.05788D-07  4.60022D-03  2.35977D-07 -5.26734D-08  7.18770D-03 -2.48598D-07 -3.98110D-08  1.32225D-01
+   22   -6.33863D-07  3.73232D+02
+   23   -1.30306D-07  1.13654D+02  1.06909D+02
+   24   -1.07318D+00  1.17713D-07  6.42832D-08  2.82008D+01
+   25    3.32006D-07 -7.95626D-01  1.12036D+00 -3.82029D-08  2.76993D+02
+   26   -1.29115D-07 -6.75052D-01  6.07637D-01 -5.21097D-08 -1.73688D+02  2.07214D+02
+   27   -5.06423D+00 -1.84892D-07 -9.70469D-08  1.46964D-01  3.08510D-07 -2.95245D-07  2.74011D+01
+   28    3.30343D-07  1.16134D+00  1.83768D-02 -9.61221D-08 -5.57550D-02  2.35550D-01  3.28910D-08  2.76993D+02
+   29   -1.47516D-07  1.91132D-01  1.85778D+00  1.76743D-08  2.35548D-01 -1.69927D-02 -9.26329D-08 -1.73688D+02  2.07214D+02
+   30    1.46964D-01 -2.11078D-07 -1.25554D-07 -5.06423D+00  2.53989D-07 -3.35704D-07 -1.16199D+00  2.44225D-07 -1.68358D-07  2.74011D+01
+   31   -6.75785D-08  4.46703D-01  5.83253D-01  2.50416D-08  3.57323D-01  3.19089D-01  6.22596D-08  1.36677D-01  3.97083D-01 -5.76732D-08
+   32    1.47562D-07 -5.97897D-01  4.38697D-01  1.65922D-08  4.86503D-01 -1.06719D-02 -7.78807D-09 -6.75464D-02 -9.58902D-02 -5.09204D-08
+   33    4.52615D-02 -5.93936D-08 -7.29669D-08 -1.11327D+00  4.76239D-08 -4.60742D-08 -1.12327D+00  7.34408D-08 -2.92688D-08  9.77931D-03
+   34   -8.24604D-08  2.39047D-02 -4.43949D-01  1.93093D-08  1.36677D-01  3.97083D-01  7.07147D-08  3.57323D-01  3.19089D-01 -4.75103D-08
+   35    1.57607D-07  2.32760D-02  5.96866D-02 -9.44080D-10 -6.75469D-02 -9.58898D-02 -1.52903D-08  4.86504D-01 -1.06723D-02 -4.29597D-08
+   36   -1.11327D+00 -5.02118D-08 -5.61991D-08  4.52615D-02  5.60886D-08 -5.39552D-08  9.77928D-03  8.54212D-08 -5.21099D-08 -1.12327D+00
+   37    1.55686D-07  8.12628D-02 -4.05676D-01 -4.84438D-08  1.21925D-01  4.50808D-02 -9.38810D-08  8.13518D-03  2.60103D-02  6.10966D-08
+   38    1.41568D-08  5.11826D-01 -1.00673D-01  2.52767D-08  3.27070D-03 -3.35585D-03  3.05347D-08  1.52112D-02 -1.25426D-03 -3.28077D-08
+   39   -2.24143D-01 -8.55165D-08 -2.33683D-09 -5.44740D-02  8.51130D-08 -9.38868D-08 -6.45514D-02  2.10503D-08 -9.12988D-09  1.52780D-02
+   40    2.05444D-07  3.10701D-02 -4.64573D-02  3.32589D-08  8.13497D-03  2.60104D-02 -2.32169D-07  1.21925D-01  4.50807D-02 -4.54175D-08
+   41    4.42810D-08  1.57293D-02 -4.65384D-01  1.98054D-08  1.52111D-02 -1.25426D-03 -5.94566D-09  3.27087D-03 -3.35596D-03 -6.72927D-08
+   42   -5.44740D-02 -7.45265D-08 -8.27560D-08 -2.24143D-01  9.72216D-08 -9.99652D-08  1.52780D-02  5.03317D-09  3.78902D-08 -6.45514D-02
+   43    4.59369D-08  4.82115D-02 -8.51074D-02  8.08713D-10  1.25470D-02 -5.90876D-01  3.43807D-08 -2.27055D-02 -8.71335D-02 -3.39414D-08
+   44    4.05727D-08 -2.89842D-02 -1.83912D-02 -4.42070D-08  1.08875D-01 -2.98831D-01 -4.92399D-08 -3.62022D-02 -1.00359D-01  5.07813D-08
+   45    7.65830D-03 -5.14333D-08 -2.77920D-08  3.50650D-02 -6.78729D-09 -1.84137D-08  6.79233D-02  2.29492D-08 -1.49030D-08 -3.19042D-02
+   46    6.12652D-08 -1.52915D-03 -6.48759D-03 -2.10076D-08 -2.27057D-02 -8.71333D-02  2.97272D-08  1.25473D-02 -5.90876D-01 -1.01255D-09
+   47    4.10572D-08 -3.92298D-03  1.61703D-02 -3.15471D-08 -3.62023D-02 -1.00359D-01 -5.51165D-08  1.08875D-01 -2.98831D-01  3.72812D-08
+   48    3.50650D-02 -6.40252D-08 -4.48511D-08  7.65830D-03 -8.56920D-09 -4.76444D-09 -3.19042D-02 -4.62080D-10 -1.01369D-09  6.79233D-02
+   49    6.82605D-08 -3.79999D-02 -2.67260D-02  1.26239D-08  5.20096D-01 -2.82899D-01 -2.56981D-07 -1.47184D-03 -7.81004D-03  9.22005D-08
+   50    2.24223D-10 -7.70159D-02  8.47714D-02  2.13774D-08 -7.21866D-01 -1.66456D+00 -7.59759D-08  5.15475D-03 -1.26018D-03  7.64603D-08
+   51    1.33084D-02 -2.54175D-07 -1.64822D-07 -8.74693D-02  2.69971D-07 -2.62943D-07  3.21835D-01  1.72853D-07 -1.15010D-07 -3.94620D-03
+   52    8.34066D-08  1.25820D-03 -2.61996D-02  6.04554D-08 -1.47147D-03 -7.81037D-03 -2.41186D-07  5.20095D-01 -2.82899D-01  7.19677D-08
+   53    3.83651D-08 -2.35620D-02 -3.46626D-02  8.83369D-08  5.15495D-03 -1.26043D-03 -1.33895D-07 -7.21867D-01 -1.66456D+00 -1.18233D-08
+   54   -8.74694D-02 -3.06591D-07 -2.15766D-07  1.33085D-02  2.52328D-07 -2.61267D-07 -3.94628D-03  2.09739D-07 -9.09708D-08  3.21835D-01
+   55   -1.40339D-07  3.66428D-02  5.06358D-04  4.19996D-08  3.28799D-01  2.46911D-01  1.22342D-07  3.50498D-02  1.14047D-01 -5.74020D-09
+   56   -1.20853D-07  8.97903D-02 -2.26050D-02 -5.62317D-09  3.10553D-02  1.24406D-01  1.92295D-07 -3.74492D-02 -5.79719D-02 -1.17048D-07
+   57    4.60011D-03 -2.96142D-07 -1.23197D-07  3.25313D-01  2.47176D-07 -2.65888D-07  1.32225D-01  1.09617D-07 -8.71781D-08  7.18776D-03
+   58   -1.66603D-07  6.91105D-03  4.80274D-02  1.27878D-08  3.50499D-02  1.14047D-01  1.41525D-07  3.28799D-01  2.46911D-01 -1.84883D-08
+   59   -1.38979D-07  1.13994D-02 -1.55430D-02  4.92508D-08 -3.74493D-02 -5.79718D-02  1.66117D-07  3.10553D-02  1.24406D-01 -6.13734D-08
+   60    3.25313D-01 -2.89451D-07 -1.72984D-07  4.60019D-03  1.69661D-07 -2.01040D-07  7.18772D-03  1.78619D-07 -7.38765D-08  1.32225D-01
 
 
               31           32           33           34           35           36           37           38           39           40
    ----- ----- ----- ----- -----
    31    7.32544D+01
    32   -1.18223D+01  6.42681D+01
-   33    1.00837D-07 -5.46645D-08  1.15275D+01
-   34   -1.37523D-02 -7.62558D-02 -2.39268D-08  7.32544D+01
-   35   -7.62526D-02  2.73215D-01 -1.55816D-08 -1.18223D+01  6.42681D+01
-   36    2.44974D-08 -2.33933D-08 -8.23506D-02 -2.82774D-07  1.02625D-07  1.15275D+01
-   37   -1.09714D+02 -2.12658D+01  2.57935D-08  1.22527D-02  2.11143D-03  9.15869D-08  3.92896D+02
-   38   -2.21073D+01 -2.37598D+01 -1.21627D-08  4.02467D-02  8.64903D-03 -2.43912D-09  7.49238D+01  8.59899D+01
-   39    5.16661D-09  6.33361D-08 -1.27712D+01 -2.84269D-08 -9.07035D-08 -1.01822D-03  3.87182D-08 -2.36964D-08  3.00155D+01
-   40    1.22531D-02  2.11134D-03 -1.92841D-09 -1.09714D+02 -2.12658D+01  3.73227D-08 -7.29271D-03  5.33745D-04  1.70604D-09  3.92896D+02
-   41    4.02467D-02  8.64901D-03 -1.73945D-08 -2.21073D+01 -2.37598D+01  2.59938D-08  5.34365D-04 -1.95065D-04  4.06753D-08  7.49238D+01
-   42    5.30650D-08  9.23515D-08 -1.01826D-03 -4.24176D-08 -3.41327D-08 -1.27712D+01 -8.90968D-08 -1.58070D-07 -4.37972D-04 -6.85653D-08
-   43   -3.08028D+01  1.93772D+01 -2.98512D-08  1.02829D-03  9.97317D-02 -1.78133D-08 -4.51872D+00  9.25799D+00 -1.80751D-08 -3.72396D-03
-   44    2.12255D+01 -3.26592D+01  3.83822D-08  3.90902D-02 -8.44001D-02 -9.14549D-09 -2.77540D+00  2.37438D+00 -1.71905D-08 -5.34946D-03
-   45    2.09722D-09 -1.35413D-08 -4.38015D+00  7.01579D-09  4.35506D-08  7.55744D-03 -3.91984D-08  3.94567D-09  1.65027D+00  3.89275D-08
-   46    1.02833D-03  9.97317D-02 -4.36202D-10 -3.08028D+01  1.93772D+01  1.17506D-08 -3.72408D-03 -8.48256D-03 -4.56313D-08 -4.51872D+00
-   47    3.90904D-02 -8.44001D-02  2.22917D-08  2.12255D+01 -3.26592D+01 -1.91529D-08 -5.34967D-03 -1.90897D-02 -1.41158D-08 -2.77540D+00
-   48    6.36581D-09 -4.98860D-08  7.55743D-03  4.57973D-09  1.96478D-08 -4.38015D+00 -5.92372D-08 -9.02945D-09 -1.30286D-03  1.19837D-08
-   49   -3.93892D+00 -2.31117D+00  4.91875D-08  5.33323D-02  2.32486D-02  6.41893D-08 -5.72312D-01  2.24288D+00  1.06015D-07 -7.92198D-03
-   50    8.58324D+00  3.33058D+00  3.57109D-09 -8.03462D-03  3.83505D-03  1.60738D-08  2.12155D+00 -3.71570D+00  8.06271D-08  6.18212D-04
-   51    8.81344D-08  9.58627D-08  1.37919D+00 -1.65367D-08  2.42676D-08  1.74383D-02 -4.87381D-07 -1.94480D-07  1.39439D+01  3.59955D-07
-   52    5.33325D-02  2.32485D-02 -8.83403D-09 -3.93892D+00 -2.31117D+00  3.27163D-08 -7.92200D-03 -2.48625D-02  1.52407D-07 -5.72312D-01
-   53   -8.03459D-03  3.83501D-03  3.13098D-08  8.58324D+00  3.33058D+00  5.83700D-08  6.18244D-04 -4.67344D-03  1.84849D-07  2.12155D+00
-   54    7.51536D-08  2.99416D-08  1.74383D-02 -2.15556D-08 -4.04150D-08  1.37919D+00 -4.55368D-07 -1.87342D-07  2.79924D-03  3.71273D-07
-   55    2.84420D+00  8.23716D+00 -8.72222D-11 -1.77256D-02 -1.44321D-02 -5.02666D-08  1.92434D+00 -5.65626D-02 -7.70663D-08  5.40215D-03
-   56   -3.57319D+00 -4.53349D+00 -4.81228D-08 -2.90160D-02 -1.56276D-02  2.03688D-08 -1.42312D-01  1.64639D+00 -9.26954D-08  2.28447D-03
-   57    3.81078D-08  8.13725D-08  1.61487D+00 -4.81709D-08 -6.13038D-08 -2.16509D-03 -3.65357D-07 -1.60299D-07 -9.19877D+00  3.55337D-07
-   58   -1.77259D-02 -1.44320D-02 -1.28444D-08  2.84420D+00  8.23716D+00 -5.53066D-08  5.40251D-03  1.98358D-02 -1.28059D-08  1.92434D+00
-   59   -2.90163D-02 -1.56275D-02 -9.95843D-08 -3.57319D+00 -4.53349D+00 -1.95513D-08  2.28476D-03  1.10359D-02 -4.28027D-08 -1.42312D-01
-   60    1.00946D-07  9.20772D-08 -2.16515D-03  2.35528D-09 -4.58017D-08  1.61487D+00 -4.51601D-07 -2.22266D-07  2.82891D-03  2.61969D-07
+   33   -1.34580D-08  1.46770D-08  1.15275D+01
+   34   -1.37522D-02 -7.62559D-02  2.96002D-08  7.32544D+01
+   35   -7.62526D-02  2.73214D-01 -3.78749D-09 -1.18223D+01  6.42681D+01
+   36    3.81016D-09 -4.20250D-08 -8.23507D-02  2.56785D-07 -3.87761D-08  1.15275D+01
+   37   -1.09714D+02 -2.12658D+01 -6.01525D-08  1.22529D-02  2.11142D-03 -1.98170D-09  3.92896D+02
+   38   -2.21073D+01 -2.37598D+01  5.33648D-10  4.02467D-02  8.64900D-03 -1.15789D-09  7.49238D+01  8.59899D+01
+   39   -5.82320D-09 -2.47859D-08 -1.27712D+01 -3.76122D-08 -7.34086D-09 -1.01824D-03  7.22774D-08  5.88925D-08  3.00155D+01
+   40    1.22529D-02  2.11132D-03 -8.60759D-08 -1.09714D+02 -2.12658D+01 -3.32850D-08 -7.29259D-03  5.33712D-04 -7.36979D-08  3.92896D+02
+   41    4.02468D-02  8.64893D-03 -8.69148D-09 -2.21073D+01 -2.37598D+01 -5.16328D-08  5.34093D-04 -1.95151D-04 -1.37525D-08  7.49238D+01
+   42    1.99446D-08 -1.84813D-08 -1.01827D-03  4.33551D-08 -1.21566D-08 -1.27712D+01  1.37514D-09  4.81770D-08 -4.38021D-04  1.96495D-08
+   43   -3.08028D+01  1.93772D+01 -1.32071D-09  1.02836D-03  9.97316D-02  5.21312D-09 -4.51872D+00  9.25799D+00 -9.35947D-09 -3.72431D-03
+   44    2.12255D+01 -3.26592D+01 -1.73039D-08  3.90902D-02 -8.44001D-02 -9.78986D-10 -2.77540D+00  2.37438D+00 -2.64399D-08 -5.34955D-03
+   45    1.12408D-08 -2.22785D-08 -4.38015D+00  2.34075D-08 -1.26032D-09  7.55743D-03  5.67583D-09  5.24464D-09  1.65027D+00 -2.72746D-09
+   46    1.02837D-03  9.97315D-02  4.31696D-09 -3.08028D+01  1.93772D+01  4.62020D-09 -3.72423D-03 -8.48254D-03 -1.63431D-08 -4.51872D+00
+   47    3.90902D-02 -8.44001D-02 -2.06924D-08  2.12255D+01 -3.26592D+01 -3.78746D-09 -5.34951D-03 -1.90897D-02 -3.05378D-09 -2.77540D+00
+   48    1.09322D-08 -2.37083D-08  7.55743D-03  9.08609D-09  2.01455D-08 -4.38015D+00 -9.61061D-09  1.65886D-08 -1.30287D-03 -3.88055D-09
+   49   -3.93892D+00 -2.31117D+00 -6.68787D-08  5.33322D-02  2.32487D-02 -3.01180D-08 -5.72312D-01  2.24288D+00 -8.81334D-08 -7.92151D-03
+   50    8.58324D+00  3.33058D+00 -3.06743D-08 -8.03465D-03  3.83511D-03 -9.15758D-09  2.12156D+00 -3.71570D+00 -2.96120D-08  6.18529D-04
+   51    1.32089D-08 -1.75942D-07  1.37919D+00 -3.04221D-08  8.88451D-08  1.74383D-02  1.62526D-07  1.76173D-07  1.39439D+01  2.35233D-07
+   52    5.33322D-02  2.32489D-02 -1.00005D-07 -3.93892D+00 -2.31117D+00 -9.41465D-09 -7.92142D-03 -2.48626D-02 -5.52658D-08 -5.72312D-01
+   53   -8.03467D-03  3.83530D-03 -3.97746D-08  8.58324D+00  3.33058D+00 -5.49364D-09  6.18542D-04 -4.67349D-03 -2.39913D-08  2.12156D+00
+   54    3.13330D-08 -1.34866D-07  1.74382D-02 -5.78810D-08  2.87262D-08  1.37919D+00  1.57960D-07  1.45080D-07  2.79926D-03  2.45003D-07
+   55    2.84420D+00  8.23716D+00  5.05511D-08 -1.77257D-02 -1.44321D-02 -1.05952D-09  1.92434D+00 -5.65627D-02  9.15769D-08  5.40237D-03
+   56   -3.57319D+00 -4.53349D+00  6.50943D-08 -2.90161D-02 -1.56276D-02  2.22788D-08 -1.42312D-01  1.64639D+00  8.39117D-08  2.28443D-03
+   57    2.91946D-08 -1.49159D-07  1.61487D+00 -5.83784D-08  5.14677D-08 -2.16515D-03  1.20438D-07  1.46486D-07 -9.19877D+00  2.25369D-07
+   58   -1.77257D-02 -1.44321D-02  6.35658D-08  2.84420D+00  8.23716D+00 -6.31153D-09  5.40218D-03  1.98358D-02  5.71265D-08  1.92434D+00
+   59   -2.90160D-02 -1.56277D-02  8.35542D-08 -3.57319D+00 -4.53349D+00  1.29312D-08  2.28429D-03  1.10358D-02 -2.03090D-09 -1.42312D-01
+   60    2.54192D-08 -1.51721D-07 -2.16522D-03 -3.30947D-08  2.72733D-08  1.61487D+00  1.91794D-07  1.05671D-07  2.82890D-03  2.08267D-07
 
 
               41           42           43           44           45           46           47           48           49           50
    ----- ----- ----- ----- -----
    41    8.59899D+01
-   42    3.67285D-08  3.00155D+01
-   43   -8.48255D-03  1.05474D-07  7.25692D+01
-   44   -1.90896D-02 -7.86796D-09 -8.85249D+00  7.42920D+01
-   45    1.24970D-08 -1.30287D-03 -1.06560D-07  4.58350D-08  9.49609D+00
-   46    9.25799D+00  6.52254D-08  2.22376D-02 -4.07853D-02 -7.07380D-09  7.25692D+01
-   47    2.37438D+00 -1.63439D-08 -4.07849D-02  1.73304D-02  1.40644D-09 -8.85249D+00  7.42920D+01
-   48    3.09959D-09  1.65027D+00  2.19755D-08  1.62876D-08  9.51771D-04  4.15038D-08 -1.70573D-07  9.49609D+00
-   49   -2.48625D-02 -2.75382D-07 -1.15043D+02 -1.70497D+01 -1.79138D-08 -2.01876D-02 -2.89290D-02 -6.81685D-08  4.10714D+02
-   50   -4.67346D-03 -2.85986D-07 -1.76171D+01 -2.32518D+01 -2.54150D-08 -3.97292D-04  2.03521D-03 -6.43179D-09  6.01944D+01  7.17950D+01
-   51    1.30149D-07  2.79918D-03  3.84838D-08 -7.93823D-08 -1.11501D+01 -1.59845D-07  8.64856D-09 -7.94521D-04 -5.29985D-08  1.92499D-07
-   52    2.24288D+00 -2.70148D-07 -2.01879D-02 -2.89288D-02  2.24209D-08 -1.15043D+02 -1.70497D+01 -2.73156D-08 -5.75509D-02 -3.04072D-03
-   53   -3.71570D+00 -1.78764D-07 -3.97446D-04  2.03527D-03 -1.48060D-08 -1.76171D+01 -2.32518D+01 -8.38694D-09 -3.04218D-03 -1.60334D-03
-   54    1.38081D-07  1.39439D+01  6.69603D-08 -2.46572D-08 -7.94542D-04 -1.82362D-07  4.71923D-08 -1.11501D+01 -5.85319D-08  1.86222D-07
-   55    1.98357D-02  2.97084D-08 -2.89072D+01 -2.92941D+01  7.77766D-09  9.75020D-03  1.36420D-02 -5.29735D-09 -1.13596D+00 -2.96567D+01
-   56    1.10357D-02  1.19878D-07 -2.83534D+01 -1.09348D+02  9.72457D-09  1.14581D-02  1.33549D-02 -1.18544D-09  7.45709D+00  1.82264D+00
-   57    1.66050D-07  2.82880D-03  3.91019D-08 -8.91436D-08 -1.02017D+01 -1.12650D-07  3.64046D-08 -4.26049D-03 -1.44387D-08  2.20302D-07
-   58   -5.65627D-02  1.16617D-07  9.75032D-03  1.36419D-02  2.85761D-08 -2.89072D+01 -2.92941D+01  4.16401D-08  3.18435D-02 -1.57970D-03
-   59    1.64639D+00  1.91512D-07  1.14583D-02  1.33547D-02  5.29066D-08 -2.83534D+01 -1.09348D+02  3.16042D-08  3.17501D-02  5.09659D-03
-   60    1.19751D-07 -9.19877D+00  3.96170D-08 -7.11430D-08 -4.26045D-03 -9.48601D-08  1.38612D-08 -1.02017D+01  2.76559D-08  1.89551D-07
+   42   -2.09688D-08  3.00155D+01
+   43   -8.48257D-03  2.82291D-08  7.25692D+01
+   44   -1.90897D-02 -3.95482D-08 -8.85249D+00  7.42920D+01
+   45    4.55767D-09 -1.30286D-03  4.13921D-08 -2.70206D-08  9.49609D+00
+   46    9.25799D+00  2.66648D-08  2.22376D-02 -4.07852D-02  3.34293D-09  7.25692D+01
+   47    2.37438D+00 -5.57323D-08 -4.07848D-02  1.73303D-02  2.79178D-08 -8.85249D+00  7.42920D+01
+   48   -3.52057D-09  1.65027D+00  3.37632D-09 -1.06898D-09  9.51778D-04  1.21064D-08 -2.04632D-08  9.49609D+00
+   49   -2.48625D-02 -2.30279D-07 -1.15043D+02 -1.70497D+01  8.80011D-08 -2.01880D-02 -2.89289D-02  1.40421D-07  4.10714D+02
+   50   -4.67339D-03 -1.37997D-07 -1.76171D+01 -2.32518D+01  3.84186D-08 -3.97524D-04  2.03521D-03  6.31231D-08  6.01944D+01  7.17950D+01
+   51   -3.55618D-09  2.79924D-03  1.21491D-08 -4.88792D-08 -1.11501D+01 -4.75315D-08 -1.23438D-07 -7.94536D-04 -2.56154D-07  1.39432D-07
+   52    2.24288D+00 -2.40064D-07 -2.01877D-02 -2.89290D-02  1.12728D-07 -1.15043D+02 -1.70497D+01  1.09940D-07 -5.75508D-02 -3.04070D-03
+   53   -3.71570D+00 -1.04167D-07 -3.97340D-04  2.03521D-03  4.92518D-08 -1.76171D+01 -2.32518D+01  5.67051D-08 -3.04213D-03 -1.60331D-03
+   54    3.00510D-08  1.39439D+01 -4.82284D-09 -4.88278D-08 -7.94467D-04 -9.51103D-08 -4.79767D-08 -1.11501D+01 -2.50302D-07  9.01040D-08
+   55    1.98358D-02  1.54151D-07 -2.89072D+01 -2.92941D+01 -8.27497D-08  9.75028D-03  1.36420D-02 -7.18397D-08 -1.13596D+00 -2.96567D+01
+   56    1.10358D-02  1.71370D-07 -2.83534D+01 -1.09348D+02 -1.00694D-07  1.14583D-02  1.33549D-02 -1.23176D-07  7.45709D+00  1.82264D+00
+   57    3.18653D-08  2.82881D-03  1.45027D-08 -1.47122D-08 -1.02017D+01 -6.29758D-08 -4.95304D-08 -4.26048D-03 -2.34730D-07  9.27701D-08
+   58   -5.65627D-02  1.54683D-07  9.75014D-03  1.36420D-02 -6.80259D-08 -2.89072D+01 -2.92941D+01 -8.24647D-08  3.18436D-02 -1.57968D-03
+   59    1.64639D+00  1.98290D-07  1.14580D-02  1.33549D-02 -8.45179D-08 -2.83534D+01 -1.09348D+02 -1.24394D-07  3.17502D-02  5.09644D-03
+   60    3.14784D-08 -9.19877D+00 -4.45819D-09 -1.30945D-08 -4.26041D-03 -6.02050D-08 -2.59705D-08 -1.02017D+01 -2.19477D-07  9.09400D-08
 
 
               51           52           53           54           55           56           57           58           59           60
    ----- ----- ----- ----- -----
    51    2.48883D+01
-   52    5.66170D-08  4.10714D+02
-   53    2.60541D-08  6.01944D+01  7.17950D+01
-   54    1.87382D-02  2.99451D-07 -2.23199D-07  2.48883D+01
-   55   -3.95488D-08  3.18432D-02 -1.58002D-03  9.36615D-08  9.18431D+01
-   56   -1.71022D-08  3.17502D-02  5.09607D-03  2.42595D-08  9.99948D+01  3.89497D+02
-   57    2.20870D+00  1.59467D-07 -2.54573D-07 -2.04470D-02  1.63913D-07  8.12515D-08  2.48339D+01
-   58   -6.28116D-08 -1.13596D+00 -2.96567D+01  5.88705D-08 -1.36540D-02 -1.77510D-02  5.18462D-08  9.18431D+01
-   59   -3.34808D-08  7.45709D+00  1.82264D+00 -5.21509D-09 -1.77421D-02 -2.31193D-02  1.41379D-07  9.99948D+01  3.89497D+02
-   60   -2.04471D-02  1.59670D-07 -2.54304D-07  2.20870D+00  1.80819D-07  1.31217D-07  2.76930D-02 -1.51281D-07 -7.31840D-08  2.48339D+01
+   52   -7.48829D-08  4.10714D+02
+   53    6.54361D-09  6.01944D+01  7.17950D+01
+   54    1.87381D-02 -1.68002D-08 -5.66770D-09  2.48883D+01
+   55   -9.19014D-09  3.18433D-02 -1.57972D-03 -7.39883D-08  9.18431D+01
+   56    5.71033D-09  3.17500D-02  5.09638D-03 -8.49133D-08  9.99948D+01  3.89497D+02
+   57    2.20870D+00 -7.30658D-08 -6.94544D-08 -2.04471D-02  1.09235D-07  1.89044D-07  2.48339D+01
+   58   -4.60015D-08 -1.13596D+00 -2.96567D+01 -4.36330D-08 -1.36539D-02 -1.77509D-02 -4.00678D-08  9.18431D+01
+   59    2.24897D-08  7.45709D+00  1.82264D+00 -1.39387D-08 -1.77419D-02 -2.31193D-02 -2.12891D-08  9.99948D+01  3.89497D+02
+   60   -2.04472D-02 -9.27875D-08 -5.10577D-08  2.20870D+00  5.83260D-08  1.83639D-07  2.76930D-02 -1.40708D-08  1.39100D-07  2.48339D+01
 
 
 
@@ -936,326 +1693,326 @@ Iterative solution of linear equations
  
  Frequency         -9.92       -1.35        3.25        6.84        9.12       17.92
  
-           1     0.00000    -0.00001    -0.08510     0.02117    -0.04865    -0.00000
-           2     0.00000    -0.00000     0.02113     0.08511     0.00812     0.00000
-           3     0.03217     0.08767    -0.00001     0.00000     0.00000     0.04614
-           4     0.00000    -0.00001    -0.08510     0.02116     0.04865     0.00000
-           5     0.00000    -0.00000     0.02113     0.08511    -0.00810     0.00000
-           6    -0.03217     0.08767    -0.00001     0.00000     0.00000    -0.04614
-           7     0.00000    -0.00001    -0.08510     0.02117    -0.01678     0.00000
-           8     0.00000    -0.00000     0.02113     0.08510     0.04526     0.00000
-           9    -0.04862     0.08766    -0.00001     0.00000     0.00000     0.11745
-          10     0.00000    -0.00001    -0.08510     0.02117     0.01679     0.00000
-          11     0.00000     0.00000     0.02113     0.08511    -0.04524     0.00000
-          12     0.04862     0.08766    -0.00001     0.00000     0.00000    -0.11745
-          13     0.00000    -0.00001    -0.08510     0.02117     0.03079     0.00000
-          14     0.00000    -0.00000     0.02113     0.08510     0.03735     0.00000
-          15    -0.07995     0.08766    -0.00001     0.00000     0.00000     0.07249
-          16     0.00000    -0.00001    -0.08510     0.02118    -0.03078    -0.00000
-          17     0.00000    -0.00000     0.02113     0.08510    -0.03733     0.00000
-          18     0.07995     0.08766    -0.00000     0.00000     0.00000    -0.07249
-          19     0.00000    -0.00001    -0.08510     0.02118    -0.02985    -0.00000
-          20    -0.00000    -0.00000     0.02112     0.08510     0.08072     0.00000
-          21    -0.08655     0.08766    -0.00001     0.00000    -0.00000     0.20950
-          22     0.00000    -0.00001    -0.08510     0.02117     0.02985     0.00000
-          23     0.00000     0.00000     0.02112     0.08511    -0.08070    -0.00000
-          24     0.08655     0.08766    -0.00000     0.00000     0.00000    -0.20950
-          25     0.00000    -0.00001    -0.08510     0.02115     0.05461     0.00000
-          26     0.00000    -0.00000     0.02113     0.08506     0.06667     0.00000
-          27    -0.14262     0.08766    -0.00001     0.00000    -0.00000     0.13082
-          28     0.00000    -0.00001    -0.08510     0.02116    -0.05461    -0.00000
-          29     0.00000     0.00000     0.02113     0.08508    -0.06665    -0.00000
-          30     0.14262     0.08766    -0.00000     0.00000     0.00000    -0.13082
-          31     0.00000    -0.00001    -0.08510     0.02110     0.09912     0.00000
-          32     0.00000    -0.00000     0.02113     0.08513    -0.01834     0.00000
-          33    -0.06285     0.08768    -0.00001     0.00000     0.00000    -0.09792
-          34     0.00000    -0.00000    -0.08509     0.02113    -0.09912    -0.00000
-          35     0.00000    -0.00000     0.02113     0.08512     0.01836     0.00000
-          36     0.06285     0.08768    -0.00000     0.00000     0.00000     0.09792
-          37     0.00000    -0.00001    -0.08509     0.02109     0.10769     0.00000
-          38     0.00000     0.00000     0.02112     0.08519    -0.05506    -0.00000
-          39    -0.01413     0.08765    -0.00001     0.00000     0.00000    -0.18835
-          40     0.00000    -0.00000    -0.08509     0.02111    -0.10769    -0.00000
-          41     0.00000    -0.00000     0.02112     0.08518     0.05508     0.00000
-          42     0.01413     0.08765    -0.00001     0.00000     0.00000     0.18835
-          43     0.00000    -0.00001    -0.08509     0.02101     0.13341     0.00000
-          44     0.00000    -0.00000     0.02113     0.08505     0.01250     0.00000
-          45    -0.14239     0.08772    -0.00001     0.00000     0.00000    -0.04423
-          46     0.00000    -0.00000    -0.08508     0.02105    -0.13341    -0.00000
-          47     0.00000    -0.00000     0.02113     0.08505    -0.01248     0.00000
-          48     0.14239     0.08772    -0.00000     0.00000     0.00000     0.04423
-          49     0.00000    -0.00001    -0.08509     0.02104     0.12725     0.00000
-          50     0.00000    -0.00000     0.02114     0.08491     0.04950     0.00000
-          51    -0.19452     0.08775    -0.00001     0.00000    -0.00000     0.04586
-          52     0.00000    -0.00000    -0.08509     0.02107    -0.12725    -0.00000
-          53     0.00000     0.00000     0.02114     0.08492    -0.04948     0.00000
-          54     0.19452     0.08775    -0.00000     0.00000     0.00000    -0.04586
-          55     0.00000    -0.00001    -0.08508     0.02090     0.16929     0.00000
-          56     0.00000    -0.00000     0.02113     0.08508     0.00170     0.00000
-          57    -0.15879     0.08773    -0.00001     0.00000     0.00000    -0.08884
-          58     0.00000    -0.00000    -0.08508     0.02094    -0.16929    -0.00000
-          59     0.00000    -0.00000     0.02113     0.08508    -0.00168     0.00000
-          60     0.15879     0.08773    -0.00000     0.00000     0.00000     0.08884
+           1     0.00000    -0.00002    -0.08510     0.02117    -0.04865     0.00000
+           2     0.00000     0.00000     0.02112     0.08511     0.00813    -0.00000
+           3     0.03217     0.08767    -0.00002     0.00000     0.00000     0.04614
+           4     0.00000    -0.00002    -0.08510     0.02116     0.04865     0.00000
+           5    -0.00000     0.00000     0.02112     0.08511    -0.00810    -0.00000
+           6    -0.03217     0.08767    -0.00002     0.00000     0.00000    -0.04614
+           7     0.00000    -0.00002    -0.08510     0.02117    -0.01678     0.00000
+           8     0.00000     0.00000     0.02112     0.08510     0.04527    -0.00000
+           9    -0.04861     0.08766    -0.00002     0.00000     0.00000     0.11745
+          10     0.00000    -0.00002    -0.08510     0.02117     0.01679     0.00000
+          11    -0.00000     0.00000     0.02112     0.08512    -0.04524     0.00000
+          12     0.04862     0.08766    -0.00002     0.00000    -0.00000    -0.11745
+          13     0.00000    -0.00002    -0.08510     0.02116     0.03079     0.00000
+          14     0.00000     0.00000     0.02112     0.08510     0.03735    -0.00000
+          15    -0.07995     0.08766    -0.00002     0.00000     0.00000     0.07249
+          16     0.00000    -0.00002    -0.08510     0.02117    -0.03078     0.00000
+          17    -0.00000     0.00000     0.02112     0.08511    -0.03733     0.00000
+          18     0.07995     0.08766    -0.00002     0.00000    -0.00000    -0.07249
+          19     0.00000    -0.00002    -0.08510     0.02117    -0.02984     0.00000
+          20     0.00000     0.00000     0.02112     0.08509     0.08072    -0.00000
+          21    -0.08655     0.08766    -0.00002     0.00000     0.00000     0.20950
+          22     0.00000    -0.00002    -0.08510     0.02116     0.02985     0.00000
+          23    -0.00000     0.00000     0.02112     0.08512    -0.08069     0.00000
+          24     0.08655     0.08766    -0.00002     0.00000    -0.00000    -0.20950
+          25     0.00000    -0.00002    -0.08510     0.02114     0.05461     0.00000
+          26     0.00000     0.00000     0.02112     0.08506     0.06667    -0.00000
+          27    -0.14262     0.08766    -0.00002     0.00000     0.00000     0.13082
+          28     0.00000    -0.00002    -0.08510     0.02116    -0.05461     0.00000
+          29    -0.00000     0.00000     0.02112     0.08508    -0.06665     0.00000
+          30     0.14262     0.08766    -0.00002     0.00000    -0.00000    -0.13082
+          31     0.00000    -0.00002    -0.08509     0.02110     0.09912     0.00000
+          32    -0.00000     0.00000     0.02112     0.08513    -0.01833    -0.00000
+          33    -0.06285     0.08768    -0.00002     0.00000    -0.00000    -0.09792
+          34     0.00000    -0.00002    -0.08509     0.02113    -0.09911     0.00000
+          35     0.00000     0.00000     0.02112     0.08512     0.01836    -0.00000
+          36     0.06285     0.08768    -0.00002     0.00000     0.00000     0.09792
+          37     0.00000    -0.00002    -0.08509     0.02108     0.10769     0.00000
+          38    -0.00000     0.00000     0.02111     0.08520    -0.05506     0.00000
+          39    -0.01413     0.08765    -0.00002     0.00000    -0.00000    -0.18835
+          40     0.00000    -0.00002    -0.08509     0.02111    -0.10768     0.00000
+          41     0.00000     0.00000     0.02111     0.08518     0.05509    -0.00000
+          42     0.01414     0.08765    -0.00002     0.00000     0.00000     0.18835
+          43     0.00000    -0.00002    -0.08509     0.02101     0.13341     0.00000
+          44     0.00000     0.00000     0.02113     0.08505     0.01250    -0.00000
+          45    -0.14239     0.08772    -0.00002     0.00000     0.00000    -0.04423
+          46     0.00000    -0.00002    -0.08509     0.02105    -0.13341     0.00000
+          47    -0.00000     0.00000     0.02113     0.08505    -0.01248    -0.00000
+          48     0.14240     0.08772    -0.00002     0.00000    -0.00000     0.04423
+          49     0.00000    -0.00002    -0.08509     0.02103     0.12725     0.00000
+          50     0.00000     0.00000     0.02114     0.08491     0.04950    -0.00000
+          51    -0.19452     0.08775    -0.00002     0.00000     0.00000     0.04586
+          52     0.00000    -0.00002    -0.08509     0.02107    -0.12725     0.00000
+          53    -0.00000     0.00000     0.02114     0.08492    -0.04948     0.00000
+          54     0.19452     0.08775    -0.00002     0.00000    -0.00000    -0.04586
+          55     0.00000    -0.00002    -0.08508     0.02089     0.16929    -0.00000
+          56     0.00000     0.00000     0.02113     0.08508     0.00170    -0.00000
+          57    -0.15879     0.08773    -0.00002     0.00000     0.00000    -0.08884
+          58     0.00000    -0.00002    -0.08508     0.02094    -0.16929     0.00000
+          59    -0.00000     0.00000     0.02113     0.08508    -0.00168    -0.00000
+          60     0.15880     0.08773    -0.00002     0.00000    -0.00000     0.08884
 
                     7           8           9          10          11          12
  
  Frequency         49.01       81.29      151.70      181.05      265.75      301.27
  
-           1    -0.00000     0.00000     0.00000     0.05678    -0.06710     0.00000
-           2    -0.00000    -0.00000     0.00000     0.01053     0.02426     0.00000
-           3    -0.04458    -0.05531     0.02076     0.00000     0.00000    -0.11846
-           4    -0.00000     0.00000    -0.00000     0.05678     0.06710     0.00000
-           5    -0.00000    -0.00000     0.00000     0.01052    -0.02426    -0.00000
-           6    -0.04458     0.05531     0.02076    -0.00000    -0.00000     0.11846
-           7    -0.00000     0.00000     0.00000     0.06198    -0.03562     0.00000
+           1    -0.00000     0.00000     0.00000     0.05678    -0.06710    -0.00000
+           2    -0.00000    -0.00000    -0.00000     0.01053     0.02426     0.00000
+           3    -0.04458     0.05531    -0.02076     0.00000     0.00000    -0.11846
+           4    -0.00000    -0.00000     0.00000     0.05678     0.06710     0.00000
+           5    -0.00000    -0.00000    -0.00000     0.01052    -0.02426    -0.00000
+           6    -0.04458    -0.05531    -0.02076     0.00000    -0.00000     0.11846
+           7    -0.00000     0.00000     0.00000     0.06198    -0.03562    -0.00000
            8    -0.00000    -0.00000    -0.00000     0.01364     0.05531     0.00000
-           9    -0.05720     0.02668     0.05684     0.00000    -0.00000    -0.07801
-          10    -0.00000     0.00000    -0.00000     0.06198     0.03562     0.00000
-          11    -0.00000    -0.00000     0.00000     0.01364    -0.05531    -0.00000
-          12    -0.05720    -0.02668     0.05684    -0.00000    -0.00000     0.07801
-          13    -0.00000     0.00000    -0.00000     0.06099     0.04505     0.00000
-          14    -0.00000    -0.00000     0.00000     0.00643     0.03727     0.00000
-          15    -0.05327     0.08506     0.06573     0.00000     0.00000     0.06449
-          16    -0.00000     0.00000     0.00000     0.06099    -0.04505     0.00000
-          17    -0.00000    -0.00000     0.00000     0.00643    -0.03727    -0.00000
-          18    -0.05327    -0.08506     0.06573     0.00000     0.00000    -0.06449
-          19    -0.00000     0.00000     0.00000     0.06243    -0.05344     0.00000
+           9    -0.05720    -0.02668    -0.05684     0.00000     0.00000    -0.07801
+          10    -0.00000    -0.00000     0.00000     0.06198     0.03562     0.00000
+          11    -0.00000     0.00000     0.00000     0.01364    -0.05531    -0.00000
+          12    -0.05720     0.02668    -0.05684     0.00000    -0.00000     0.07801
+          13    -0.00000    -0.00000     0.00000     0.06099     0.04505     0.00000
+          14    -0.00000    -0.00000    -0.00000     0.00643     0.03727     0.00000
+          15    -0.05327    -0.08506    -0.06573     0.00000     0.00000     0.06449
+          16    -0.00000     0.00000     0.00000     0.06099    -0.04505    -0.00000
+          17    -0.00000     0.00000    -0.00000     0.00643    -0.03727    -0.00000
+          18    -0.05327     0.08506    -0.06573     0.00000     0.00000    -0.06449
+          19    -0.00000     0.00000     0.00000     0.06243    -0.05344    -0.00000
           20    -0.00000    -0.00000    -0.00000     0.01382     0.10413     0.00000
-          21    -0.06189     0.05296     0.04389     0.00000    -0.00000    -0.11910
-          22    -0.00000     0.00000    -0.00000     0.06243     0.05344     0.00000
-          23    -0.00000    -0.00000     0.00000     0.01382    -0.10413    -0.00000
-          24    -0.06189    -0.05296     0.04389    -0.00000    -0.00000     0.11910
-          25    -0.00000     0.00000    -0.00000     0.05942     0.08282     0.00000
+          21    -0.06189    -0.05296    -0.04389     0.00000     0.00000    -0.11910
+          22    -0.00000    -0.00000     0.00000     0.06243     0.05344     0.00000
+          23    -0.00000     0.00000     0.00000     0.01382    -0.10413    -0.00000
+          24    -0.06189     0.05296    -0.04389    -0.00000    -0.00000     0.11910
+          25    -0.00000    -0.00000     0.00000     0.05942     0.08282     0.00000
           26    -0.00000    -0.00000    -0.00000     0.00251     0.08104     0.00000
-          27    -0.05766     0.16013     0.05764     0.00000     0.00000     0.08322
-          28    -0.00000     0.00000     0.00000     0.05942    -0.08282     0.00000
-          29    -0.00000    -0.00000     0.00000     0.00251    -0.08104    -0.00000
-          30    -0.05766    -0.16013     0.05764    -0.00000     0.00000    -0.08322
-          31    -0.00000     0.00000    -0.00000    -0.03069     0.03030     0.00000
-          32    -0.00000    -0.00000     0.00000     0.02870    -0.02384    -0.00000
-          33    -0.01339     0.08997    -0.12599    -0.00000     0.00000    -0.03636
+          27    -0.05766    -0.16013    -0.05764     0.00000     0.00000     0.08322
+          28    -0.00000     0.00000     0.00000     0.05942    -0.08282    -0.00000
+          29    -0.00000     0.00000    -0.00000     0.00251    -0.08104    -0.00000
+          30    -0.05766     0.16013    -0.05764    -0.00000     0.00000    -0.08322
+          31    -0.00000    -0.00000    -0.00000    -0.03069     0.03030     0.00000
+          32    -0.00000     0.00000     0.00000     0.02870    -0.02384    -0.00000
+          33    -0.01339    -0.08997     0.12599    -0.00000     0.00000    -0.03636
           34    -0.00000     0.00000     0.00000    -0.03069    -0.03030    -0.00000
-          35    -0.00000    -0.00000    -0.00000     0.02870     0.02384     0.00000
-          36    -0.01339    -0.08997    -0.12599    -0.00000     0.00000     0.03636
-          37    -0.00000     0.00000    -0.00000    -0.05166     0.01289     0.00000
-          38    -0.00000    -0.00000     0.00000     0.11818     0.04826     0.00000
-          39    -0.11918     0.25122    -0.35623    -0.00000     0.00000    -0.25933
-          40    -0.00000     0.00000     0.00000    -0.05166    -0.01289    -0.00000
-          41    -0.00000    -0.00000    -0.00000     0.11818    -0.04826     0.00000
-          42    -0.11918    -0.25122    -0.35623    -0.00000     0.00000     0.25933
-          43    -0.00000     0.00000    -0.00000    -0.12655    -0.06658    -0.00000
-          44    -0.00000    -0.00000     0.00000    -0.05557    -0.11206    -0.00000
-          45     0.15095    -0.08982    -0.00428     0.00000    -0.00000    -0.02102
-          46    -0.00000     0.00000     0.00000    -0.12655     0.06658    -0.00000
-          47    -0.00000    -0.00000     0.00000    -0.05557     0.11206    -0.00000
-          48     0.15095     0.08982    -0.00428    -0.00000    -0.00000     0.02102
-          49    -0.00000     0.00000    -0.00000    -0.10888    -0.04633    -0.00000
+          35    -0.00000    -0.00000     0.00000     0.02870     0.02384     0.00000
+          36    -0.01339     0.08997     0.12599    -0.00000    -0.00000     0.03636
+          37    -0.00000    -0.00000    -0.00000    -0.05166     0.01289     0.00000
+          38    -0.00000     0.00000     0.00000     0.11818     0.04826     0.00000
+          39    -0.11918    -0.25122     0.35623    -0.00000     0.00000    -0.25933
+          40    -0.00000     0.00000    -0.00000    -0.05166    -0.01289    -0.00000
+          41    -0.00000    -0.00000     0.00000     0.11818    -0.04826    -0.00000
+          42    -0.11918     0.25122     0.35623    -0.00000    -0.00000     0.25933
+          43     0.00000    -0.00000    -0.00000    -0.12655    -0.06658    -0.00000
+          44    -0.00000    -0.00000    -0.00000    -0.05557    -0.11206    -0.00000
+          45     0.15095     0.08982     0.00428     0.00000    -0.00000    -0.02102
+          46    -0.00000     0.00000    -0.00000    -0.12655     0.06658     0.00000
+          47    -0.00000    -0.00000    -0.00000    -0.05557     0.11206     0.00000
+          48     0.15095    -0.08982     0.00428     0.00000    -0.00000     0.02102
+          49     0.00000    -0.00000    -0.00000    -0.10888    -0.04633     0.00000
           50    -0.00000    -0.00000    -0.00000    -0.15873    -0.22732    -0.00000
-          51     0.27573    -0.27841     0.24306     0.00000    -0.00000     0.20778
-          52    -0.00000     0.00000     0.00000    -0.10888     0.04633    -0.00000
-          53     0.00000    -0.00000     0.00000    -0.15873     0.22732    -0.00000
-          54     0.27573     0.27841     0.24306     0.00000    -0.00000    -0.20778
-          55    -0.00000     0.00000    -0.00000    -0.23087    -0.18385    -0.00000
-          56    -0.00000    -0.00000     0.00000    -0.02434    -0.07747    -0.00000
-          57     0.16993    -0.05957    -0.14359     0.00000     0.00000    -0.23349
-          58     0.00000     0.00000     0.00000    -0.23087     0.18385    -0.00000
-          59    -0.00000    -0.00000     0.00000    -0.02434     0.07747    -0.00000
-          60     0.16993     0.05957    -0.14359    -0.00000    -0.00000     0.23349
+          51     0.27573     0.27841    -0.24306     0.00000    -0.00000     0.20778
+          52    -0.00000     0.00000    -0.00000    -0.10888     0.04633     0.00000
+          53    -0.00000     0.00000    -0.00000    -0.15873     0.22732     0.00000
+          54     0.27573    -0.27841    -0.24306     0.00000     0.00000    -0.20778
+          55     0.00000    -0.00000    -0.00000    -0.23087    -0.18385    -0.00000
+          56    -0.00000    -0.00000    -0.00000    -0.02434    -0.07747    -0.00000
+          57     0.16993     0.05957     0.14359    -0.00000     0.00000    -0.23349
+          58    -0.00000     0.00000    -0.00000    -0.23087     0.18385     0.00000
+          59    -0.00000    -0.00000    -0.00000    -0.02434     0.07747     0.00000
+          60     0.16993    -0.05957     0.14359    -0.00000    -0.00000     0.23349
 
                    13          14          15          16          17          18
  
  Frequency        407.92      424.39      468.98      487.93      578.92      657.87
  
-           1     0.06233     0.00000    -0.00000    -0.02307     0.03797    -0.00000
-           2     0.06102     0.00000     0.00000     0.03327    -0.06916    -0.00000
-           3    -0.00000     0.01084     0.13222    -0.00000     0.00000     0.02736
+           1     0.06233     0.00000     0.00000    -0.02307     0.03797    -0.00000
+           2     0.06102     0.00000    -0.00000     0.03327    -0.06916    -0.00000
+           3    -0.00000     0.01084     0.13222     0.00000    -0.00000     0.02736
            4    -0.06233    -0.00000     0.00000    -0.02307    -0.03797     0.00000
-           5    -0.06102    -0.00000    -0.00000     0.03327     0.06916    -0.00000
-           6    -0.00000     0.01084     0.13222    -0.00000     0.00000    -0.02736
-           7     0.00252    -0.00000    -0.00000    -0.04171     0.07931    -0.00000
-           8    -0.02401    -0.00000     0.00000     0.04783    -0.03825    -0.00000
-           9    -0.00000     0.12087    -0.06190     0.00000    -0.00000    -0.08228
+           5    -0.06102    -0.00000    -0.00000     0.03327     0.06916     0.00000
+           6    -0.00000     0.01084     0.13222     0.00000    -0.00000    -0.02736
+           7     0.00252     0.00000     0.00000    -0.04171     0.07931    -0.00000
+           8    -0.02401    -0.00000    -0.00000     0.04783    -0.03825    -0.00000
+           9    -0.00000     0.12087    -0.06190    -0.00000    -0.00000    -0.08228
           10    -0.00252     0.00000     0.00000    -0.04171    -0.07931     0.00000
-          11     0.02401     0.00000     0.00000     0.04783     0.03825     0.00000
-          12    -0.00000     0.12087    -0.06190     0.00000    -0.00000     0.08228
-          13    -0.07035    -0.00000    -0.00000    -0.04286    -0.01392     0.00000
-          14    -0.02928    -0.00000     0.00000     0.05698    -0.01297    -0.00000
-          15     0.00000    -0.12494    -0.03989     0.00000     0.00000     0.07877
-          16     0.07035     0.00000    -0.00000    -0.04286     0.01392    -0.00000
-          17     0.02928     0.00000     0.00000     0.05698     0.01297     0.00000
+          11     0.02401     0.00000    -0.00000     0.04783     0.03825     0.00000
+          12    -0.00000     0.12087    -0.06190    -0.00000    -0.00000     0.08228
+          13    -0.07035    -0.00000     0.00000    -0.04286    -0.01392     0.00000
+          14    -0.02928    -0.00000    -0.00000     0.05698    -0.01297    -0.00000
+          15     0.00000    -0.12494    -0.03989    -0.00000     0.00000     0.07877
+          16     0.07035     0.00000     0.00000    -0.04286     0.01392    -0.00000
+          17     0.02928     0.00000    -0.00000     0.05698     0.01297     0.00000
           18     0.00000    -0.12494    -0.03989    -0.00000     0.00000    -0.07877
-          19     0.03779     0.00000    -0.00000    -0.04590     0.08497    -0.00000
-          20    -0.11570    -0.00000     0.00000     0.05444    -0.05171    -0.00000
-          21    -0.00000     0.23241    -0.22743     0.00000    -0.00000    -0.11226
-          22    -0.03779     0.00000     0.00000    -0.04590    -0.08497     0.00000
+          19     0.03779     0.00000     0.00000    -0.04590     0.08497    -0.00000
+          20    -0.11570    -0.00000    -0.00000     0.05444    -0.05171    -0.00000
+          21    -0.00000     0.23241    -0.22743    -0.00000    -0.00000    -0.11226
+          22    -0.03779    -0.00000     0.00000    -0.04590    -0.08497     0.00000
           23     0.11570     0.00000    -0.00000     0.05444     0.05171     0.00000
-          24    -0.00000     0.23241    -0.22743     0.00000    -0.00000     0.11226
-          25    -0.07248     0.00000     0.00000    -0.04412    -0.09398     0.00000
-          26    -0.03305    -0.00000     0.00000     0.05565    -0.11018    -0.00000
-          27     0.00000    -0.28134    -0.19195     0.00000     0.00000     0.13474
-          28     0.07248     0.00000    -0.00000    -0.04412     0.09398    -0.00000
+          24    -0.00000     0.23241    -0.22743    -0.00000    -0.00000     0.11226
+          25    -0.07248    -0.00000     0.00000    -0.04412    -0.09398     0.00000
+          26    -0.03305    -0.00000    -0.00000     0.05565    -0.11018    -0.00000
+          27     0.00000    -0.28134    -0.19195    -0.00000     0.00000     0.13474
+          28     0.07248     0.00000     0.00000    -0.04412     0.09398    -0.00000
           29     0.03305     0.00000    -0.00000     0.05565     0.11018     0.00000
-          30     0.00000    -0.28134    -0.19195     0.00000     0.00000    -0.13474
-          31     0.00243     0.00000     0.00000     0.09736     0.10217     0.00000
+          30     0.00000    -0.28134    -0.19195    -0.00000     0.00000    -0.13474
+          31     0.00243     0.00000    -0.00000     0.09736     0.10217     0.00000
           32    -0.11048    -0.00000    -0.00000    -0.01407     0.05567     0.00000
-          33    -0.00000    -0.00253     0.04259    -0.00000     0.00000    -0.09644
-          34    -0.00243    -0.00000     0.00000     0.09736    -0.10217    -0.00000
-          35     0.11048     0.00000    -0.00000    -0.01407    -0.05567     0.00000
-          36     0.00000    -0.00253     0.04259     0.00000     0.00000     0.09644
-          37     0.01267     0.00000     0.00000     0.09900     0.10803     0.00000
-          38    -0.16285    -0.00000    -0.00000    -0.02943     0.02986     0.00000
-          39    -0.00000    -0.01385    -0.13640     0.00000     0.00000     0.13055
-          40    -0.01267    -0.00000     0.00000     0.09900    -0.10803    -0.00000
-          41     0.16285     0.00000    -0.00000    -0.02943    -0.02986     0.00000
-          42     0.00000    -0.01385    -0.13640     0.00000     0.00000    -0.13055
+          33    -0.00000    -0.00253     0.04259     0.00000    -0.00000    -0.09644
+          34    -0.00243    -0.00000    -0.00000     0.09736    -0.10217    -0.00000
+          35     0.11048     0.00000     0.00000    -0.01407    -0.05567    -0.00000
+          36     0.00000    -0.00253     0.04259     0.00000    -0.00000     0.09644
+          37     0.01267     0.00000    -0.00000     0.09900     0.10803     0.00000
+          38    -0.16285    -0.00000     0.00000    -0.02943     0.02986    -0.00000
+          39     0.00000    -0.01385    -0.13640    -0.00000     0.00000     0.13055
+          40    -0.01267    -0.00000    -0.00000     0.09900    -0.10803    -0.00000
+          41     0.16285     0.00000     0.00000    -0.02943    -0.02986    -0.00000
+          42     0.00000    -0.01385    -0.13640    -0.00000    -0.00000    -0.13055
           43     0.03932     0.00000    -0.00000     0.01768     0.01300     0.00000
-          44    -0.09043    -0.00000    -0.00000    -0.10304    -0.03511     0.00000
-          45    -0.00000     0.00074    -0.01871     0.00000    -0.00000     0.01639
-          46    -0.03932    -0.00000     0.00000     0.01768    -0.01300    -0.00000
-          47     0.09043     0.00000    -0.00000    -0.10304     0.03511     0.00000
-          48    -0.00000     0.00074    -0.01871     0.00000    -0.00000    -0.01639
-          49     0.03611     0.00000     0.00000     0.04793     0.04988     0.00000
-          50    -0.06588    -0.00000    -0.00000    -0.27471    -0.25315    -0.00000
-          51    -0.00000     0.02871     0.16236    -0.00000    -0.00000    -0.20851
-          52    -0.03611    -0.00000     0.00000     0.04793    -0.04988    -0.00000
-          53     0.06588     0.00000    -0.00000    -0.27471     0.25315     0.00000
-          54    -0.00000     0.02871     0.16236    -0.00000    -0.00000     0.20851
-          55     0.06843    -0.00000    -0.00000    -0.14510    -0.19200    -0.00000
-          56    -0.10050    -0.00000    -0.00000    -0.05619     0.02532     0.00000
-          57     0.00000    -0.02539    -0.25321     0.00000     0.00000     0.35709
-          58    -0.06843     0.00000    -0.00000    -0.14510     0.19200     0.00000
-          59     0.10050     0.00000    -0.00000    -0.05619    -0.02532     0.00000
-          60    -0.00000    -0.02539    -0.25321     0.00000     0.00000    -0.35709
+          44    -0.09043    -0.00000     0.00000    -0.10304    -0.03511    -0.00000
+          45     0.00000     0.00074    -0.01871    -0.00000    -0.00000     0.01639
+          46    -0.03932    -0.00000    -0.00000     0.01768    -0.01300    -0.00000
+          47     0.09043     0.00000     0.00000    -0.10304     0.03511    -0.00000
+          48     0.00000     0.00074    -0.01871     0.00000    -0.00000    -0.01639
+          49     0.03611     0.00000    -0.00000     0.04793     0.04988     0.00000
+          50    -0.06588    -0.00000     0.00000    -0.27471    -0.25315    -0.00000
+          51    -0.00000     0.02871     0.16236     0.00000    -0.00000    -0.20851
+          52    -0.03611    -0.00000    -0.00000     0.04793    -0.04988    -0.00000
+          53     0.06588     0.00000     0.00000    -0.27471     0.25315     0.00000
+          54    -0.00000     0.02871     0.16236     0.00000    -0.00000     0.20851
+          55     0.06843     0.00000     0.00000    -0.14510    -0.19200    -0.00000
+          56    -0.10050    -0.00000     0.00000    -0.05619     0.02532    -0.00000
+          57     0.00000    -0.02539    -0.25321    -0.00000     0.00000     0.35709
+          58    -0.06843    -0.00000     0.00000    -0.14510     0.19200     0.00000
+          59     0.10050     0.00000     0.00000    -0.05619    -0.02532    -0.00000
+          60     0.00000    -0.02539    -0.25321    -0.00000     0.00000    -0.35709
 
                    19          20          21          22          23          24
  
  Frequency        673.47      707.33      735.12      810.69      862.51      893.98
  
-           1    -0.04040    -0.00000     0.00161    -0.00000    -0.00735     0.00000
-           2    -0.00027    -0.00000     0.01015    -0.00000    -0.03625    -0.00000
-           3     0.00000    -0.06850     0.00000    -0.14256     0.00000    -0.00213
-           4     0.04040     0.00000     0.00161     0.00000     0.00735     0.00000
-           5     0.00027     0.00000     0.01015    -0.00000     0.03625     0.00000
-           6     0.00000    -0.06850     0.00000     0.14256     0.00000     0.00213
-           7    -0.08893     0.00000    -0.03821     0.00000     0.11601     0.00000
-           8    -0.09855    -0.00000    -0.07523    -0.00000     0.00186     0.00000
-           9     0.00000    -0.01327     0.00000     0.05829    -0.00000    -0.06359
-          10     0.08893    -0.00000    -0.03821     0.00000    -0.11601    -0.00000
-          11     0.09855    -0.00000    -0.07523    -0.00000    -0.00186     0.00000
-          12    -0.00000    -0.01327    -0.00000    -0.05829    -0.00000     0.06359
+           1    -0.04040    -0.00000     0.00161    -0.00000    -0.00735    -0.00000
+           2    -0.00027     0.00000     0.01015     0.00000    -0.03625    -0.00000
+           3     0.00000     0.06850    -0.00000    -0.14256    -0.00000    -0.00213
+           4     0.04040     0.00000     0.00161     0.00000     0.00735    -0.00000
+           5     0.00027     0.00000     0.01015     0.00000     0.03625     0.00000
+           6     0.00000     0.06850    -0.00000     0.14256    -0.00000     0.00213
+           7    -0.08893    -0.00000    -0.03821    -0.00000     0.11601     0.00000
+           8    -0.09855    -0.00000    -0.07523    -0.00000     0.00186    -0.00000
+           9     0.00000     0.01327     0.00000     0.05829     0.00000    -0.06359
+          10     0.08893     0.00000    -0.03821     0.00000    -0.11601    -0.00000
+          11     0.09855    -0.00000    -0.07523    -0.00000    -0.00186    -0.00000
+          12    -0.00000     0.01327     0.00000    -0.05829    -0.00000     0.06359
           13     0.06162     0.00000    -0.01410     0.00000     0.11777     0.00000
           14    -0.12263    -0.00000    -0.07363    -0.00000    -0.03435    -0.00000
-          15     0.00000    -0.01708    -0.00000    -0.05684     0.00000    -0.07062
+          15    -0.00000     0.01708    -0.00000    -0.05684     0.00000    -0.07062
           16    -0.06162    -0.00000    -0.01410    -0.00000    -0.11777    -0.00000
-          17     0.12263    -0.00000    -0.07363     0.00000     0.03435     0.00000
-          18     0.00000    -0.01708    -0.00000     0.05684    -0.00000     0.07062
-          19    -0.10491     0.00000    -0.01933    -0.00000     0.08785     0.00000
-          20    -0.05681    -0.00000    -0.12589    -0.00000     0.09835     0.00000
-          21    -0.00000     0.25586    -0.00000     0.15511    -0.00000     0.43162
-          22     0.10491    -0.00000    -0.01933     0.00000    -0.08785     0.00000
+          17     0.12263     0.00000    -0.07363     0.00000     0.03435    -0.00000
+          18     0.00000     0.01708    -0.00000     0.05684     0.00000     0.07062
+          19    -0.10491    -0.00000    -0.01933    -0.00000     0.08785     0.00000
+          20    -0.05681    -0.00000    -0.12589     0.00000     0.09835     0.00000
+          21     0.00000    -0.25586     0.00000     0.15511    -0.00000     0.43162
+          22     0.10491     0.00000    -0.01933     0.00000    -0.08785     0.00000
           23     0.05681    -0.00000    -0.12589    -0.00000    -0.09835    -0.00000
-          24    -0.00000     0.25586     0.00000    -0.15511     0.00000    -0.43162
-          25     0.08399    -0.00000    -0.04801     0.00000     0.07287    -0.00000
+          24     0.00000    -0.25586     0.00000    -0.15511     0.00000    -0.43162
+          25     0.08399     0.00000    -0.04801     0.00000     0.07287    -0.00000
           26    -0.09557    -0.00000    -0.11191    -0.00000    -0.10063    -0.00000
-          27     0.00000     0.25282    -0.00000    -0.15507    -0.00000     0.44923
-          28    -0.08399    -0.00000    -0.04801     0.00000    -0.07287    -0.00000
-          29     0.09557     0.00000    -0.11191     0.00000     0.10063    -0.00000
-          30     0.00000     0.25282    -0.00000     0.15507     0.00000    -0.44923
-          31     0.02095     0.00000     0.07198     0.00000    -0.03707    -0.00000
-          32     0.00441     0.00000     0.10255     0.00000    -0.05193    -0.00000
-          33     0.00000     0.09532    -0.00000    -0.06774    -0.00000    -0.00046
-          34    -0.02095    -0.00000     0.07198     0.00000     0.03707     0.00000
+          27    -0.00000    -0.25282    -0.00000    -0.15507    -0.00000     0.44923
+          28    -0.08399    -0.00000    -0.04801    -0.00000    -0.07287    -0.00000
+          29     0.09557    -0.00000    -0.11191    -0.00000     0.10063    -0.00000
+          30     0.00000    -0.25282    -0.00000     0.15507     0.00000    -0.44923
+          31     0.02095     0.00000     0.07198    -0.00000    -0.03707     0.00000
+          32     0.00441     0.00000     0.10255    -0.00000    -0.05193    -0.00000
+          33     0.00000    -0.09532     0.00000    -0.06774     0.00000    -0.00046
+          34    -0.02095     0.00000     0.07198     0.00000     0.03707     0.00000
           35    -0.00441     0.00000     0.10255     0.00000     0.05193     0.00000
-          36    -0.00000     0.09532    -0.00000     0.06774    -0.00000     0.00046
-          37     0.02192     0.00000     0.07556     0.00000    -0.04011    -0.00000
-          38     0.00030     0.00000     0.10592     0.00000    -0.05473    -0.00000
-          39    -0.00000    -0.14974     0.00000     0.08855     0.00000    -0.00102
-          40    -0.02192    -0.00000     0.07556     0.00000     0.04011     0.00000
+          36    -0.00000    -0.09532     0.00000     0.06774     0.00000     0.00046
+          37     0.02192     0.00000     0.07556    -0.00000    -0.04011     0.00000
+          38     0.00030     0.00000     0.10592     0.00000    -0.05473     0.00000
+          39    -0.00000     0.14974    -0.00000     0.08855    -0.00000    -0.00102
+          40    -0.02192     0.00000     0.07556     0.00000     0.04011     0.00000
           41    -0.00030     0.00000     0.10592     0.00000     0.05473     0.00000
-          42     0.00000    -0.14974     0.00000    -0.08855     0.00000     0.00102
-          43     0.01521    -0.00000    -0.00669    -0.00000     0.00136    -0.00000
-          44    -0.00833    -0.00000     0.05019     0.00000    -0.03528    -0.00000
-          45     0.00000    -0.01415    -0.00000     0.00631     0.00000     0.00157
+          42     0.00000     0.14974    -0.00000    -0.08855    -0.00000     0.00102
+          43     0.01521     0.00000    -0.00669     0.00000     0.00136    -0.00000
+          44    -0.00833     0.00000     0.05019     0.00000    -0.03528    -0.00000
+          45    -0.00000     0.01415    -0.00000     0.00631     0.00000     0.00157
           46    -0.01521    -0.00000    -0.00669    -0.00000    -0.00136    -0.00000
-          47     0.00833     0.00000     0.05019     0.00000     0.03528     0.00000
-          48     0.00000    -0.01415    -0.00000    -0.00631     0.00000    -0.00157
-          49     0.02124     0.00000     0.02469     0.00000    -0.02022    -0.00000
-          50    -0.04491    -0.00000    -0.14774    -0.00000     0.09895     0.00000
-          51     0.00000     0.20973     0.00000    -0.11597    -0.00000     0.01085
+          47     0.00833     0.00000     0.05019    -0.00000     0.03528     0.00000
+          48    -0.00000     0.01415    -0.00000    -0.00631     0.00000    -0.00157
+          49     0.02124     0.00000     0.02469    -0.00000    -0.02022    -0.00000
+          50    -0.04491    -0.00000    -0.14774     0.00000     0.09895     0.00000
+          51     0.00000    -0.20973     0.00000    -0.11597    -0.00000     0.01085
           52    -0.02124    -0.00000     0.02469    -0.00000     0.02022     0.00000
-          53     0.04491     0.00000    -0.14774    -0.00000    -0.09895    -0.00000
-          54    -0.00000     0.20973    -0.00000     0.11597    -0.00000    -0.01085
-          55    -0.01403    -0.00000    -0.20682    -0.00000     0.15090     0.00000
-          56     0.00015     0.00000     0.11207     0.00000    -0.08152    -0.00000
-          57    -0.00000    -0.35822     0.00000     0.22519    -0.00000    -0.01649
-          58     0.01403    -0.00000    -0.20682    -0.00000    -0.15090    -0.00000
+          53     0.04491    -0.00000    -0.14774    -0.00000    -0.09895    -0.00000
+          54    -0.00000    -0.20973     0.00000     0.11597    -0.00000    -0.01085
+          55    -0.01403    -0.00000    -0.20682     0.00000     0.15090     0.00000
+          56     0.00015     0.00000     0.11207    -0.00000    -0.08152    -0.00000
+          57    -0.00000     0.35822    -0.00000     0.22519    -0.00000    -0.01649
+          58     0.01403    -0.00000    -0.20682     0.00000    -0.15090    -0.00000
           59    -0.00015     0.00000     0.11207     0.00000     0.08152     0.00000
-          60     0.00000    -0.35822     0.00000    -0.22519    -0.00000     0.01649
+          60     0.00000     0.35822    -0.00000    -0.22519    -0.00000     0.01649
 
                    25          26          27          28          29          30
  
  Frequency        896.43      980.87      980.98     1017.89     1036.48     1073.56
  
-           1     0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00790
-           2    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.02569
-           3    -0.09617    -0.00352    -0.00464     0.01792     0.00053    -0.00000
-           4    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00790
-           5     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.02569
-           6    -0.09617     0.00352    -0.00464    -0.01792     0.00053    -0.00000
-           7     0.00000     0.00000     0.00000     0.00000    -0.00000     0.12357
-           8    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00034
-           9     0.05631    -0.00011    -0.00041    -0.06703    -0.07538    -0.00000
-          10    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.12357
-          11     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00034
-          12     0.05631     0.00011    -0.00041     0.06703    -0.07538    -0.00000
-          13     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.11040
-          14    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.03538
-          15     0.06224     0.00087     0.00351     0.06477     0.07373     0.00000
-          16    -0.00000    -0.00000    -0.00000    -0.00000     0.00000    -0.11040
-          17     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.03538
-          18     0.06224    -0.00087     0.00351    -0.06477     0.07373     0.00000
+           1     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00790
+           2    -0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.02569
+           3     0.09617    -0.00352    -0.00464     0.01792    -0.00053    -0.00000
+           4     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.00790
+           5     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.02569
+           6     0.09617     0.00352    -0.00464    -0.01792    -0.00053    -0.00000
+           7     0.00000     0.00000     0.00000     0.00000     0.00000     0.12357
+           8    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00034
+           9    -0.05631    -0.00011    -0.00041    -0.06703     0.07538     0.00000
+          10    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.12357
+          11    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00034
+          12    -0.05631     0.00011    -0.00041     0.06703     0.07538    -0.00000
+          13     0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.11040
+          14     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.03538
+          15    -0.06224     0.00087     0.00351     0.06477    -0.07373     0.00000
+          16    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.11040
+          17    -0.00000    -0.00000     0.00000     0.00000     0.00000     0.03538
+          18    -0.06224    -0.00087     0.00351    -0.06477    -0.07373     0.00000
           19     0.00000     0.00000     0.00000     0.00000    -0.00000     0.18868
-          20     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.15968
-          21    -0.34857     0.00224     0.00597     0.45182     0.43580    -0.00000
-          22    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.18868
-          23    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.15968
-          24    -0.34857    -0.00224     0.00597    -0.45182     0.43580     0.00000
-          25     0.00000     0.00000     0.00000    -0.00000     0.00000    -0.23832
-          26    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.11368
-          27    -0.35803    -0.01067    -0.01853    -0.42623    -0.41633    -0.00000
-          28    -0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.23832
-          29     0.00000     0.00000     0.00000     0.00000     0.00000    -0.11368
-          30    -0.35803     0.01067    -0.01853     0.42623    -0.41633    -0.00000
-          31    -0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00306
-          32    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00131
-          33     0.04810    -0.03547     0.03601     0.00985    -0.00064    -0.00000
-          34    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.00306
+          20    -0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.15968
+          21     0.34857     0.00224     0.00597     0.45182    -0.43580    -0.00000
+          22    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.18868
+          23    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.15968
+          24     0.34857    -0.00224     0.00597    -0.45182    -0.43580     0.00000
+          25    -0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.23832
+          26    -0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.11368
+          27     0.35803    -0.01067    -0.01853    -0.42623     0.41633     0.00000
+          28    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.23832
+          29     0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.11368
+          30     0.35803     0.01067    -0.01853     0.42623     0.41633    -0.00000
+          31    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00306
+          32    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00131
+          33    -0.04810    -0.03547     0.03601     0.00985     0.00064     0.00000
+          34     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00306
           35     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00131
-          36     0.04810     0.03547     0.03601    -0.00985    -0.00064     0.00000
-          37     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00224
-          38    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.02106
-          39    -0.02853     0.01368    -0.01384     0.02069    -0.00305     0.00000
-          40     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00224
-          41    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.02106
-          42    -0.02853    -0.01368    -0.01384    -0.02069    -0.00305    -0.00000
-          43     0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00627
-          44    -0.00000     0.00000     0.00000     0.00000     0.00000     0.01722
-          45    -0.00157     0.10289    -0.10289    -0.00161     0.00247     0.00000
-          46    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00627
-          47     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.01722
-          48    -0.00157    -0.10289    -0.10289     0.00161     0.00247     0.00000
-          49     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.01791
-          50    -0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.05605
-          51     0.05827    -0.42437     0.42436     0.02614    -0.01922     0.00000
-          52     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.01791
-          53    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.05605
-          54     0.05827     0.42439     0.42434    -0.02614    -0.01922    -0.00000
-          55    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.07140
-          56    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.04148
-          57    -0.14367    -0.41774     0.41664    -0.02724    -0.00556    -0.00000
-          58    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.07140
-          59     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.04148
-          60    -0.14367     0.41776     0.41662     0.02724    -0.00556     0.00000
+          36    -0.04810     0.03547     0.03601    -0.00985     0.00064     0.00000
+          37    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00224
+          38    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.02106
+          39     0.02853     0.01368    -0.01384     0.02069     0.00305    -0.00000
+          40     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00224
+          41     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.02106
+          42     0.02853    -0.01368    -0.01384    -0.02069     0.00305    -0.00000
+          43    -0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00627
+          44    -0.00000    -0.00000     0.00000    -0.00000     0.00000     0.01722
+          45     0.00157     0.10289    -0.10289    -0.00161    -0.00247    -0.00000
+          46    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00627
+          47     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.01722
+          48     0.00157    -0.10289    -0.10289     0.00161    -0.00247    -0.00000
+          49    -0.00000    -0.00000     0.00000    -0.00000     0.00000     0.01791
+          50     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.05605
+          51    -0.05827    -0.42439     0.42434     0.02614     0.01922     0.00000
+          52     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.01791
+          53    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.05605
+          54    -0.05827     0.42437     0.42436    -0.02614     0.01922     0.00000
+          55     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.07140
+          56    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.04148
+          57     0.14367    -0.41776     0.41662    -0.02724     0.00556     0.00000
+          58    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.07140
+          59     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.04148
+          60     0.14367     0.41774     0.41664     0.02724     0.00556     0.00000
 
                    31          32          33          34          35          36
  
@@ -1263,64 +2020,64 @@ Iterative solution of linear equations
  
            1     0.04695     0.00000     0.00000     0.01907    -0.02863    -0.00344
            2     0.02536     0.00000     0.00000     0.05340     0.04211    -0.06549
-           3    -0.00000     0.00087     0.00189    -0.00000    -0.00000    -0.00000
-           4     0.04695    -0.00000     0.00000    -0.01907    -0.02863     0.00344
-           5     0.02536    -0.00000     0.00000    -0.05340     0.04211     0.06549
-           6     0.00000     0.00087    -0.00189    -0.00000    -0.00000    -0.00000
-           7    -0.02101     0.00000    -0.00000     0.01975     0.02729    -0.03669
-           8    -0.01933     0.00000    -0.00000     0.02742     0.04694     0.02375
-           9     0.00000     0.00297     0.00254    -0.00000     0.00000     0.00000
+           3     0.00000    -0.00087     0.00189     0.00000     0.00000     0.00000
+           4     0.04695     0.00000    -0.00000    -0.01907    -0.02863     0.00344
+           5     0.02536    -0.00000    -0.00000    -0.05340     0.04211     0.06549
+           6     0.00000    -0.00087    -0.00189     0.00000    -0.00000    -0.00000
+           7    -0.02101     0.00000     0.00000     0.01975     0.02729    -0.03669
+           8    -0.01933     0.00000     0.00000     0.02742     0.04694     0.02375
+           9     0.00000    -0.00297     0.00254     0.00000     0.00000    -0.00000
           10    -0.02101    -0.00000    -0.00000    -0.01975     0.02729     0.03669
           11    -0.01933    -0.00000    -0.00000    -0.02742     0.04694    -0.02375
-          12     0.00000     0.00297    -0.00254    -0.00000    -0.00000    -0.00000
-          13    -0.04801     0.00000    -0.00000     0.03976     0.01627    -0.03140
-          14     0.00569    -0.00000     0.00000    -0.01821    -0.07108    -0.00831
-          15    -0.00000    -0.00308     0.00218     0.00000     0.00000    -0.00000
+          12     0.00000    -0.00297    -0.00254     0.00000    -0.00000    -0.00000
+          13    -0.04801     0.00000     0.00000     0.03976     0.01627    -0.03140
+          14     0.00569    -0.00000    -0.00000    -0.01821    -0.07108    -0.00831
+          15    -0.00000     0.00308     0.00218    -0.00000    -0.00000     0.00000
           16    -0.04801    -0.00000    -0.00000    -0.03976     0.01627     0.03140
           17     0.00569     0.00000     0.00000     0.01821    -0.07108     0.00831
-          18    -0.00000    -0.00308    -0.00218     0.00000    -0.00000     0.00000
+          18    -0.00000     0.00308    -0.00218    -0.00000    -0.00000     0.00000
           19     0.03412     0.00000     0.00000     0.01344    -0.06977    -0.18951
-          20    -0.17692     0.00000    -0.00000     0.05642     0.33449     0.42650
-          21    -0.00000    -0.00462    -0.02532    -0.00000    -0.00000    -0.00000
-          22     0.03412    -0.00000     0.00000    -0.01344    -0.06977     0.18951
+          20    -0.17692    -0.00000     0.00000     0.05642     0.33449     0.42650
+          21    -0.00000     0.00462    -0.02532     0.00000    -0.00000    -0.00000
+          22     0.03412     0.00000    -0.00000    -0.01344    -0.06977     0.18951
           23    -0.17692    -0.00000    -0.00000    -0.05642     0.33449    -0.42650
-          24    -0.00000    -0.00462     0.02532    -0.00000    -0.00000    -0.00000
-          25    -0.05561     0.00000    -0.00000     0.08425    -0.24895    -0.27168
+          24    -0.00000     0.00462     0.02532    -0.00000     0.00000     0.00000
+          25    -0.05561     0.00000     0.00000     0.08425    -0.24895    -0.27168
           26     0.00502     0.00000     0.00000     0.02707    -0.40591    -0.29756
-          27    -0.00000    -0.00364     0.01729     0.00000    -0.00000     0.00000
+          27     0.00000     0.00364     0.01729     0.00000     0.00000    -0.00000
           28    -0.05561    -0.00000    -0.00000    -0.08425    -0.24895     0.27168
           29     0.00502    -0.00000     0.00000    -0.02707    -0.40591     0.29756
-          30     0.00000    -0.00364    -0.01729     0.00000     0.00000     0.00000
-          31     0.04504    -0.00000     0.00000    -0.04318     0.00748    -0.02481
-          32     0.02723    -0.00000     0.00000    -0.02354     0.00840    -0.02169
-          33     0.00000     0.05838    -0.05888    -0.00000    -0.00000     0.00000
+          30    -0.00000     0.00364    -0.01729    -0.00000     0.00000     0.00000
+          31     0.04504    -0.00000    -0.00000    -0.04318     0.00748    -0.02481
+          32     0.02723    -0.00000    -0.00000    -0.02354     0.00840    -0.02169
+          33     0.00000    -0.05838    -0.05888     0.00000    -0.00000     0.00000
           34     0.04504     0.00000     0.00000     0.04318     0.00748     0.02481
           35     0.02723     0.00000     0.00000     0.02354     0.00840     0.02169
-          36    -0.00000     0.05838     0.05888    -0.00000     0.00000     0.00000
-          37    -0.01470     0.00000    -0.00000     0.01435     0.00167    -0.00836
-          38     0.29024    -0.00000     0.00000    -0.27122     0.02886    -0.11095
-          39    -0.00000    -0.55235     0.55189     0.00000     0.00000     0.00000
+          36     0.00000    -0.05838     0.05888     0.00000    -0.00000     0.00000
+          37    -0.01470     0.00000     0.00000     0.01435     0.00167    -0.00836
+          38     0.29024    -0.00000    -0.00000    -0.27122     0.02886    -0.11095
+          39    -0.00000     0.55236     0.55188    -0.00000     0.00000     0.00000
           40    -0.01470    -0.00000    -0.00000    -0.01435     0.00167     0.00836
           41     0.29024     0.00000     0.00000     0.27122     0.02886     0.11095
-          42     0.00000    -0.55235    -0.55189     0.00000     0.00000    -0.00000
-          43    -0.03775     0.00000    -0.00000     0.03461    -0.00346     0.00810
-          44    -0.05944     0.00000    -0.00000     0.07151    -0.02144    -0.00126
-          45    -0.00000    -0.00480     0.00489     0.00000    -0.00000    -0.00000
+          42    -0.00000     0.55235    -0.55189    -0.00000     0.00000     0.00000
+          43    -0.03775     0.00000     0.00000     0.03461    -0.00346     0.00810
+          44    -0.05944     0.00000     0.00000     0.07151    -0.02144    -0.00126
+          45    -0.00000     0.00480     0.00489     0.00000    -0.00000    -0.00000
           46    -0.03775    -0.00000    -0.00000    -0.03461    -0.00346    -0.00810
           47    -0.05944    -0.00000    -0.00000    -0.07151    -0.02144     0.00126
-          48     0.00000    -0.00480    -0.00489     0.00000    -0.00000    -0.00000
-          49    -0.09351     0.00000    -0.00000     0.09074    -0.01214     0.01809
-          50     0.28921    -0.00000     0.00000    -0.28513     0.03879    -0.05437
-          51    -0.00000    -0.31353     0.31252     0.00000     0.00000     0.00000
+          48     0.00000     0.00480    -0.00489     0.00000    -0.00000    -0.00000
+          49    -0.09351     0.00000     0.00000     0.09074    -0.01214     0.01809
+          50     0.28921    -0.00000    -0.00000    -0.28513     0.03879    -0.05437
+          51    -0.00000     0.31354     0.31252    -0.00000     0.00000     0.00000
           52    -0.09351    -0.00000    -0.00000    -0.09074    -0.01214    -0.01809
           53     0.28921     0.00000     0.00000     0.28513     0.03879     0.05437
-          54     0.00000    -0.31353    -0.31252     0.00000     0.00000     0.00000
-          55     0.30578    -0.00000     0.00000    -0.33075     0.10345     0.00611
-          56    -0.16347     0.00000    -0.00000     0.18341    -0.05499    -0.00223
-          57     0.00000     0.22715    -0.22625    -0.00000     0.00000     0.00000
+          54    -0.00000     0.31353    -0.31252    -0.00000     0.00000     0.00000
+          55     0.30578    -0.00000    -0.00000    -0.33075     0.10345     0.00611
+          56    -0.16347     0.00000     0.00000     0.18341    -0.05499    -0.00223
+          57     0.00000    -0.22715    -0.22625     0.00000     0.00000     0.00000
           58     0.30578     0.00000     0.00000     0.33075     0.10345    -0.00611
           59    -0.16347    -0.00000    -0.00000    -0.18341    -0.05499     0.00223
-          60    -0.00000     0.22715     0.22625    -0.00000     0.00000     0.00000
+          60     0.00000    -0.22715     0.22625     0.00000     0.00000     0.00000
 
                    37          38          39          40          41          42
  
@@ -1328,259 +2085,259 @@ Iterative solution of linear equations
  
            1    -0.04121     0.00126     0.12417    -0.07796     0.01964     0.04504
            2     0.12978    -0.12804     0.03521    -0.01087    -0.01047    -0.00154
-           3     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+           3     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
            4    -0.04121    -0.00126     0.12417     0.07796     0.01964    -0.04504
            5     0.12978     0.12804     0.03521     0.01087    -0.01047     0.00154
-           6     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+           6    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
            7     0.00047    -0.03753    -0.05352    -0.00610     0.00048     0.01030
            8    -0.04829    -0.05690     0.08213     0.01245     0.02855    -0.01862
            9    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
           10     0.00047     0.03753    -0.05352     0.00610     0.00048    -0.01030
           11    -0.04829     0.05690     0.08213    -0.01245     0.02855     0.01862
-          12    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+          12    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
           13     0.05548     0.00312    -0.04646     0.01128    -0.01627    -0.01265
           14     0.01802     0.07015    -0.06652     0.03349    -0.02299    -0.01380
-          15     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          15     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           16     0.05548    -0.00312    -0.04646    -0.01128    -0.01627     0.01265
           17     0.01802    -0.07015    -0.06652    -0.03349    -0.02299     0.01380
-          18    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          18     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           19     0.10585    -0.03061     0.03565     0.12124     0.01548    -0.07875
           20    -0.32492    -0.11288    -0.16310    -0.33260    -0.00676     0.22426
-          21     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+          21     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
           22     0.10585     0.03061     0.03565    -0.12124     0.01548     0.07875
           23    -0.32492     0.11288    -0.16310     0.33260    -0.00676    -0.22426
-          24     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00000
+          24     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           25    -0.06399     0.12498    -0.03794    -0.23106     0.02576     0.14481
           26    -0.12729     0.23416    -0.05327    -0.25731     0.02695     0.17713
-          27    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          27     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
           28    -0.06399    -0.12498    -0.03794     0.23106     0.02576    -0.14481
           29    -0.12729    -0.23416    -0.05327     0.25731     0.02695    -0.17713
-          30    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          30     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
           31    -0.02903    -0.04530    -0.04595    -0.05229     0.06164    -0.04614
           32    -0.01723    -0.03078    -0.03339    -0.02815     0.01096    -0.00036
-          33    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
+          33     0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
           34    -0.02903     0.04530    -0.04595     0.05229     0.06164     0.04614
           35    -0.01723     0.03078    -0.03339     0.02815     0.01096     0.00036
-          36    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          36    -0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
           37     0.00841    -0.00843    -0.04728    -0.11330     0.18734    -0.15748
           38    -0.21089    -0.22644    -0.04891     0.21076    -0.48958     0.44375
-          39    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          39    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
           40     0.00841     0.00843    -0.04728     0.11330     0.18734     0.15748
           41    -0.21089     0.22644    -0.04891    -0.21076    -0.48958    -0.44375
-          42     0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
+          42     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
           43     0.00426     0.01683     0.02584     0.04321    -0.07098     0.06153
           44    -0.01942    -0.01485     0.01209     0.00816     0.01040    -0.01490
-          45     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          45    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
           46     0.00426    -0.01683     0.02584    -0.04321    -0.07098    -0.06153
           47    -0.01942     0.01485     0.01209    -0.00816     0.01040     0.01490
-          48    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
+          48    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
           49     0.01091     0.03264     0.04981     0.07900    -0.12421     0.10457
           50    -0.04585    -0.09142    -0.11905    -0.17606     0.26384    -0.21461
-          51    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          51     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           52     0.01091    -0.03264     0.04981    -0.07900    -0.12421    -0.10457
           53    -0.04585     0.09142    -0.11905     0.17606     0.26384     0.21461
-          54     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          54     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           55     0.05818     0.00433    -0.04882    -0.01595    -0.03896     0.03857
           56    -0.03966    -0.01588     0.03266     0.02235     0.00981    -0.01628
-          57    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          57     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           58     0.05818    -0.00433    -0.04882     0.01595    -0.03896    -0.03857
           59    -0.03966     0.01588     0.03266    -0.02235     0.00981     0.01628
-          60     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          60     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
 
                    43          44          45          46          47          48
  
  Frequency       1514.55     1565.51     1575.25     1639.67     1690.89     1738.51
  
-           1    -0.08527     0.01922     0.03916     0.02450    -0.13387    -0.00455
-           2     0.00349     0.02693    -0.01785     0.10213     0.01394    -0.08069
-           3    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
-           4    -0.08527    -0.01922     0.03916     0.02450     0.13387     0.00455
-           5     0.00349    -0.02693    -0.01785     0.10213    -0.01394     0.08069
-           6    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
-           7     0.04360    -0.01123    -0.00023     0.05014     0.07415    -0.01531
-           8     0.07878     0.02451    -0.03521    -0.07383    -0.05240     0.12506
-           9     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
-          10     0.04360     0.01123    -0.00023     0.05014    -0.07415     0.01531
-          11     0.07878    -0.02451    -0.03521    -0.07383     0.05240    -0.12506
-          12    -0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
-          13    -0.00985     0.01485    -0.02100    -0.07262    -0.09009    -0.04485
-          14    -0.09862    -0.00336     0.02237    -0.04321    -0.02881    -0.11056
-          15     0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-          16    -0.00985    -0.01485    -0.02100    -0.07262     0.09009     0.04485
-          17    -0.09862     0.00336     0.02237    -0.04321     0.02881     0.11056
-          18     0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-          19     0.14080     0.01369    -0.06086    -0.07316     0.01804     0.08717
-          20    -0.14093    -0.04284     0.11833     0.28373     0.12911    -0.13563
-          21    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
-          22     0.14080    -0.01369    -0.06086    -0.07316    -0.01804    -0.08717
-          23    -0.14094     0.04284     0.11833     0.28373    -0.12911     0.13563
-          24     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          25     0.24353    -0.00265    -0.01876     0.14395     0.03694     0.12753
-          26     0.19038    -0.02953     0.03544     0.23626     0.14245     0.08862
-          27    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
-          28     0.24353     0.00265    -0.01876     0.14395    -0.03694    -0.12753
-          29     0.19038     0.02953     0.03544     0.23626    -0.14245    -0.08862
-          30    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.00000
-          31    -0.00043    -0.02437    -0.02828    -0.01304    -0.00315     0.00495
-          32     0.04378     0.08495     0.06810    -0.02166    -0.01482    -0.02291
-          33     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
-          34    -0.00043     0.02437    -0.02828    -0.01304     0.00315    -0.00495
-          35     0.04378    -0.08495     0.06810    -0.02166     0.01482     0.02291
-          36    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
-          37    -0.00013     0.03404     0.03510    -0.01750     0.01293    -0.00562
-          38     0.03124    -0.17996    -0.21585    -0.01811    -0.07351     0.02452
-          39    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
-          40    -0.00013    -0.03404     0.03510    -0.01750    -0.01293     0.00562
-          41     0.03124     0.17996    -0.21585    -0.01811     0.07351    -0.02452
-          42     0.00000     0.00000     0.00000    -0.00000     0.00000    -0.00000
-          43     0.00641    -0.02001    -0.02356     0.01332    -0.01812    -0.00650
-          44    -0.02123    -0.00061     0.00872    -0.01177     0.02548     0.00948
-          45     0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
-          46     0.00641     0.02001    -0.02356     0.01332     0.01812     0.00650
-          47    -0.02123     0.00061     0.00872    -0.01177    -0.02548    -0.00948
-          48     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          49     0.02288     0.05062     0.04685     0.00220     0.00195    -0.00215
-          50    -0.08859    -0.36141    -0.35913     0.05800    -0.10371    -0.02689
-          51    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          52     0.02288    -0.05062     0.04685     0.00220    -0.00195     0.00215
-          53    -0.08859     0.36141    -0.35913     0.05800     0.10371     0.02689
+           1    -0.08527     0.01922    -0.03916     0.02450    -0.13387    -0.00455
+           2     0.00349     0.02693     0.01785     0.10213     0.01394    -0.08069
+           3     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+           4    -0.08527    -0.01922    -0.03916     0.02450     0.13387     0.00455
+           5     0.00349    -0.02693     0.01785     0.10213    -0.01394     0.08069
+           6    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+           7     0.04360    -0.01123     0.00023     0.05014     0.07415    -0.01531
+           8     0.07878     0.02451     0.03521    -0.07383    -0.05240     0.12506
+           9    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+          10     0.04360     0.01123     0.00023     0.05014    -0.07415     0.01531
+          11     0.07878    -0.02451     0.03521    -0.07383     0.05240    -0.12506
+          12    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+          13    -0.00985     0.01485     0.02100    -0.07262    -0.09009    -0.04485
+          14    -0.09862    -0.00336    -0.02237    -0.04321    -0.02881    -0.11056
+          15     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
+          16    -0.00985    -0.01485     0.02100    -0.07262     0.09009     0.04485
+          17    -0.09862     0.00336    -0.02237    -0.04321     0.02881     0.11056
+          18     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
+          19     0.14080     0.01369     0.06086    -0.07316     0.01804     0.08717
+          20    -0.14093    -0.04284    -0.11833     0.28373     0.12911    -0.13563
+          21     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
+          22     0.14080    -0.01369     0.06086    -0.07316    -0.01804    -0.08717
+          23    -0.14094     0.04284    -0.11833     0.28373    -0.12911     0.13563
+          24    -0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
+          25     0.24353    -0.00265     0.01876     0.14395     0.03694     0.12753
+          26     0.19038    -0.02953    -0.03544     0.23626     0.14245     0.08862
+          27     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          28     0.24353     0.00265     0.01876     0.14395    -0.03694    -0.12753
+          29     0.19038     0.02953    -0.03544     0.23626    -0.14245    -0.08862
+          30     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
+          31    -0.00043    -0.02437     0.02828    -0.01304    -0.00315     0.00495
+          32     0.04378     0.08495    -0.06810    -0.02166    -0.01482    -0.02291
+          33     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
+          34    -0.00043     0.02437     0.02828    -0.01304     0.00315    -0.00495
+          35     0.04378    -0.08495    -0.06810    -0.02166     0.01482     0.02291
+          36     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
+          37    -0.00013     0.03404    -0.03510    -0.01750     0.01293    -0.00562
+          38     0.03124    -0.17996     0.21585    -0.01811    -0.07351     0.02452
+          39    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+          40    -0.00013    -0.03404    -0.03510    -0.01750    -0.01293     0.00562
+          41     0.03124     0.17996     0.21585    -0.01811     0.07351    -0.02452
+          42     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          43     0.00641    -0.02001     0.02356     0.01332    -0.01812    -0.00650
+          44    -0.02123    -0.00061    -0.00872    -0.01177     0.02548     0.00948
+          45    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          46     0.00641     0.02001     0.02356     0.01332     0.01812     0.00650
+          47    -0.02123     0.00061    -0.00872    -0.01177    -0.02548    -0.00948
+          48    -0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49     0.02288     0.05062    -0.04685     0.00220     0.00195    -0.00215
+          50    -0.08859    -0.36141     0.35913     0.05800    -0.10371    -0.02689
+          51     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
+          52     0.02288    -0.05062    -0.04685     0.00220    -0.00195     0.00215
+          53    -0.08859     0.36141     0.35913     0.05800     0.10371     0.02689
           54     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          55     0.13523     0.42776     0.40139    -0.08296     0.07989     0.01532
-          56    -0.06599    -0.14594    -0.12812     0.01581    -0.00176     0.00414
-          57     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          58     0.13523    -0.42776     0.40139    -0.08296    -0.07989    -0.01532
-          59    -0.06599     0.14594    -0.12812     0.01581     0.00176    -0.00414
+          55     0.13523     0.42776    -0.40139    -0.08296     0.07989     0.01532
+          56    -0.06599    -0.14594     0.12812     0.01581    -0.00176     0.00414
+          57     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
+          58     0.13523    -0.42776    -0.40139    -0.08296    -0.07989    -0.01532
+          59    -0.06599     0.14594     0.12812     0.01581     0.00176    -0.00414
           60     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
 
                    49          50          51          52          53          54
  
  Frequency       1814.83     1815.80     3394.04     3394.76     3432.83     3432.87
  
-           1    -0.03130     0.01449     0.00016     0.00015    -0.00037     0.00033
-           2     0.00993    -0.02488     0.00002     0.00005    -0.00160     0.00159
-           3     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
-           4     0.03130     0.01449     0.00016    -0.00015    -0.00037    -0.00033
-           5    -0.00993    -0.02488     0.00002    -0.00005    -0.00160    -0.00159
-           6     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
-           7     0.01075    -0.00476     0.00077     0.00028     0.00152    -0.00201
-           8     0.01758    -0.00541     0.00008    -0.00011     0.00056    -0.00076
-           9     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00000
-          10    -0.01075    -0.00476     0.00077    -0.00028     0.00152     0.00201
-          11    -0.01758    -0.00541     0.00008     0.00011     0.00056     0.00076
+           1    -0.03130     0.01449    -0.00016     0.00015    -0.00037     0.00033
+           2     0.00993    -0.02488    -0.00002     0.00005    -0.00160     0.00159
+           3    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+           4     0.03130     0.01449    -0.00016    -0.00015    -0.00037    -0.00033
+           5    -0.00993    -0.02488    -0.00002    -0.00005    -0.00160    -0.00159
+           6     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
+           7     0.01075    -0.00476    -0.00077     0.00028     0.00152    -0.00201
+           8     0.01758    -0.00541    -0.00008    -0.00011     0.00056    -0.00076
+           9     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          10    -0.01075    -0.00476    -0.00077    -0.00028     0.00152     0.00201
+          11    -0.01758    -0.00541    -0.00008     0.00011     0.00056     0.00076
           12     0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
-          13    -0.02265    -0.00002    -0.00110     0.00097    -0.00037     0.00042
-          14    -0.02175     0.01020     0.00077    -0.00052    -0.00018    -0.00055
-          15    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          16     0.02265    -0.00002    -0.00110    -0.00097    -0.00037    -0.00042
-          17     0.02175     0.01020     0.00077     0.00052    -0.00018     0.00055
-          18    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-          19     0.02205    -0.01127    -0.00875    -0.00197    -0.01771     0.02382
-          20    -0.00276     0.00595    -0.00286    -0.00056    -0.00539     0.00779
-          21     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
-          22    -0.02205    -0.01127    -0.00875     0.00197    -0.01771    -0.02382
-          23     0.00276     0.00595    -0.00286     0.00056    -0.00539    -0.00779
-          24     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          25     0.00665    -0.02765     0.01019    -0.00723     0.00245    -0.00479
-          26     0.01606    -0.01927    -0.00766     0.00526    -0.00178     0.00358
-          27    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          28    -0.00665    -0.02765     0.01019     0.00723     0.00245     0.00479
-          29    -0.01606    -0.01927    -0.00766    -0.00526    -0.00178    -0.00358
-          30    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
-          31    -0.07194    -0.07136     0.01097    -0.01087     0.05774     0.05776
-          32     0.10892     0.11364     0.00791    -0.00786     0.00949     0.00953
-          33    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          34     0.07194    -0.07136     0.01097     0.01087     0.05774    -0.05777
-          35    -0.10892     0.11364     0.00791     0.00786     0.00949    -0.00953
-          36    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          37    -0.03015    -0.02931    -0.17459     0.17265    -0.63089    -0.63120
-          38    -0.14277    -0.13894    -0.03967     0.03932    -0.14649    -0.14657
-          39     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
-          40     0.03015    -0.02931    -0.17459    -0.17265    -0.63084     0.63125
-          41     0.14277    -0.13894    -0.03967    -0.03932    -0.14648     0.14659
-          42     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
-          43     0.07693     0.07771     0.02954    -0.02952    -0.01393    -0.01384
-          44    -0.09225    -0.09392    -0.03603     0.03607     0.01031     0.01016
-          45    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
-          46    -0.07693     0.07771     0.02954     0.02952    -0.01393     0.01384
-          47     0.09225    -0.09392    -0.03603    -0.03607     0.01031    -0.01016
+          13    -0.02265    -0.00002     0.00110     0.00097    -0.00037     0.00042
+          14    -0.02175     0.01020    -0.00077    -0.00052    -0.00018    -0.00055
+          15    -0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          16     0.02265    -0.00002     0.00110    -0.00097    -0.00037    -0.00042
+          17     0.02175     0.01020    -0.00077     0.00052    -0.00018     0.00055
+          18    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
+          19     0.02205    -0.01127     0.00875    -0.00197    -0.01771     0.02382
+          20    -0.00276     0.00595     0.00286    -0.00056    -0.00539     0.00779
+          21    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
+          22    -0.02205    -0.01127     0.00875     0.00197    -0.01771    -0.02382
+          23     0.00276     0.00595     0.00286     0.00056    -0.00539    -0.00779
+          24    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
+          25     0.00665    -0.02765    -0.01019    -0.00723     0.00245    -0.00479
+          26     0.01606    -0.01927     0.00766     0.00526    -0.00178     0.00358
+          27    -0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          28    -0.00665    -0.02765    -0.01019     0.00723     0.00245     0.00479
+          29    -0.01606    -0.01927     0.00766    -0.00526    -0.00178    -0.00358
+          30    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
+          31    -0.07194    -0.07136    -0.01097    -0.01087     0.05774     0.05777
+          32     0.10892     0.11364    -0.00791    -0.00786     0.00949     0.00953
+          33     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          34     0.07194    -0.07136    -0.01097     0.01087     0.05774    -0.05777
+          35    -0.10892     0.11364    -0.00791     0.00786     0.00949    -0.00953
+          36     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          37    -0.03015    -0.02931     0.17459     0.17265    -0.63087    -0.63122
+          38    -0.14277    -0.13894     0.03967     0.03932    -0.14649    -0.14658
+          39    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          40     0.03015    -0.02931     0.17459    -0.17265    -0.63086     0.63122
+          41     0.14277    -0.13894     0.03967    -0.03932    -0.14649     0.14658
+          42    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+          43     0.07693     0.07771    -0.02954    -0.02952    -0.01393    -0.01384
+          44    -0.09225    -0.09392     0.03603     0.03607     0.01031     0.01016
+          45     0.00000     0.00000     0.00000    -0.00000     0.00000    -0.00000
+          46    -0.07693     0.07771    -0.02954     0.02952    -0.01393     0.01384
+          47     0.09225    -0.09392     0.03603    -0.03607     0.01031    -0.01016
           48    -0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
-          49     0.04826     0.04843    -0.44963     0.45016     0.14518     0.14368
-          50     0.19162     0.19577    -0.08010     0.08018     0.02805     0.02779
-          51     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
-          52    -0.04826     0.04843    -0.44964    -0.45016     0.14517    -0.14369
-          53    -0.19162     0.19577    -0.08010    -0.08018     0.02804    -0.02780
-          54     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
-          55    -0.17114    -0.17148     0.14250    -0.14272    -0.02990    -0.02936
-          56    -0.03740    -0.03904     0.45482    -0.45520    -0.09567    -0.09397
-          57     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
-          58     0.17114    -0.17148     0.14250     0.14272    -0.02990     0.02936
-          59     0.03740    -0.03904     0.45483     0.45520    -0.09566     0.09398
-          60     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          49     0.04826     0.04843     0.44964     0.45016     0.14517     0.14368
+          50     0.19162     0.19577     0.08010     0.08018     0.02805     0.02779
+          51    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          52    -0.04826     0.04843     0.44963    -0.45016     0.14517    -0.14368
+          53    -0.19162     0.19577     0.08010    -0.08018     0.02805    -0.02779
+          54    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          55    -0.17114    -0.17148    -0.14250    -0.14272    -0.02990    -0.02936
+          56    -0.03740    -0.03904    -0.45483    -0.45520    -0.09567    -0.09398
+          57    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          58     0.17114    -0.17148    -0.14250     0.14272    -0.02990     0.02936
+          59     0.03740    -0.03904    -0.45482     0.45520    -0.09566     0.09398
+          60    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
 
                    55          56          57          58          59          60
  
  Frequency       3447.88     3451.35     3471.32     3474.29     3546.60     3546.62
  
-           1     0.00118     0.00257    -0.00372    -0.00146    -0.00015    -0.00016
-           2    -0.00216    -0.00161     0.00002    -0.00203     0.00032     0.00032
-           3    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-           4     0.00118    -0.00257    -0.00372     0.00146    -0.00015     0.00016
-           5    -0.00216     0.00161     0.00002     0.00203     0.00032    -0.00032
-           6     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-           7    -0.05177    -0.05188     0.02224    -0.02230     0.00003     0.00010
-           8    -0.01792    -0.01832     0.01128    -0.01081    -0.00002     0.00008
-           9     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
-          10    -0.05177     0.05188     0.02224     0.02230     0.00003    -0.00010
-          11    -0.01792     0.01832     0.01128     0.01081    -0.00002    -0.00008
-          12    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          13     0.01904     0.01827     0.04224    -0.04266    -0.00032     0.00042
-          14    -0.01193    -0.01192    -0.03625     0.03639     0.00026    -0.00037
-          15     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          16     0.01904    -0.01827     0.04224     0.04266    -0.00032    -0.00042
-          17    -0.01193     0.01192    -0.03625    -0.03639     0.00026     0.00037
-          18    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
-          19     0.58124     0.58283    -0.24588     0.24125     0.00015    -0.00072
-          20     0.21356     0.21457    -0.09207     0.08969    -0.00006    -0.00029
-          21    -0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
-          22     0.58124    -0.58283    -0.24588    -0.24125     0.00015     0.00072
-          23     0.21356    -0.21457    -0.09207    -0.08969    -0.00006     0.00029
-          24     0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
-          25    -0.20615    -0.20206    -0.47833     0.47992     0.00498    -0.00614
-          26     0.16669     0.16442     0.39214    -0.39313    -0.00363     0.00464
+           1    -0.00118     0.00257     0.00372    -0.00146     0.00015    -0.00016
+           2     0.00216    -0.00161    -0.00002    -0.00203    -0.00032     0.00032
+           3    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+           4    -0.00118    -0.00257     0.00372     0.00146     0.00015     0.00016
+           5     0.00216     0.00161    -0.00002     0.00203    -0.00032    -0.00032
+           6     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+           7     0.05177    -0.05188    -0.02224    -0.02230    -0.00003     0.00010
+           8     0.01792    -0.01832    -0.01128    -0.01081     0.00002     0.00008
+           9    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+          10     0.05177     0.05188    -0.02224     0.02230    -0.00003    -0.00010
+          11     0.01792     0.01832    -0.01128     0.01081     0.00002    -0.00008
+          12    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          13    -0.01904     0.01827    -0.04224    -0.04266     0.00032     0.00042
+          14     0.01193    -0.01192     0.03625     0.03639    -0.00026    -0.00037
+          15     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
+          16    -0.01904    -0.01827    -0.04224     0.04266     0.00032    -0.00042
+          17     0.01193     0.01192     0.03625    -0.03639    -0.00026     0.00037
+          18     0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          19    -0.58124     0.58283     0.24588     0.24125    -0.00015    -0.00072
+          20    -0.21356     0.21457     0.09207     0.08969     0.00006    -0.00029
+          21     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          22    -0.58124    -0.58283     0.24588    -0.24125    -0.00015     0.00072
+          23    -0.21356    -0.21457     0.09207    -0.08969     0.00006     0.00029
+          24    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          25     0.20615    -0.20206     0.47833     0.47992    -0.00498    -0.00614
+          26    -0.16669     0.16442    -0.39214    -0.39313     0.00363     0.00464
           27     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
-          28    -0.20615     0.20206    -0.47833    -0.47992     0.00498     0.00614
-          29     0.16669    -0.16442     0.39214     0.39313    -0.00363    -0.00464
+          28     0.20615     0.20206     0.47833    -0.47992    -0.00498     0.00614
+          29    -0.16669    -0.16442    -0.39214     0.39313     0.00363    -0.00464
           30     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
-          31     0.00193    -0.00209     0.00005    -0.00073    -0.00316     0.00317
-          32     0.00028    -0.00041    -0.00015    -0.00004    -0.00067     0.00067
-          33    -0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          34     0.00193     0.00209     0.00005     0.00073    -0.00316    -0.00317
-          35     0.00028     0.00041    -0.00015     0.00004    -0.00067    -0.00067
-          36     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
-          37    -0.02045     0.02369     0.00261     0.00567     0.03650    -0.03663
-          38    -0.00351     0.00486     0.00117     0.00001     0.00653    -0.00655
-          39     0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
-          40    -0.02045    -0.02369     0.00261    -0.00567     0.03652     0.03661
-          41    -0.00351    -0.00486     0.00117    -0.00001     0.00653     0.00655
-          42    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
-          43    -0.00006     0.00030    -0.00022     0.00043    -0.05033     0.05034
-          44    -0.00053    -0.00071    -0.00095     0.00093    -0.04414     0.04415
-          45     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
-          46    -0.00006    -0.00030    -0.00022    -0.00043    -0.05035    -0.05033
-          47    -0.00053     0.00071    -0.00095    -0.00093    -0.04416    -0.04414
-          48    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          49    -0.00357    -0.00515    -0.00295     0.00048     0.46692    -0.46711
-          50    -0.00086    -0.00110    -0.00092     0.00049     0.07797    -0.07800
-          51    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          52    -0.00357     0.00515    -0.00295    -0.00048     0.46709     0.46694
-          53    -0.00086     0.00110    -0.00092    -0.00049     0.07800     0.07797
-          54     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          55     0.00231     0.00194     0.00303    -0.00301     0.13349    -0.13352
-          56     0.00819     0.00591     0.00987    -0.01061     0.44623    -0.44635
-          57     0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
-          58     0.00231    -0.00194     0.00303     0.00301     0.13354     0.13347
-          59     0.00819    -0.00590     0.00987     0.01061     0.44639     0.44619
-          60     0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+          31    -0.00193    -0.00209    -0.00005    -0.00073     0.00316     0.00317
+          32    -0.00028    -0.00041     0.00015    -0.00004     0.00067     0.00067
+          33     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          34    -0.00193     0.00209    -0.00005     0.00073     0.00316    -0.00317
+          35    -0.00028     0.00041     0.00015     0.00004     0.00067    -0.00067
+          36     0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
+          37     0.02045     0.02369    -0.00261     0.00567    -0.03651    -0.03662
+          38     0.00351     0.00486    -0.00117     0.00001    -0.00653    -0.00655
+          39     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          40     0.02045    -0.02369    -0.00261    -0.00567    -0.03651     0.03662
+          41     0.00351    -0.00486    -0.00117    -0.00001    -0.00653     0.00655
+          42     0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
+          43     0.00006     0.00030     0.00022     0.00043     0.05034     0.05033
+          44     0.00053    -0.00071     0.00095     0.00093     0.04415     0.04414
+          45     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          46     0.00006    -0.00030     0.00022    -0.00043     0.05034    -0.05034
+          47     0.00053     0.00071     0.00095    -0.00093     0.04415    -0.04415
+          48     0.00000    -0.00000    -0.00000    -0.00000     0.00000    -0.00000
+          49     0.00357    -0.00515     0.00295     0.00048    -0.46701    -0.46701
+          50     0.00086    -0.00110     0.00092     0.00049    -0.07798    -0.07798
+          51     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          52     0.00357     0.00515     0.00295    -0.00048    -0.46700     0.46703
+          53     0.00086     0.00110     0.00092    -0.00049    -0.07798     0.07798
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.00231     0.00194    -0.00303    -0.00301    -0.13352    -0.13349
+          56    -0.00819     0.00591    -0.00987    -0.01061    -0.44632    -0.44626
+          57     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          58    -0.00231    -0.00194    -0.00303     0.00301    -0.13351     0.13350
+          59    -0.00819    -0.00591    -0.00987     0.01061    -0.44630     0.44628
+          60     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
 
 
 
@@ -1588,66 +2345,66 @@ Iterative solution of linear equations
  Normal Eigenvalue ||         Derivative Dipole Moments (debye/angs)
   Mode   [cm**-1]  ||      [d/dqX]             [d/dqY]           [d/dqZ]
  ------ ---------- || ------------------ ------------------ -----------------
-    1       -9.919 ||       0.000              -0.000            -0.000
-    2       -1.353 ||       0.000              -0.000             0.000
+    1       -9.919 ||       0.000              -0.000             0.000
+    2       -1.352 ||       0.000              -0.000             0.000
     3        3.249 ||       0.000              -0.000            -0.000
     4        6.841 ||      -0.000               0.000             0.000
     5        9.117 ||      -0.000               0.000            -0.000
     6       17.916 ||      -0.000               0.000             0.000
-    7       49.008 ||      -0.000               0.000             0.027
-    8       81.293 ||      -0.000               0.000            -0.000
-    9      151.697 ||       0.000              -0.000            -0.091
+    7       49.008 ||       0.000              -0.000             0.027
+    8       81.294 ||      -0.000              -0.000             0.000
+    9      151.697 ||      -0.000              -0.000             0.091
    10      181.054 ||       0.031              -0.073             0.000
    11      265.748 ||       0.000              -0.000             0.000
-   12      301.268 ||       0.000              -0.000            -0.000
+   12      301.268 ||      -0.000              -0.000            -0.000
    13      407.922 ||       0.000              -0.000             0.000
-   14      424.393 ||       0.000              -0.000            -0.049
-   15      468.979 ||      -0.000               0.000             0.372
-   16      487.926 ||      -0.018               0.214             0.000
-   17      578.924 ||      -0.000               0.000             0.000
-   18      657.869 ||       0.000              -0.000            -0.000
-   19      673.473 ||      -0.000              -0.000            -0.000
-   20      707.330 ||       0.000              -0.000            -0.105
-   21      735.120 ||      -0.024               0.319            -0.000
+   14      424.393 ||      -0.000               0.000            -0.049
+   15      468.979 ||       0.000              -0.000             0.372
+   16      487.926 ||       0.018              -0.214             0.000
+   17      578.924 ||      -0.000              -0.000             0.000
+   18      657.869 ||      -0.000               0.000            -0.000
+   19      673.473 ||       0.000              -0.000             0.000
+   20      707.330 ||       0.000               0.000            -0.105
+   21      735.120 ||      -0.024               0.319             0.000
    22      810.690 ||      -0.000               0.000             0.000
    23      862.508 ||      -0.000               0.000            -0.000
-   24      893.976 ||      -0.000               0.000            -0.000
-   25      896.431 ||       0.000              -0.000             0.788
-   26      980.875 ||      -0.000               0.000             0.000
-   27      980.976 ||      -0.000               0.000             0.930
-   28     1017.887 ||      -0.000               0.000            -0.000
-   29     1036.478 ||      -0.000               0.000            -0.013
-   30     1073.560 ||       0.014              -0.106            -0.000
-   31     1102.049 ||       0.034               0.456             0.000
-   32     1107.686 ||       0.000               0.000            -0.558
-   33     1107.841 ||      -0.000               0.000            -0.000
-   34     1110.640 ||      -0.000              -0.000             0.000
+   24      893.976 ||       0.000               0.000            -0.000
+   25      896.431 ||      -0.000               0.000             0.788
+   26      980.875 ||      -0.000              -0.000            -0.000
+   27      980.976 ||       0.000              -0.000             0.930
+   28     1017.887 ||      -0.000               0.000             0.000
+   29     1036.478 ||      -0.000               0.000             0.013
+   30     1073.560 ||       0.014              -0.106             0.000
+   31     1102.049 ||       0.034               0.456            -0.000
+   32     1107.686 ||       0.000              -0.000             0.558
+   33     1107.841 ||       0.000              -0.000            -0.000
+   34     1110.640 ||      -0.000               0.000            -0.000
    35     1203.742 ||      -0.090               0.165             0.000
-   36     1260.980 ||      -0.000               0.000             0.000
+   36     1260.980 ||       0.000               0.000             0.000
    37     1284.279 ||       0.024               0.025            -0.000
    38     1296.192 ||       0.000               0.000             0.000
    39     1350.011 ||      -0.050              -0.460            -0.000
    40     1398.579 ||       0.000               0.000            -0.000
    41     1422.110 ||      -0.086               0.440            -0.000
-   42     1427.475 ||      -0.000              -0.000             0.000
-   43     1514.547 ||       0.648               0.167            -0.000
+   42     1427.475 ||      -0.000               0.000             0.000
+   43     1514.547 ||       0.648               0.167             0.000
    44     1565.513 ||      -0.000              -0.000            -0.000
-   45     1575.248 ||       0.081               0.084             0.000
+   45     1575.248 ||      -0.081              -0.084             0.000
    46     1639.667 ||      -0.039               0.601            -0.000
-   47     1690.893 ||      -0.000              -0.000             0.000
-   48     1738.514 ||      -0.000              -0.000            -0.000
-   49     1814.825 ||       0.000              -0.000             0.000
+   47     1690.893 ||       0.000              -0.000            -0.000
+   48     1738.514 ||       0.000              -0.000             0.000
+   49     1814.825 ||       0.000              -0.000            -0.000
    50     1815.798 ||      -0.188              -0.009             0.000
    51     3394.040 ||      -0.362               1.486            -0.000
-   52     3394.760 ||       0.000              -0.000            -0.000
-   53     3432.829 ||      -0.068               0.287             0.000
+   52     3394.760 ||      -0.000               0.000            -0.000
+   53     3432.829 ||      -0.068               0.287            -0.000
    54     3432.873 ||       0.000              -0.000             0.000
-   55     3447.880 ||       0.173               0.028            -0.000
-   56     3451.354 ||      -0.000               0.000             0.000
-   57     3471.324 ||      -0.347               0.112             0.000
-   58     3474.287 ||       0.000              -0.000            -0.000
-   59     3546.603 ||       0.012              -0.020            -0.000
-   60     3546.616 ||      -0.000               0.000             0.000
+   55     3447.880 ||      -0.173              -0.028             0.000
+   56     3451.354 ||       0.000              -0.000            -0.000
+   57     3471.324 ||       0.347              -0.112             0.000
+   58     3474.287 ||      -0.000               0.000             0.000
+   59     3546.603 ||       0.012              -0.020             0.000
+   60     3546.616 ||       0.000              -0.000             0.000
  ----------------------------------------------------------------------------
 
 
@@ -1659,13 +2416,13 @@ Iterative solution of linear equations
   Mode   [cm**-1]  || [atomic units] [(debye/angs)**2] [(KM/mol)] [arbitrary]
  ------ ---------- || -------------- ----------------- ---------- -----------
     1       -9.919 ||    0.000000           0.000         0.000       0.000
-    2       -1.353 ||    0.000000           0.000         0.000       0.000
+    2       -1.352 ||    0.000000           0.000         0.000       0.000
     3        3.249 ||    0.000000           0.000         0.000       0.000
     4        6.841 ||    0.000000           0.000         0.000       0.000
     5        9.117 ||    0.000000           0.000         0.000       0.000
     6       17.916 ||    0.000000           0.000         0.000       0.000
     7       49.008 ||    0.000030           0.001         0.030       0.068
-    8       81.293 ||    0.000000           0.000         0.000       0.000
+    8       81.294 ||    0.000000           0.000         0.000       0.000
     9      151.697 ||    0.000359           0.008         0.350       0.797
    10      181.054 ||    0.000273           0.006         0.266       0.607
    11      265.748 ||    0.000000           0.000         0.000       0.000
@@ -1722,12 +2479,12 @@ Iterative solution of linear equations
 
 
 
- 
- 
+
+
         Vibrational analysis via the FX method 
   --- with translations and rotations projected out ---
   --- via the Eckart algorithm                      ---
- Projected Nuclear Hessian trans-rot subspace norm:1.8124D-33
+ Projected Nuclear Hessian trans-rot subspace norm:1.9498D-33
                          (should be close to zero!) 
 
           --------------------------------------------------------
@@ -1738,235 +2495,235 @@ Iterative solution of linear equations
                1            2            3            4            5            6            7            8            9           10
    ----- ----- ----- ----- -----
     1    6.04379D+01
-    2    1.45037D-01  5.88029D+01
-    3   -9.59140D-08  7.98377D-08  1.31746D+01
-    4   -7.00970D+00  1.31537D+00  6.67209D-08  6.04379D+01
-    5    1.31538D+00  8.54315D-01 -7.07152D-08  1.45038D-01  5.88029D+01
-    6   -9.94169D-09  1.03027D-07 -7.47357D-01  2.82748D-07 -1.23481D-08  1.31746D+01
-    7   -2.21707D+01  1.15479D+01  6.69531D-08  1.76226D+00 -3.07985D+00  1.90940D-08  6.86234D+01
-    8    4.45961D+00 -1.74173D+01 -8.74279D-08 -9.06153D+00 -1.31701D+00 -7.21166D-08  4.62201D+00  6.31125D+01
-    9   -3.32712D-08  1.73966D-07 -5.54096D+00  2.26021D-07 -8.89283D-08  5.77012D-01 -1.59512D-07  2.53145D-07  1.17721D+01
-   10    1.76226D+00 -3.07985D+00 -2.27594D-08 -2.21707D+01  1.15479D+01 -5.59249D-08 -6.73269D-01  2.26148D+00 -8.01823D-08  6.86234D+01
-   11   -9.06153D+00 -1.31701D+00 -3.59542D-08  4.45961D+00 -1.74173D+01 -1.29940D-08  2.26149D+00 -6.38040D+00 -4.66221D-08  4.62201D+00
-   12   -2.24742D-09  1.65889D-07  5.77012D-01  2.50558D-07 -1.05213D-07 -5.54096D+00  3.58317D-08  2.27353D-07 -5.94090D-01 -1.20431D-07
-   13    5.11171D+00  8.53474D-01  2.65776D-08 -2.64806D+01 -8.05815D+00  1.89297D-08 -1.28546D+01  1.13604D+00  4.64501D-08 -4.97401D+00
-   14    6.70473D+00 -4.60721D+00  1.51943D-07 -1.29265D+00 -1.28897D+01  2.07759D-08 -7.41473D+00 -3.14760D+01 -3.89831D-08 -4.90004D-01
-   15    1.55986D-10 -1.66694D-07  5.85678D-01 -3.11428D-07  7.31463D-08 -5.64374D+00 -4.35762D-08 -2.11989D-07 -5.20671D+00  1.12415D-07
-   16   -2.64806D+01 -8.05815D+00 -2.90468D-08  5.11171D+00  8.53474D-01 -3.73861D-08 -4.97401D+00  4.43995D+00  1.46018D-08 -1.28546D+01
-   17   -1.29265D+00 -1.28897D+01  8.24680D-08  6.70473D+00 -4.60721D+00 -4.33509D-08 -4.90004D-01  6.23044D+00 -9.38716D-08 -7.41473D+00
-   18    6.19519D-08 -1.58702D-07 -5.64374D+00 -2.51182D-07  8.04282D-08  5.85678D-01 -4.75464D-09 -2.02110D-07  5.41715D-01  1.68762D-07
-   19   -4.19802D+00 -3.86475D+00 -2.62068D-07  3.50654D-01  1.08780D-02 -5.87402D-09 -1.05256D+02 -3.16206D+01  2.21573D-07  3.01137D-01
-   20    6.72964D+00  2.87431D+00 -1.76403D-07  4.28060D-01 -1.50690D+00 -7.40864D-08 -3.16238D+01 -3.05537D+01 -5.64704D-08  1.70012D-01
-   21    7.20226D-08  1.42631D-07  6.89146D-01  7.21603D-08 -6.11522D-08  2.53584D+00  8.37715D-08  8.91448D-08 -1.14741D+01 -5.13392D-08
-   22    3.50654D-01  1.08787D-02 -1.95073D-07 -4.19802D+00 -3.86475D+00  5.72965D-08  3.01137D-01  2.26222D-01  2.29168D-07 -1.05256D+02
-   23    4.28059D-01 -1.50690D+00 -2.21203D-08  6.72965D+00  2.87431D+00  9.13457D-08  1.70011D-01 -1.43419D-01  1.05769D-07 -3.16238D+01
-   24   -2.08009D-09  1.15103D-07  2.53584D+00 -4.80680D-08 -9.63272D-08  6.89146D-01 -2.52437D-08  1.02413D-07 -2.54238D-01  5.98655D-09
-   25    4.25502D-02 -5.24504D-01  4.62864D-08 -4.33550D+00  6.47274D+00 -2.15941D-07  2.61335D+00 -3.26051D+00 -2.66330D-07 -1.07181D+00
-   26   -9.72304D-01 -1.15659D+00 -8.51077D-09 -4.01992D+00  3.68339D+00  1.06390D-07  8.13590D+00 -3.85920D+00  4.53019D-08 -7.37272D-01
-   27    3.29074D-08  1.48889D-08  2.54140D+00 -6.10824D-08 -5.78195D-08  8.14710D-01  6.36641D-08 -5.01113D-08  1.04769D+00  6.40644D-08
-   28   -4.33550D+00  6.47274D+00  2.87771D-07  4.25499D-02 -5.24505D-01  3.28276D-08 -1.07181D+00 -1.17323D+00  5.48650D-09  2.61335D+00
-   29   -4.01992D+00  3.68339D+00 -1.82195D-07 -9.72303D-01 -1.15659D+00 -5.02594D-08 -7.37273D-01 -4.41840D-01 -3.53941D-08  8.13590D+00
-   30   -9.01435D-09  2.05678D-08  8.14710D-01 -1.02810D-07 -1.92177D-08  2.54140D+00 -9.76737D-08 -5.88132D-08  2.21629D+00  5.65149D-08
-   31   -1.89665D-02  1.29561D-01 -4.77753D-08 -1.02955D+01 -4.67897D+00 -2.60658D-08 -5.34149D-01 -7.18466D-02  1.90214D-09  5.38019D-01
-   32   -2.82185D-02 -5.03080D-01 -1.17982D-08 -2.21575D+00 -1.97807D+01 -2.29671D-08 -1.40891D-01  8.43326D-01 -5.67831D-08  5.46648D-01
-   33    1.03926D-08 -9.04209D-08 -8.24741D-02  1.42356D-09  6.58818D-08 -5.28324D+00 -9.51031D-09  3.09160D-08  5.74224D-01 -9.10659D-10
-   34   -1.02955D+01 -4.67897D+00 -1.18681D-08 -1.89664D-02  1.29561D-01  5.58790D-09  5.38019D-01  2.66583D+00  5.56317D-08 -5.34149D-01
-   35   -2.21575D+00 -1.97807D+01  2.32705D-08 -2.82186D-02 -5.03080D-01  2.86866D-08  5.46648D-01 -3.70760D+00 -1.87943D-08 -1.40891D-01
-   36    3.51579D-09 -9.23264D-08 -5.28324D+00 -6.01237D-09  6.10434D-08 -8.24741D-02  5.03839D-09 -1.20649D-08  3.30793D-01 -5.74474D-11
-   37    5.02985D-02  1.64557D-02 -2.79481D-08 -6.97622D-01  1.07982D+00 -2.00741D-07 -4.23419D-02  4.66841D-02 -2.35844D-07  4.25950D-01
-   38    2.24300D-02  4.71754D-02  7.25473D-09 -9.13488D+00 -1.91373D+00  1.27401D-08 -4.91546D-01  7.80113D-02 -8.72787D-09 -6.39881D-01
-   39   -2.03697D-08  5.49604D-08  2.89544D-02 -1.08045D-07 -3.18615D-08  6.69646D-01 -1.82818D-08  1.97524D-08  8.06062D-03 -2.37371D-08
-   40   -6.97622D-01  1.07983D+00  8.27886D-08  5.02982D-02  1.64542D-02 -7.73048D-08  4.25950D-01  7.03135D-01 -7.21312D-08 -4.23424D-02
-   41   -9.13488D+00 -1.91373D+00 -2.94233D-08  2.24310D-02  4.71756D-02 -4.35828D-09 -6.39882D-01  5.12788D-01 -5.96320D-08 -4.91545D-01
-   42    5.98380D-08  3.13914D-08  6.69646D-01  6.86224D-09 -3.17991D-08  2.89544D-02  1.07664D-07  7.27638D-08 -2.57774D-01 -1.95168D-08
-   43    6.29786D-03 -1.62394D-01  4.73811D-08  1.44693D+00  1.09134D+00  2.29876D-08 -5.10253D-02  2.46812D-01  4.45305D-10  8.50891D-02
-   44    7.74459D-02  1.51901D-01 -3.07319D-09  1.79293D+00 -4.01856D+00 -3.20854D-08  1.20669D-01 -1.41703D-01 -5.38486D-08 -5.87738D-01
-   45   -3.41346D-08 -3.72488D-08 -4.18461D-03 -2.52372D-08  2.32578D-08  4.58751D-01  2.35545D-08  1.53875D-08 -3.69301D-02 -2.38538D-08
-   46    1.44693D+00  1.09134D+00  2.47019D-08  6.29784D-03 -1.62394D-01  7.47004D-09  8.50890D-02 -5.92808D-01  9.35958D-11 -5.10255D-02
-   47    1.79293D+00 -4.01856D+00  5.52629D-08  7.74460D-02  1.51901D-01  1.09533D-08 -5.87738D-01  2.41085D-01 -7.02352D-09  1.20669D-01
-   48    1.59478D-08 -2.33569D-08  4.58751D-01  2.62426D-08  3.17822D-08 -4.18461D-03  2.03715D-08  6.13802D-08  1.18657D-01 -2.88666D-08
-   49   -2.50874D-02 -3.57326D-02  2.33208D-08  1.39517D-01 -3.99070D-01 -1.14038D-07  1.15484D-01 -1.06052D-02 -1.42361D-07 -3.44225D-02
-   50   -1.64877D-03 -1.31596D-02 -3.11607D-08 -4.34271D-01  4.60429D-01  4.24031D-09 -7.02834D-02  4.95096D-02 -5.47949D-08 -1.86713D-02
-   51    9.05195D-08 -8.26488D-08 -2.67740D-02 -1.49911D-07  5.49967D-08 -2.35994D+00  7.46552D-08 -5.28345D-08  4.25911D-02  8.62270D-08
-   52    1.39518D-01 -3.99070D-01 -3.77847D-08 -2.50878D-02 -3.57342D-02 -1.21372D-07 -3.44227D-02 -4.34137D-02 -7.03695D-09  1.15483D-01
-   53   -4.34272D-01  4.60429D-01 -9.56977D-08 -1.64788D-03 -1.31599D-02 -6.35688D-08 -1.86722D-02  4.50881D-03 -8.76367D-08 -7.02826D-02
-   54   -9.86285D-10 -9.46654D-08 -2.35994D+00 -1.80854D-07  4.54106D-08 -2.67740D-02 -5.93374D-08 -4.95404D-08  6.97689D-03  1.25997D-08
-   55    1.43289D-02 -1.91390D-02 -4.86107D-08 -9.66933D-01  3.57531D-01 -1.47073D-07  6.56994D-02 -4.82194D-03 -9.85923D-08  2.23784D-01
-   56    4.52390D-02  3.47556D-02 -6.98536D-08  7.91876D-01 -9.96804D-03  3.28946D-08 -6.61145D-02  4.17081D-03  2.68796D-08 -1.42856D-01
-   57    5.62144D-08 -2.10028D-08  4.10233D-02 -1.63504D-07 -1.31436D-08  3.71287D+00  1.75271D-09 -6.09990D-09 -8.72593D-02  2.64117D-08
-   58   -9.66933D-01  3.57532D-01  4.51524D-08  1.43290D-02 -1.91406D-02  7.20660D-09  2.23783D-01  2.66661D-01  1.17001D-07  6.56988D-02
-   59    7.91875D-01 -9.96809D-03 -2.61634D-08  4.52400D-02  3.47557D-02  5.65296D-08 -1.42857D-01 -1.13262D-01  4.79059D-08 -6.61138D-02
-   60    9.23064D-09 -2.23964D-08  3.71287D+00 -1.61407D-07  9.62154D-09  4.10233D-02  2.95176D-08 -7.52083D-08  1.57019D-03  2.15597D-08
+    2    1.45038D-01  5.88029D+01
+    3    1.04947D-07  1.25751D-07  1.31746D+01
+    4   -7.00970D+00  1.31537D+00 -8.09310D-08  6.04379D+01
+    5    1.31538D+00  8.54314D-01  3.68384D-08  1.45037D-01  5.88029D+01
+    6    1.08924D-07  1.25020D-07 -7.47356D-01  4.15540D-07 -1.70989D-07  1.31746D+01
+    7   -2.21707D+01  1.15479D+01 -3.48560D-08  1.76226D+00 -3.07985D+00 -3.17346D-08  6.86234D+01
+    8    4.45961D+00 -1.74173D+01  6.29911D-08 -9.06153D+00 -1.31701D+00  4.90079D-08  4.62201D+00  6.31125D+01
+    9    5.94280D-08  1.86578D-07 -5.54096D+00  3.53361D-07 -1.26969D-07  5.77012D-01 -1.83345D-07 -4.62806D-08  1.17721D+01
+   10    1.76226D+00 -3.07985D+00 -6.63806D-08 -2.21707D+01  1.15479D+01 -6.29446D-08 -6.73269D-01  2.26148D+00 -8.75372D-08  6.86234D+01
+   11   -9.06153D+00 -1.31701D+00  3.35951D-08  4.45961D+00 -1.74173D+01  3.15855D-08  2.26149D+00 -6.38040D+00  2.68625D-08  4.62201D+00
+   12    1.09228D-07  1.66760D-07  5.77012D-01  3.75236D-07 -1.27086D-07 -5.54096D+00 -1.69101D-07 -2.63574D-08 -5.94090D-01 -3.49257D-07
+   13    5.11171D+00  8.53474D-01 -1.20587D-08 -2.64806D+01 -8.05815D+00 -6.29448D-08 -1.28546D+01  1.13604D+00 -3.62164D-08 -4.97401D+00
+   14    6.70473D+00 -4.60721D+00 -1.22940D-07 -1.29265D+00 -1.28897D+01 -1.34157D-08 -7.41473D+00 -3.14760D+01 -1.34706D-07 -4.90004D-01
+   15   -1.65601D-07 -1.90865D-07  5.85677D-01 -4.58818D-07  1.53858D-07 -5.64374D+00  1.63332D-07 -3.94196D-08 -5.20671D+00  2.98975D-07
+   16   -2.64806D+01 -8.05815D+00 -7.14853D-09  5.11171D+00  8.53473D-01 -3.91789D-08 -4.97401D+00  4.43995D+00 -1.97130D-08 -1.28546D+01
+   17   -1.29265D+00 -1.28897D+01 -1.16946D-07  6.70473D+00 -4.60721D+00 -2.63321D-09 -4.90004D-01  6.23044D+00 -1.19901D-07 -7.41473D+00
+   18   -1.32436D-07 -1.98921D-07 -5.64374D+00 -4.16681D-07  1.40998D-07  5.85678D-01  1.91592D-07 -1.77855D-08  5.41715D-01  3.40749D-07
+   19   -4.19802D+00 -3.86475D+00  1.56298D-07  3.50654D-01  1.08776D-02 -2.09149D-07 -1.05256D+02 -3.16206D+01  2.15276D-07  3.01137D-01
+   20    6.72964D+00  2.87431D+00  6.07554D-08  4.28060D-01 -1.50690D+00 -7.45154D-08 -3.16238D+01 -3.05537D+01  1.16107D-07  1.70012D-01
+   21    5.91915D-08  3.46705D-08  6.89146D-01  1.15530D-07 -2.68187D-08  2.53584D+00 -6.20015D-08 -3.80524D-08 -1.14741D+01 -2.09538D-07
+   22    3.50655D-01  1.08784D-02  2.96814D-07 -4.19802D+00 -3.86475D+00 -1.15875D-07  3.01136D-01  2.26221D-01  3.35605D-07 -1.05256D+02
+   23    4.28059D-01 -1.50690D+00  7.26596D-08  6.72965D+00  2.87431D+00  2.66449D-08  1.70011D-01 -1.43419D-01  2.08770D-07 -3.16238D+01
+   24   -4.54728D-08  6.90979D-08  2.53584D+00 -4.83907D-08 -1.19990D-08  6.89146D-01 -7.44618D-08 -6.22453D-08 -2.54238D-01 -4.87416D-08
+   25    4.25496D-02 -5.24504D-01 -9.89059D-09 -4.33550D+00  6.47274D+00 -2.85138D-08  2.61335D+00 -3.26051D+00 -1.42707D-07 -1.07181D+00
+   26   -9.72304D-01 -1.15659D+00 -5.01556D-08 -4.01992D+00  3.68339D+00 -6.99574D-08  8.13590D+00 -3.85920D+00 -6.99391D-09 -7.37272D-01
+   27   -8.70810D-08 -5.30312D-08  2.54140D+00 -1.61082D-07  6.12991D-08  8.14710D-01  4.71005D-08 -1.33210D-08  1.04769D+00 -8.89165D-09
+   28   -4.33550D+00  6.47274D+00 -6.12917D-08  4.25501D-02 -5.24505D-01 -4.22935D-08 -1.07181D+00 -1.17323D+00 -1.68170D-07  2.61335D+00
+   29   -4.01992D+00  3.68339D+00 -3.94408D-08 -9.72303D-01 -1.15659D+00 -3.59184D-09 -7.37273D-01 -4.41840D-01  5.69895D-08  8.13590D+00
+   30   -1.41879D-07 -4.42066D-08  8.14710D-01 -1.88974D-07  9.84821D-08  2.54140D+00  3.67742D-08 -2.24074D-08  2.21629D+00  1.08683D-07
+   31   -1.89664D-02  1.29561D-01  2.97043D-08 -1.02955D+01 -4.67897D+00 -4.09504D-08 -5.34149D-01 -7.18467D-02  1.55499D-08  5.38019D-01
+   32   -2.82187D-02 -5.03080D-01  5.58636D-09 -2.21575D+00 -1.97807D+01  1.79273D-08 -1.40891D-01  8.43326D-01  2.33741D-08  5.46649D-01
+   33   -2.87195D-08 -4.07316D-08 -8.24742D-02 -2.71071D-08  1.33771D-08 -5.28324D+00  8.11027D-09  2.34235D-08  5.74224D-01  1.93640D-08
+   34   -1.02955D+01 -4.67897D+00 -2.91852D-09 -1.89665D-02  1.29560D-01 -4.08515D-08  5.38019D-01  2.66583D+00  1.07940D-08 -5.34149D-01
+   35   -2.21575D+00 -1.97807D+01  6.86508D-09 -2.82184D-02 -5.03080D-01  9.57719D-09  5.46648D-01 -3.70760D+00  1.87940D-08 -1.40891D-01
+   36   -3.46170D-08 -3.93377D-08 -5.28324D+00  6.24907D-10 -1.11144D-09 -8.24742D-02 -8.69148D-09  2.06132D-08  3.30793D-01 -1.96489D-08
+   37    5.02982D-02  1.64557D-02 -4.33904D-08 -6.97622D-01  1.07982D+00 -8.57595D-08 -4.23416D-02  4.66845D-02 -1.72403D-07  4.25950D-01
+   38    2.24300D-02  4.71754D-02  8.46010D-09 -9.13488D+00 -1.91373D+00 -1.82662D-08 -4.91547D-01  7.80112D-02  7.53512D-08 -6.39881D-01
+   39    2.65339D-08 -1.37181D-08  2.89544D-02 -5.43952D-08  2.66813D-08  6.69646D-01 -3.55894D-08 -1.26694D-08  8.06064D-03 -8.74417D-09
+   40   -6.97623D-01  1.07983D+00 -2.15790D-08  5.02985D-02  1.64541D-02  3.28328D-08  4.25950D-01  7.03135D-01 -6.16832D-08 -4.23424D-02
+   41   -9.13488D+00 -1.91373D+00  3.19279D-08  2.24309D-02  4.71757D-02 -2.22223D-08 -6.39882D-01  5.12788D-01  6.35462D-08 -4.91546D-01
+   42    5.37857D-08 -1.31807D-08  6.69646D-01  1.16295D-07 -6.56318D-08  2.89544D-02  2.19468D-08  1.90634D-08 -2.57775D-01 -1.52484D-07
+   43    6.29775D-03 -1.62394D-01  3.20960D-09  1.44693D+00  1.09134D+00 -2.78548D-08 -5.10253D-02  2.46812D-01 -2.64144D-08  8.50890D-02
+   44    7.74457D-02  1.51901D-01 -1.95517D-08  1.79293D+00 -4.01856D+00  1.69790D-08  1.20669D-01 -1.41703D-01 -2.47199D-08 -5.87738D-01
+   45    1.60467D-08 -1.51875D-08 -4.18463D-03  2.16523D-08 -5.90269D-10  4.58751D-01  8.20028D-09  9.44625D-09 -3.69301D-02 -3.86994D-08
+   46    1.44693D+00  1.09134D+00 -7.15421D-09  6.29785D-03 -1.62394D-01 -2.31668D-09  8.50890D-02 -5.92808D-01 -7.32102D-09 -5.10255D-02
+   47    1.79293D+00 -4.01856D+00 -2.97056D-08  7.74461D-02  1.51901D-01  1.13069D-08 -5.87738D-01  2.41085D-01 -1.81537D-08  1.20669D-01
+   48    3.22939D-08 -2.08448D-08  4.58751D-01  6.64364D-08 -1.01148D-08 -4.18463D-03 -2.34104D-10  8.02375D-09  1.18657D-01 -3.01681D-08
+   49   -2.50875D-02 -3.57323D-02 -1.54848D-08  1.39517D-01 -3.99070D-01 -5.18144D-08  1.15484D-01 -1.06051D-02 -1.55171D-07 -3.44225D-02
+   50   -1.64873D-03 -1.31595D-02 -6.90007D-08 -4.34271D-01  4.60429D-01 -4.55535D-08 -7.02834D-02  4.95095D-02 -2.29573D-08 -1.86714D-02
+   51   -4.67137D-08 -9.07838D-08 -2.67740D-02 -1.97092D-07  8.67545D-08 -2.35994D+00  7.91126D-08 -2.80338D-10  4.25911D-02  6.45702D-08
+   52    1.39517D-01 -3.99069D-01 -6.72276D-08 -2.50876D-02 -3.57343D-02 -1.60175D-08 -3.44225D-02 -4.34136D-02 -8.08506D-08  1.15483D-01
+   53   -4.34272D-01  4.60429D-01 -7.58382D-09 -1.64795D-03 -1.31599D-02  2.32546D-08 -1.86724D-02  4.50861D-03  3.32574D-08 -7.02827D-02
+   54   -3.75502D-08 -6.74746D-08 -2.35994D+00 -1.70918D-07  5.35212D-08 -2.67740D-02  4.18543D-08 -2.63049D-08  6.97691D-03  1.42311D-07
+   55    1.43292D-02 -1.91392D-02  1.86969D-08 -9.66933D-01  3.57531D-01 -1.56949D-07  6.56993D-02 -4.82197D-03 -4.79659D-08  2.23784D-01
+   56    4.52393D-02  3.47555D-02  1.42462D-08  7.91876D-01 -9.96808D-03 -4.82056D-08 -6.61147D-02  4.17055D-03  1.20693D-07 -1.42856D-01
+   57    1.81945D-08 -7.78887D-08  4.10233D-02 -2.09039D-07  8.13776D-08  3.71287D+00  5.07007D-08  9.27242D-09 -8.72593D-02  6.54045D-08
+   58   -9.66933D-01  3.57531D-01  9.76285D-10  1.43289D-02 -1.91407D-02 -7.07213D-08  2.23783D-01  2.66661D-01  6.89972D-09  6.56990D-02
+   59    7.91875D-01 -9.96833D-03  3.85743D-08  4.52398D-02  3.47557D-02 -2.41950D-08 -1.42857D-01 -1.13262D-01  9.75446D-08 -6.61137D-02
+   60   -3.88105D-08 -8.24074D-08  3.71287D+00 -6.22218D-08  1.30667D-08  4.10233D-02  9.03062D-08 -3.71847D-09  1.57013D-03  3.20669D-08
 
 
               11           12           13           14           15           16           17           18           19           20
    ----- ----- ----- ----- -----
    11    6.31125D+01
-   12   -3.30787D-07  1.17721D+01
-   13    4.43995D+00 -1.76681D-08  6.51306D+01
-   14    6.23044D+00  9.89345D-08 -5.68245D+00  6.65657D+01
-   15    3.14308D-07  5.41715D-01  5.46930D-08 -6.36526D-08  1.17872D+01
-   16    1.13604D+00 -4.74504D-08 -2.66827D+00 -3.53290D+00  9.79571D-09  6.51306D+01
-   17   -3.14760D+01  3.27878D-08 -3.53290D+00 -4.23506D+00 -9.71968D-08 -5.68245D+00  6.65657D+01
-   18    3.49762D-07 -5.20671D+00  8.23913D-08 -1.01865D-07 -5.34557D-01  3.46647D-08  2.36815D-08  1.17872D+01
-   19    2.26221D-01 -1.67330D-07  4.79582D-01  1.79682D+00  3.48235D-07 -4.42336D-01  1.15827D+00 -1.52920D-07  3.73232D+02
-   20   -1.43419D-01 -1.75783D-07 -9.54721D+00 -1.69570D+00  1.63003D-07  7.09932D-01 -1.04052D+00 -1.57719D-08  1.13654D+02  1.06907D+02
-   21   -3.13453D-07 -2.54238D-01 -1.54349D-07  5.98449D-08  9.56901D-01  7.54251D-08  2.63895D-08  2.14180D+00 -3.54533D-07 -1.89194D-07
-   22   -3.16206D+01 -1.68120D-07 -4.42336D-01  1.15827D+00  3.09321D-07  4.79582D-01  1.79682D+00 -1.91741D-07 -1.93614D-01 -1.70114D-01
-   23   -3.05537D+01  3.27645D-08  7.09932D-01 -1.04052D+00  7.82022D-08 -9.54721D+00 -1.69570D+00 -1.25377D-07 -1.70126D-01  1.19976D-01
-   24   -1.05462D-07 -1.14741D+01 -1.42017D-07  2.44689D-08  2.14180D+00  8.03981D-08 -7.56721D-08  9.56901D-01  2.89298D-07 -4.33377D-08
-   25   -1.17323D+00 -4.65824D-08 -7.85167D+01  4.84345D+01  9.97376D-08  1.28126D-01 -2.98509D-01  4.71339D-08  1.16150D+00  1.57819D-02
-   26   -4.41840D-01 -5.58433D-08  4.81983D+01 -5.80325D+01 -1.05558D-07 -2.75202D-01  2.19822D-02  8.39141D-08  1.88579D-01  1.86030D+00
-   27   -6.32071D-08  2.21629D+00 -5.88342D-08  7.32303D-09 -1.15804D+01  5.46137D-08  9.83221D-08 -2.59435D-01 -2.22634D-07  1.59031D-07
-   28   -3.26051D+00  2.41161D-07  1.28126D-01 -2.98509D-01 -2.04171D-07 -7.85167D+01  4.84345D+01 -2.58948D-07 -7.95667D-01  1.12280D+00
-   29   -3.85920D+00 -1.15914D-07 -2.75202D-01  2.19822D-02  5.08094D-08  4.81983D+01 -5.80325D+01  2.29925D-07 -6.72934D-01  6.03017D-01
-   30    3.04649D-08  1.04769D+00 -6.69484D-08 -5.81968D-08 -2.59435D-01  5.15288D-08 -4.74031D-08 -1.15804D+01  2.58216D-07  2.61006D-07
-   31    2.66583D+00 -4.71272D-08  1.04035D-01 -2.78333D+00  6.66898D-08 -4.12613D-01  7.86900D-02 -1.62157D-08  2.31108D-02 -4.43198D-01
-   32   -3.70760D+00  2.03866D-09 -1.77407D+00 -2.09789D+00  7.70420D-08  5.21431D-01  5.69991D-01 -1.89426D-08  2.37113D-02  5.88497D-02
-   33    2.69029D-08  3.30793D-01 -9.71395D-09 -4.22991D-08  2.33314D-01 -3.00297D-08  1.49668D-08  6.16229D-01 -4.95625D-08  2.19854D-08
-   34   -7.18467D-02  1.56748D-09 -4.12613D-01  7.86901D-02  5.92519D-08  1.04035D-01 -2.78333D+00 -3.48883D-08  4.47298D-01  5.82617D-01
-   35    8.43326D-01  4.64321D-08  5.21430D-01  5.69991D-01 -8.60247D-10 -1.77407D+00 -2.09789D+00 -8.88348D-08 -5.98275D-01  4.39618D-01
-   36   -2.82490D-08  5.74224D-01  2.33672D-08 -2.50331D-08  6.16229D-01  5.09766D-09  3.52982D-08  2.33314D-01  3.61894D-08 -5.74725D-10
-   37    7.03134D-01 -1.24071D-07  1.99774D-01  2.69222D-02  1.32849D-07 -3.35609D-02 -5.88793D-03  3.47901D-07  3.12815D-02 -5.09043D-02
-   38    5.12788D-01  2.81412D-08  5.21480D-01 -1.52950D+00  3.22233D-08  3.62207D-02  4.48825D-02 -4.78642D-08  1.58147D-02 -4.62618D-01
-   39   -7.21141D-08 -2.57774D-01 -4.04678D-08  3.66337D-08  7.12795D-01  8.47751D-08 -4.11127D-08 -1.85659D-02  1.27396D-07  4.43968D-08
-   40    4.66831D-02  9.04168D-08 -3.35609D-02 -5.88777D-03 -2.36257D-07  1.99774D-01  2.69220D-02 -3.87397D-08  8.13104D-02 -4.00807D-01
-   41    7.80113D-02 -4.35399D-08  3.62207D-02  4.48825D-02  5.67814D-08  5.21480D-01 -1.52949D+00  4.65480D-09  5.12163D-01 -1.03139D-01
-   42   -1.93354D-07  8.06063D-03 -1.56172D-07  6.02987D-08 -1.85659D-02 -3.79910D-08  4.30811D-08  7.12795D-01 -1.59951D-07 -1.16441D-07
-   43   -5.92808D-01  2.45637D-08 -4.20945D-01 -4.30101D-01 -1.75400D-08  1.64426D-01  1.25538D-01 -6.18817D-08 -1.97032D-03 -7.01501D-03
-   44    2.41085D-01 -2.21956D-08  5.28371D-01  3.25540D-01 -1.18374D-08 -7.33009D-02 -2.66601D-01  5.39941D-08 -4.09923D-03  1.63567D-02
-   45   -5.06182D-08  1.18657D-01  1.79158D-08  1.64535D-08  3.63869D-02 -3.65039D-09  2.24979D-08 -8.64022D-03  4.35411D-08 -1.77699D-08
-   46    2.46812D-01  3.99414D-08  1.64425D-01  1.25538D-01  3.49139D-09 -4.20945D-01 -4.30100D-01 -4.35612D-08  4.85886D-02 -8.46606D-02
-   47   -1.41703D-01  2.60627D-08 -7.33009D-02 -2.66601D-01 -5.59302D-08  5.28371D-01  3.25540D-01  2.29521D-08 -2.88791D-02 -1.86665D-02
-   48    1.50268D-09 -3.69301D-02 -2.67911D-08 -1.16431D-08 -8.64022D-03 -4.40320D-08 -2.25001D-08  3.63869D-02  8.33967D-09  1.23063D-08
-   49   -4.34142D-02 -1.65954D-07  1.44244D-01 -3.12555D-01 -7.63349D-08 -5.14895D-02  1.27553D-02  3.68577D-07 -1.01108D-03 -2.54821D-02
-   50    4.50887D-03 -6.81159D-08  3.79823D-01 -3.85826D-01 -2.98690D-08 -3.79506D-02  1.58714D-02  1.29602D-07 -2.42382D-02 -3.63246D-02
-   51   -8.67536D-09  6.97688D-03 -6.93827D-08 -1.64797D-08  4.39838D-02  4.54972D-09  8.91688D-08  8.28467D-02 -2.75906D-07  1.94346D-07
-   52   -1.06061D-02 -1.49199D-08 -5.14892D-02  1.27557D-02 -2.45861D-07  1.44244D-01 -3.12556D-01  1.57995D-07 -3.56624D-02 -2.79762D-02
-   53    4.95096D-02 -7.53444D-08 -3.79505D-02  1.58716D-02  6.54560D-09  3.79822D-01 -3.85826D-01  1.74050D-07 -7.66773D-02  8.44602D-02
-   54    6.91692D-08  4.25911D-02  7.00479D-09 -5.91621D-08  8.28466D-02  7.87494D-08 -3.13881D-08  4.39838D-02  2.28361D-07  3.64646D-07
-   55    2.66660D-01 -1.49904D-07 -1.59043D-01 -5.00094D-02  2.28411D-07 -7.66038D-02  2.12922D-02  1.71877D-07  5.99663D-03  4.39783D-02
-   56   -1.13261D-01 -1.74617D-08  6.37264D-02  1.36143D-01  1.53197D-07  1.21671D-01 -5.72765D-02 -1.21481D-07  1.12237D-02 -1.44050D-02
-   57    5.62248D-08  1.57019D-03 -4.67587D-08 -4.26873D-08 -1.25471D-01  1.48625D-08  5.21638D-08 -2.59541D-01 -3.95877D-08  1.62455D-07
-   58   -4.82275D-03  9.97216D-08 -7.66037D-02  2.12921D-02 -1.28010D-07 -1.59043D-01 -5.00093D-02 -2.27831D-07  3.78133D-02  4.79183D-03
-   59    4.17090D-03  3.51662D-09  1.21670D-01 -5.72769D-02  9.03983D-08  6.37264D-02  1.36143D-01 -1.74884D-07  9.02780D-02 -2.31254D-02
-   60   -4.57273D-08 -8.72594D-02 -1.79337D-08 -2.80237D-08 -2.59541D-01  3.28212D-08  4.24850D-08 -1.25471D-01  7.99037D-08  2.65791D-07
+   12   -9.83818D-09  1.17721D+01
+   13    4.43995D+00 -6.40363D-08  6.51306D+01
+   14    6.23044D+00 -7.69067D-08 -5.68245D+00  6.65657D+01
+   15   -3.98006D-09  5.41715D-01  1.40090D-07  2.38462D-07  1.17872D+01
+   16    1.13604D+00 -4.08344D-08 -2.66827D+00 -3.53290D+00  7.85382D-08  6.51306D+01
+   17   -3.14760D+01 -6.32611D-08 -3.53290D+00 -4.23506D+00  6.16964D-08 -5.68245D+00  6.65657D+01
+   18    2.80903D-08 -5.20671D+00  1.17123D-07  2.14762D-07 -5.34556D-01 -3.31043D-09  6.52279D-08  1.17872D+01
+   19    2.26220D-01  5.87147D-08  4.79582D-01  1.79682D+00  4.52407D-08 -4.42336D-01  1.15828D+00 -8.49916D-08  3.73232D+02
+   20   -1.43419D-01  3.15975D-08 -9.54721D+00 -1.69570D+00 -4.65467D-08  7.09932D-01 -1.04052D+00 -1.09359D-07  1.13654D+02  1.06907D+02
+   21   -1.57713D-07 -2.54237D-01 -3.70112D-08 -8.32925D-08  9.56901D-01  4.02149D-08  5.23405D-08  2.14180D+00  4.52313D-08  1.35900D-08
+   22   -3.16206D+01  1.13568D-07 -4.42335D-01  1.15827D+00 -3.53370D-08  4.79581D-01  1.79682D+00 -1.58322D-07 -1.93614D-01 -1.70113D-01
+   23   -3.05537D+01  8.67509D-08  7.09932D-01 -1.04052D+00 -8.03893D-08 -9.54721D+00 -1.69570D+00 -1.23906D-07 -1.70126D-01  1.19976D-01
+   24   -1.26813D-07 -1.14741D+01 -1.92019D-08 -8.31970D-08  2.14180D+00  1.35593D-07 -1.69306D-08  9.56901D-01  2.39425D-07  1.47277D-07
+   25   -1.17323D+00  4.23539D-08 -7.85167D+01  4.84345D+01 -1.18860D-07  1.28126D-01 -2.98509D-01 -1.00325D-07  1.16150D+00  1.57818D-02
+   26   -4.41841D-01 -3.84539D-08  4.81983D+01 -5.80325D+01  1.15259D-07 -2.75202D-01  2.19820D-02  1.47293D-07  1.88580D-01  1.86030D+00
+   27   -5.56194D-08  2.21629D+00  8.03824D-09  4.57076D-08 -1.15804D+01  1.48765D-08  7.09866D-08 -2.59435D-01  4.63428D-08  3.84709D-08
+   28   -3.26051D+00 -3.63433D-09  1.28126D-01 -2.98509D-01 -2.68087D-08 -7.85167D+01  4.84345D+01 -2.87527D-08 -7.95667D-01  1.12280D+00
+   29   -3.85920D+00  1.50085D-09 -2.75202D-01  2.19822D-02  6.44016D-09  4.81983D+01 -5.80325D+01  4.23409D-08 -6.72933D-01  6.03017D-01
+   30   -2.54066D-08  1.04769D+00  3.08884D-08 -6.44760D-09 -2.59435D-01  5.58862D-08  2.11914D-08 -1.15804D+01  1.87392D-07  5.66733D-08
+   31    2.66583D+00  1.50811D-08  1.04035D-01 -2.78333D+00 -1.34277D-08 -4.12613D-01  7.86901D-02 -2.39015D-08  2.31107D-02 -4.43198D-01
+   32   -3.70760D+00  4.21960D-08 -1.77407D+00 -2.09789D+00 -4.44581D-08  5.21431D-01  5.69991D-01 -4.53632D-08  2.37112D-02  5.88499D-02
+   33    2.77294D-08  3.30793D-01  6.56791D-09 -2.70516D-08  2.33314D-01 -1.26610D-08  5.20331D-09  6.16229D-01  6.09460D-09  3.95353D-09
+   34   -7.18468D-02  1.16527D-08 -4.12613D-01  7.86902D-02 -1.65790D-08  1.04035D-01 -2.78333D+00 -3.09672D-08  4.47298D-01  5.82617D-01
+   35    8.43326D-01  4.06147D-08  5.21431D-01  5.69991D-01 -8.26121D-08 -1.77407D+00 -2.09789D+00 -7.29404D-08 -5.98275D-01  4.39618D-01
+   36    3.14434D-08  5.74224D-01 -1.65213D-08  3.32928D-10  6.16229D-01 -2.66113D-08  1.80133D-08  2.33314D-01 -9.45211D-08  1.10216D-08
+   37    7.03135D-01 -4.80747D-09  1.99774D-01  2.69218D-02  3.57940D-08 -3.35608D-02 -5.88819D-03  5.53023D-08  3.12817D-02 -5.09043D-02
+   38    5.12788D-01  4.17133D-08  5.21480D-01 -1.52950D+00 -1.00215D-07  3.62208D-02  4.48825D-02 -1.14361D-07  1.58149D-02 -4.62618D-01
+   39   -5.44207D-08 -2.57774D-01 -1.97022D-08 -1.18514D-07  7.12795D-01  2.95646D-08  3.87793D-09 -1.85659D-02  1.00294D-07  1.48303D-07
+   40    4.66838D-02  7.68931D-08 -3.35611D-02 -5.88810D-03 -7.80833D-08  1.99774D-01  2.69216D-02 -2.24883D-08  8.13105D-02 -4.00808D-01
+   41    7.80113D-02  5.90373D-08  3.62209D-02  4.48825D-02 -7.37803D-08  5.21480D-01 -1.52949D+00 -1.13177D-07  5.12163D-01 -1.03139D-01
+   42   -3.33283D-08  8.06066D-03 -7.35744D-08 -3.71129D-08 -1.85660D-02  1.56542D-08  5.11106D-08  7.12795D-01 -1.57554D-07 -3.38765D-08
+   43   -5.92808D-01  1.13619D-08 -4.20945D-01 -4.30100D-01 -1.66563D-08  1.64426D-01  1.25538D-01 -2.06143D-08 -1.97047D-03 -7.01500D-03
+   44    2.41085D-01 -9.62968D-09  5.28371D-01  3.25539D-01  8.25069D-09 -7.33008D-02 -2.66601D-01  1.65183D-08 -4.09904D-03  1.63568D-02
+   45   -4.62299D-09  1.18657D-01 -2.49641D-08 -1.29114D-08  3.63869D-02 -1.33154D-08  1.53514D-08 -8.64021D-03 -7.88015D-08 -2.61803D-08
+   46    2.46812D-01  1.96621D-08  1.64426D-01  1.25538D-01 -1.35113D-08 -4.20945D-01 -4.30100D-01 -4.02727D-09  4.85885D-02 -8.46605D-02
+   47   -1.41703D-01 -8.00692D-09 -7.33010D-02 -2.66601D-01  1.08717D-08  5.28371D-01  3.25539D-01  2.18871D-08 -2.88789D-02 -1.86667D-02
+   48   -1.23921D-09 -3.69301D-02 -2.99879D-08 -1.57362D-08 -8.64022D-03 -1.71350D-08  2.72244D-08  3.63869D-02 -7.26738D-08 -3.40003D-08
+   49   -4.34141D-02 -4.46038D-08  1.44243D-01 -3.12556D-01  7.35481D-08 -5.14892D-02  1.27549D-02  1.46455D-07 -1.01009D-03 -2.54820D-02
+   50    4.50866D-03 -1.69228D-08  3.79823D-01 -3.85826D-01 -1.83378D-09 -3.79504D-02  1.58712D-02  1.33241D-08 -2.42375D-02 -3.63246D-02
+   51   -1.09105D-08  6.97691D-03  1.50927D-08  4.05871D-08  4.39839D-02 -1.83235D-08  6.50565D-08  8.28467D-02 -1.12227D-07 -6.43398D-08
+   52   -1.06059D-02  3.59345D-08 -5.14898D-02  1.27553D-02  6.33450D-09  1.44244D-01 -3.12556D-01  5.90031D-08 -3.56615D-02 -2.79761D-02
+   53    4.95094D-02  4.91949D-08 -3.79505D-02  1.58714D-02 -8.52282D-08  3.79823D-01 -3.85827D-01 -7.56524D-08 -7.66766D-02  8.44604D-02
+   54   -4.15368D-08  4.25911D-02  4.56448D-08  5.44399D-08  8.28467D-02  3.80037D-08  4.90810D-08  4.39839D-02  2.28183D-09  1.39306D-08
+   55    2.66660D-01 -2.24701D-08 -1.59043D-01 -5.00092D-02  5.87290D-08 -7.66037D-02  2.12923D-02  5.10128D-08  5.99622D-03  4.39781D-02
+   56   -1.13262D-01  2.23308D-08  6.37269D-02  1.36143D-01 -5.37234D-08  1.21671D-01 -5.72763D-02 -9.17019D-08  1.12232D-02 -1.44051D-02
+   57    4.63210D-10  1.57016D-03 -1.53996D-08 -1.72199D-08 -1.25471D-01  8.67276D-09  1.24688D-08 -2.59541D-01 -3.42757D-08 -2.32369D-08
+   58   -4.82282D-03  2.75742D-08 -7.66037D-02  2.12923D-02  5.20648D-08 -1.59043D-01 -5.00092D-02  2.26250D-08  3.78127D-02  4.79167D-03
+   59    4.17054D-03  1.00261D-08  1.21671D-01 -5.72765D-02 -6.57783D-08  6.37264D-02  1.36143D-01 -1.00929D-07  9.02776D-02 -2.31254D-02
+   60   -4.55239D-08 -8.72594D-02  6.38624D-09  3.28989D-08 -2.59541D-01  2.96468D-08  7.04727D-08 -1.25471D-01 -1.15002D-07 -6.50241D-08
 
 
               21           22           23           24           25           26           27           28           29           30
    ----- ----- ----- ----- -----
    21    2.81963D+01
-   22   -5.32080D-07  3.73232D+02
-   23   -5.56793D-08  1.13654D+02  1.06907D+02
-   24   -1.06876D+00  2.38300D-07  1.33008D-07  2.81963D+01
-   25   -2.48979D-08 -7.95668D-01  1.12280D+00 -1.02522D-07  2.76990D+02
-   26    5.36665D-08 -6.72935D-01  6.03017D-01  9.91207D-08 -1.73687D+02  2.07219D+02
-   27   -5.03816D+00 -2.77767D-07 -1.74443D-07  1.20769D-01  1.39331D-07  1.04346D-07  2.74434D+01
-   28    2.09102D-07  1.16150D+00  1.57827D-02  1.27303D-07 -5.32475D-02  2.33621D-01 -2.64644D-07  2.76990D+02
-   29   -5.21919D-08  1.88579D-01  1.86030D+00  5.93512D-08  2.33619D-01 -2.63634D-02  3.52096D-07 -1.73687D+02  2.07219D+02
-   30    1.20769D-01  1.59361D-07 -7.63172D-08 -5.03816D+00  1.13578D-07 -4.66352D-08 -1.20447D+00 -2.40794D-07 -3.93542D-08  2.74434D+01
-   31   -8.02864D-08  4.47298D-01  5.82616D-01 -1.00004D-07  3.57239D-01  3.21426D-01 -1.16525D-07  1.36519D-01  3.94604D-01  5.98919D-08
-   32    4.81939D-09 -5.98274D-01  4.39619D-01 -5.31329D-08  4.85930D-01 -1.20193D-02 -3.75249D-08 -6.70919D-02 -9.51050D-02  1.21022D-07
-   33    3.84125D-02 -1.19191D-08 -1.61846D-08 -1.10639D+00 -2.32215D-08  1.22082D-08 -1.13016D+00  2.92669D-08  2.42657D-08  1.66746D-02
-   34    6.25882D-08  2.31111D-02 -4.43197D-01 -1.50911D-08  1.36520D-01  3.94605D-01  2.02596D-08  3.57240D-01  3.21427D-01  1.53694D-07
-   35    3.30005D-08  2.37103D-02  5.88501D-02 -2.36186D-08 -6.70924D-02 -9.51056D-02 -1.62759D-07  4.85930D-01 -1.20187D-02  1.88477D-08
-   36   -1.10639D+00  5.71692D-08  2.42650D-08  3.84124D-02  1.47409D-08 -5.21945D-08  1.66746D-02  8.84581D-08  3.29649D-09 -1.13016D+00
-   37    2.03957D-07  8.13097D-02 -4.00806D-01  1.02690D-07  1.17211D-01  4.78888D-02  4.38575D-07  1.29611D-02  2.27406D-02  1.81443D-07
-   38    7.80257D-08  5.12163D-01 -1.03139D-01  2.85733D-08  5.77979D-03 -5.69321D-03  8.36415D-08  1.25204D-02 -8.50400D-04  7.17188D-08
-   39   -2.14984D-01  1.11842D-07  9.56824D-08 -6.37001D-02  5.38427D-08 -8.10545D-08 -8.45826D-02 -1.23955D-07  3.68389D-08  3.51816D-02
-   40    5.76566D-08  3.12819D-02 -5.09032D-02 -5.08117D-08  1.29610D-02  2.27400D-02 -1.54791D-08  1.17211D-01  4.78892D-02 -2.59746D-07
-   41   -7.10918D-08  1.58137D-02 -4.62618D-01 -4.38901D-08  1.25205D-02 -8.50168D-04 -3.20809D-08  5.77960D-03 -5.69334D-03 -6.24059D-08
-   42   -6.37001D-02 -1.04035D-07 -3.63980D-08 -2.14984D-01  1.24296D-07  3.53027D-08  3.51816D-02 -4.71663D-08  2.56291D-08 -8.45825D-02
-   43    3.54154D-08  4.85884D-02 -8.46606D-02  5.52094D-08  1.15826D-02 -5.88975D-01 -5.42913D-08 -2.18474D-02 -8.93711D-02 -6.18260D-08
-   44    5.43137D-08 -2.88793D-02 -1.86665D-02  4.65883D-09  1.08853D-01 -2.98777D-01  9.23453D-08 -3.64270D-02 -1.01150D-01 -1.13111D-08
-   45    8.24963D-03  2.60187D-08 -1.18695D-09  3.45079D-02  4.68389D-08 -2.51764D-08  6.88313D-02  7.63817D-08 -5.18839D-08 -3.27958D-02
-   46   -1.13086D-08 -1.97027D-03 -7.01482D-03 -3.46394D-09 -2.18473D-02 -8.93712D-02 -2.75064D-08  1.15824D-02 -5.88975D-01  2.49764D-08
-   47    8.32780D-08 -4.09961D-03  1.63570D-02  4.41071D-08 -3.64272D-02 -1.01150D-01  1.36742D-08  1.08853D-01 -2.98777D-01 -4.04373D-08
-   48    3.45079D-02 -2.89424D-09  2.19822D-08  8.24964D-03 -1.16849D-08  2.61819D-08 -3.27957D-02  2.57339D-08  2.09549D-08  6.88313D-02
-   49    1.71381D-07 -3.56629D-02 -2.79750D-02  4.57679D-08  5.18806D-01 -2.74663D-01  2.96203D-07 -2.59171D-04 -1.74626D-02 -1.05615D-07
-   50    7.77387D-08 -7.66782D-02  8.44603D-02 -4.41407D-09 -7.23542D-01 -1.66405D+00  8.58078D-08  5.88825D-03 -5.98180D-03 -2.04161D-07
-   51    9.82933D-03 -1.98194D-07 -2.35570D-07 -8.40520D-02  2.59366D-07 -1.38623D-08  3.37401D-01 -1.47641D-07  1.51508D-08 -1.96349D-02
-   52    1.28174D-07 -1.00990D-03 -2.54806D-02  5.13358D-09 -2.59447D-04 -1.74631D-02  2.43536D-07  5.18807D-01 -2.74663D-01 -2.30482D-07
-   53    4.17887D-08 -2.42382D-02 -3.63245D-02  7.43132D-09  5.88838D-03 -5.98153D-03  2.91565D-07 -7.23542D-01 -1.66405D+00  1.12955D-08
-   54   -8.40520D-02  2.38392D-07 -9.71133D-08  9.82937D-03  1.93883D-07 -1.21898D-07 -1.96350D-02 -2.93767D-07 -3.07666D-08  3.37401D-01
-   55   -1.29338D-07  3.78122D-02  4.79166D-03 -2.59322D-08  3.23485D-01  2.53984D-01  6.03967D-08  4.04745D-02  1.06327D-01  1.13896D-07
-   56   -1.59082D-07  9.02774D-02 -2.31253D-02 -1.06650D-08  3.14445D-02  1.24388D-01 -1.74695D-07 -3.81309D-02 -5.95695D-02  1.06843D-07
-   57    4.13063D-03 -9.18877D-08 -1.29388D-07  3.25722D-01  1.89696D-07 -6.79021D-08  1.25434D-01 -1.27999D-07 -1.10831D-08  1.38572D-02
-   58   -8.86298D-08  5.99758D-03  4.39794D-02  4.14831D-08  4.04745D-02  1.06327D-01 -1.12046D-07  3.23485D-01  2.53984D-01 -1.86139D-08
-   59   -1.33972D-07  1.12222D-02 -1.44051D-02 -6.19218D-09 -3.81315D-02 -5.95695D-02 -1.95381D-07  3.14442D-02  1.24388D-01  1.31483D-07
-   60    3.25722D-01  7.91706D-08 -7.75393D-08  4.13062D-03  1.19747D-07 -5.32599D-08  1.38572D-02 -2.08327D-07  1.14591D-08  1.25434D-01
+   22   -5.33246D-07  3.73232D+02
+   23   -1.15960D-07  1.13654D+02  1.06907D+02
+   24   -1.06876D+00  2.37254D-07  1.45124D-07  2.81963D+01
+   25    2.64487D-07 -7.95668D-01  1.12280D+00 -1.15168D-07  2.76990D+02
+   26   -3.40206D-08 -6.72935D-01  6.03017D-01  7.70636D-08 -1.73687D+02  2.07219D+02
+   27   -5.03816D+00 -6.76113D-08 -4.50622D-08  1.20769D-01  2.33328D-07 -1.48805D-07  2.74434D+01
+   28    3.24826D-07  1.16150D+00  1.57821D-02 -1.74288D-07 -5.32475D-02  2.33620D-01  2.75923D-08  2.76990D+02
+   29   -1.14486D-07  1.88579D-01  1.86030D+00  4.33612D-08  2.33619D-01 -2.63627D-02 -1.86310D-08 -1.73687D+02  2.07219D+02
+   30    1.20769D-01 -7.83648D-08 -3.09615D-08 -5.03816D+00  2.13912D-07 -2.10133D-07 -1.20447D+00  1.97765D-07 -1.32602D-07  2.74434D+01
+   31   -8.42235D-08  4.47298D-01  5.82616D-01  3.39089D-08  3.57239D-01  3.21426D-01  5.24485D-08  1.36519D-01  3.94604D-01 -4.74896D-08
+   32    1.82637D-07 -5.98275D-01  4.39619D-01  7.73575D-08  4.85930D-01 -1.20191D-02  3.43292D-08 -6.70915D-02 -9.51054D-02  1.72487D-08
+   33    3.84125D-02 -1.02624D-08 -6.04877D-08 -1.10639D+00  3.74525D-08  6.47531D-10 -1.13016D+00  6.63563D-08 -2.01513D-08  1.66746D-02
+   34   -1.90075D-07  2.31110D-02 -4.43197D-01  3.98343D-08  1.36519D-01  3.94605D-01  9.14591D-09  3.57239D-01  3.21427D-01 -6.34599D-08
+   35    1.27859D-07  2.37101D-02  5.88500D-02  2.02941D-08 -6.70928D-02 -9.51055D-02 -3.36753D-08  4.85930D-01 -1.20193D-02 -1.89019D-08
+   36   -1.10639D+00 -4.89037D-08 -4.68396D-08  3.84125D-02  2.21059D-08  2.46769D-08  1.66746D-02  1.70116D-08 -4.36307D-08 -1.13016D+00
+   37    2.22670D-07  8.13097D-02 -4.00807D-01 -8.80080D-08  1.17212D-01  4.78891D-02 -2.65067D-08  1.29615D-02  2.27403D-02  4.90523D-08
+   38   -8.50660D-08  5.12163D-01 -1.03139D-01  1.64553D-09  5.77944D-03 -5.69310D-03 -2.29893D-08  1.25201D-02 -8.50146D-04 -5.13788D-08
+   39   -2.14984D-01  6.14550D-08  7.50897D-08 -6.37001D-02  1.54252D-08  5.18793D-08 -8.45826D-02 -2.26240D-08  3.52598D-08  3.51816D-02
+   40    2.78708D-07  3.12817D-02 -5.09037D-02 -3.85984D-08  1.29615D-02  2.27402D-02 -1.60407D-07  1.17212D-01  4.78890D-02 -8.25332D-08
+   41   -7.30502D-09  1.58140D-02 -4.62618D-01  4.80784D-08  1.25202D-02 -8.50100D-04 -1.52994D-08  5.77923D-03 -5.69306D-03 -3.32263D-08
+   42   -6.37001D-02  7.95427D-09 -4.88908D-10 -2.14984D-01  3.07515D-08  3.72646D-08  3.51817D-02 -2.23703D-08  1.16171D-07 -8.45825D-02
+   43    3.15891D-08  4.85883D-02 -8.46605D-02  1.65903D-08  1.15824D-02 -5.88975D-01  1.46904D-08 -2.18472D-02 -8.93714D-02 -4.91364D-09
+   44    6.20332D-08 -2.88791D-02 -1.86667D-02 -2.91574D-08  1.08853D-01 -2.98777D-01 -8.51590D-09 -3.64270D-02 -1.01150D-01  6.07916D-08
+   45    8.24961D-03 -2.79880D-08 -3.01844D-09  3.45079D-02 -4.63137D-08  3.57365D-08  6.88313D-02 -7.50839D-10  1.13406D-08 -3.27957D-02
+   46    6.60132D-08 -1.97026D-03 -7.01479D-03  2.59826D-09 -2.18474D-02 -8.93712D-02  3.72984D-08  1.15827D-02 -5.88975D-01  2.95875D-08
+   47    7.73676D-08 -4.09942D-03  1.63568D-02 -2.81172D-08 -3.64271D-02 -1.01150D-01 -1.36139D-08  1.08853D-01 -2.98777D-01  4.99227D-08
+   48    3.45079D-02 -4.59552D-08 -4.99830D-09  8.24960D-03 -3.43722D-08  3.61349D-08 -3.27957D-02 -1.92983D-08  2.61313D-08  6.88313D-02
+   49    2.66930D-07 -3.56628D-02 -2.79754D-02 -3.44270D-08  5.18807D-01 -2.74662D-01 -6.17289D-08 -2.59392D-04 -1.74619D-02  7.59935D-08
+   50   -1.21989D-08 -7.66779D-02  8.44603D-02 -3.68127D-08 -7.23542D-01 -1.66405D+00 -5.02914D-08  5.88774D-03 -5.98099D-03  2.83256D-08
+   51    9.82929D-03 -1.19579D-07 -9.30539D-08 -8.40519D-02  1.91518D-07 -8.19864D-08  3.37401D-01  1.65742D-07 -2.03534D-08 -1.96349D-02
+   52    2.75811D-07 -1.01001D-03 -2.54811D-02 -5.23523D-08 -2.58899D-04 -1.74628D-02 -6.92404D-08  5.18806D-01 -2.74662D-01  1.33426D-08
+   53    5.76806D-08 -2.42380D-02 -3.63245D-02  4.48667D-08  5.88837D-03 -5.98135D-03 -7.59131D-08 -7.23543D-01 -1.66405D+00 -4.33381D-08
+   54   -8.40520D-02 -1.97880D-07 -7.82957D-08  9.82931D-03  2.03583D-07 -1.38878D-07 -1.96349D-02  1.76355D-07 -1.62063D-08  3.37401D-01
+   55   -1.08474D-07  3.78121D-02  4.79194D-03  5.55575D-08  3.23485D-01  2.53984D-01  1.45211D-07  4.04740D-02  1.06327D-01  4.31931D-08
+   56   -2.54598D-07  9.02777D-02 -2.31248D-02  7.42530D-08  3.14440D-02  1.24388D-01  1.03675D-07 -3.81315D-02 -5.95693D-02 -3.29460D-08
+   57    4.13066D-03 -1.54008D-07 -5.60122D-08  3.25722D-01  1.58899D-07 -1.06896D-07  1.25434D-01  8.75531D-08 -1.72740D-08  1.38572D-02
+   58   -1.04201D-07  5.99749D-03  4.39796D-02 -2.67375D-09  4.04744D-02  1.06327D-01  1.86489D-07  3.23485D-01  2.53984D-01  1.82576D-08
+   59   -2.44841D-07  1.12224D-02 -1.44046D-02  1.16664D-07 -3.81320D-02 -5.95696D-02  1.15641D-07  3.14436D-02  1.24388D-01  8.67267D-11
+   60    3.25722D-01 -2.02700D-07 -5.98183D-08  4.13068D-03  1.11294D-07 -1.15556D-07  1.38572D-02  1.62947D-07 -6.11672D-09  1.25434D-01
 
 
               31           32           33           34           35           36           37           38           39           40
    ----- ----- ----- ----- -----
    31    7.32551D+01
    32   -1.18227D+01  6.42682D+01
-   33    8.26488D-08 -4.67030D-08  1.15294D+01
-   34   -1.45585D-02 -7.58459D-02 -1.66936D-08  7.32550D+01
-   35   -7.58431D-02  2.73109D-01 -7.88901D-09 -1.18227D+01  6.42682D+01
-   36    1.31416D-08 -2.33035D-08 -8.41952D-02 -2.27566D-07  8.50862D-08  1.15294D+01
-   37   -1.09714D+02 -2.12668D+01  2.29413D-08  1.19695D-02  3.17050D-03  1.26455D-07  3.92887D+02
-   38   -2.21073D+01 -2.37593D+01  2.25123D-08  4.03139D-02  8.20000D-03  2.85430D-08  7.49289D+01  8.59875D+01
-   39   -5.03080D-09  9.29416D-08 -1.27671D+01 -5.36127D-09 -4.61532D-08 -5.09814D-03  1.01594D-07  2.63112D-08  2.99937D+01
-   40    1.19699D-02  3.17145D-03 -1.72342D-08 -1.09714D+02 -2.12668D+01  1.08732D-07  1.83715D-03 -4.18795D-03 -1.15444D-07  3.92887D+02
-   41    4.03132D-02  8.19972D-03 -2.31065D-08 -2.21073D+01 -2.37593D+01 -1.66013D-08 -4.18729D-03  2.71780D-03  2.74603D-08  7.49289D+01
-   42   -6.32921D-09  8.29045D-08 -5.09814D-03  6.02007D-08 -9.76333D-08 -1.27671D+01  8.84714D-08 -8.62027D-08  2.12162D-02 -8.59416D-08
-   43   -3.08024D+01  1.93767D+01 -2.18687D-08  4.91595D-04  1.00159D-01 -3.16290D-08 -4.52040D+00  9.25890D+00  6.28666D-08 -2.10596D-03
-   44    2.12256D+01 -3.26593D+01  3.80000D-08  3.89336D-02 -8.43458D-02 -7.62673D-09 -2.77523D+00  2.37426D+00 -4.72371D-08 -5.60318D-03
-   45   -3.36937D-11 -1.97949D-08 -4.37979D+00  2.87889D-09  4.24806D-08  7.21893D-03  4.88042D-08 -1.45041D-08  1.64765D+00  1.41241D-08
-   46    4.91673D-04  1.00159D-01  1.81734D-08 -3.08024D+01  1.93767D+01  3.71297D-08 -2.10605D-03 -9.48199D-03  2.39444D-08 -4.52040D+00
-   47    3.89336D-02 -8.43458D-02  1.62397D-08  2.12256D+01 -3.26593D+01  3.76638D-10 -5.60355D-03 -1.90099D-02 -6.91154D-08 -2.77523D+00
-   48    2.15976D-09 -3.61937D-08  7.21893D-03  3.50854D-08  2.12524D-08 -4.37979D+00 -2.62477D-08  3.49209D-08  1.35104D-03 -4.04795D-08
-   49   -3.93652D+00 -2.31294D+00  2.72144D-09  5.06804D-02  2.47853D-02  7.06855D-08 -5.74257D-01  2.24398D+00 -9.08556D-09 -5.90956D-03
-   50    8.58379D+00  3.32975D+00 -1.64573D-08 -8.69966D-03  4.14707D-03 -1.36861D-08  2.11919D+00 -3.71534D+00 -4.63997D-08  2.62258D-03
-   51    1.65634D-08  7.78528D-08  1.37877D+00 -1.34159D-08  3.55259D-09  1.78808D-02 -2.99143D-07 -1.50358D-07  1.39446D+01  4.01196D-07
-   52    5.06808D-02  2.47863D-02 -9.46469D-09 -3.93652D+00 -2.31294D+00  1.35183D-07 -5.90941D-03 -2.65149D-02  2.68654D-08 -5.74257D-01
-   53   -8.69999D-03  4.14725D-03  5.35754D-08  8.58379D+00  3.32975D+00  9.50572D-08  2.62297D-03 -6.83704D-03  1.56974D-07  2.11919D+00
-   54    7.40685D-08  6.20633D-08  1.78808D-02  1.07132D-07 -4.64012D-08  1.37877D+00 -4.15115D-07 -1.24557D-07  1.99040D-03  2.18019D-07
-   55    2.84552D+00  8.23532D+00 -4.08446D-08 -1.92408D-02 -1.25967D-02 -8.37163D-08  1.91452D+00 -5.08784D-02 -4.37961D-08  1.54756D-02
-   56   -3.57282D+00 -4.53345D+00 -2.23281D-08 -2.93012D-02 -1.54395D-02 -7.51314D-09 -1.41106D-01  1.64625D+00  2.66188D-08  1.36372D-03
-   57   -1.58787D-08  8.43508D-08  1.61674D+00 -6.23179D-08 -4.24843D-08 -4.00647D-03 -2.55858D-07 -1.12396D-07 -9.21250D+00  3.23269D-07
-   58   -1.92409D-02 -1.25952D-02  1.48071D-08  2.84552D+00  8.23532D+00  6.02274D-08  1.54760D-02  1.43629D-02  4.22612D-08  1.91452D+00
-   59   -2.93025D-02 -1.54394D-02 -7.57775D-08 -3.57282D+00 -4.53345D+00 -3.71304D-08  1.36287D-03  1.19701D-02  6.96415D-08 -1.41107D-01
-   60    7.23423D-08  1.07851D-07 -4.00651D-03  1.44388D-07 -8.77973D-08  1.61674D+00 -3.67792D-07 -1.43393D-07  1.64976D-02  1.69389D-07
+   33   -7.34379D-09  2.82525D-08  1.15294D+01
+   34   -1.45584D-02 -7.58459D-02  3.35244D-08  7.32550D+01
+   35   -7.58431D-02  2.73109D-01 -2.98820D-09 -1.18227D+01  6.42682D+01
+   36    5.70690D-10 -2.13848D-08 -8.41952D-02  2.06982D-07 -3.08216D-08  1.15294D+01
+   37   -1.09714D+02 -2.12668D+01 -3.90584D-08  1.19696D-02  3.17042D-03  6.43622D-09  3.92887D+02
+   38   -2.21073D+01 -2.37593D+01 -1.39213D-08  4.03139D-02  8.19998D-03 -1.66186D-08  7.49289D+01  8.59875D+01
+   39    7.65929D-09  2.86902D-08 -1.27671D+01  5.95597D-09  4.70015D-09 -5.09811D-03  7.23344D-08  3.78405D-08  2.99937D+01
+   40    1.19697D-02  3.17145D-03 -8.56414D-08 -1.09714D+02 -2.12668D+01 -1.08402D-07  1.83723D-03 -4.18802D-03 -9.33405D-08  3.92887D+02
+   41    4.03133D-02  8.19975D-03 -1.61376D-09 -2.21073D+01 -2.37593D+01 -1.02134D-08 -4.18759D-03  2.71779D-03  9.69527D-09  7.49289D+01
+   42    5.91200D-10  4.18688D-08 -5.09809D-03 -8.31436D-08 -1.51391D-08 -1.27671D+01  3.49799D-08  9.88194D-09  2.12162D-02  5.53882D-08
+   43   -3.08024D+01  1.93767D+01  2.77793D-09  4.91655D-04  1.00159D-01  1.11277D-08 -4.52040D+00  9.25890D+00 -3.77794D-09 -2.10628D-03
+   44    2.12256D+01 -3.26593D+01 -7.64073D-09  3.89336D-02 -8.43458D-02  1.03971D-08 -2.77523D+00  2.37426D+00  2.74159D-09 -5.60330D-03
+   45    7.55828D-09 -7.39492D-09 -4.37979D+00  2.05895D-08 -8.84346D-10  7.21892D-03  2.16772D-09  2.16503D-09  1.64765D+00 -1.07123D-08
+   46    4.91707D-04  1.00159D-01  9.24717D-09 -3.08024D+01  1.93767D+01 -1.72024D-08 -2.10619D-03 -9.48194D-03  1.06753D-08 -4.52040D+00
+   47    3.89334D-02 -8.43458D-02 -1.59481D-08  2.12256D+01 -3.26593D+01  1.01874D-08 -5.60343D-03 -1.90100D-02  5.89361D-09 -2.77523D+00
+   48    4.95084D-09 -9.39071D-10  7.21894D-03 -1.80218D-08  2.66766D-08 -4.37979D+00 -2.41334D-08  1.98976D-08  1.35102D-03 -1.12531D-08
+   49   -3.93652D+00 -2.31294D+00 -2.80976D-08  5.06804D-02  2.47853D-02  5.37633D-09 -5.74257D-01  2.24398D+00 -6.48365D-08 -5.90901D-03
+   50    8.58379D+00  3.32975D+00 -3.26970D-08 -8.69974D-03  4.14714D-03  2.51659D-08  2.11919D+00 -3.71534D+00 -6.51243D-08  2.62294D-03
+   51    1.13101D-08 -1.30609D-07  1.37877D+00 -4.96065D-08  7.84075D-08  1.78808D-02  2.31851D-07  1.50218D-07  1.39446D+01  2.99914D-07
+   52    5.06804D-02  2.47868D-02 -9.66635D-08 -3.93652D+00 -2.31294D+00 -7.35496D-08 -5.90905D-03 -2.65151D-02 -9.56247D-08 -5.74257D-01
+   53   -8.70013D-03  4.14767D-03 -4.23710D-08  8.58379D+00  3.32975D+00 -1.72100D-09  2.62314D-03 -6.83708D-03 -3.75939D-08  2.11919D+00
+   54    2.74007D-08 -5.55947D-08  1.78807D-02 -1.10207D-07  5.68899D-08  1.37877D+00  1.20726D-07  1.56183D-07  1.99043D-03  2.37534D-07
+   55    2.84552D+00  8.23532D+00  7.60201D-08 -1.92411D-02 -1.25968D-02  3.59526D-08  1.91452D+00 -5.08786D-02  1.10591D-07  1.54758D-02
+   56   -3.57282D+00 -4.53345D+00  6.51801D-08 -2.93015D-02 -1.54395D-02  3.77949D-08 -1.41107D-01  1.64625D+00  1.29373D-07  1.36363D-03
+   57    3.37675D-08 -1.06191D-07  1.61674D+00 -2.61745D-08  4.59145D-08 -4.00649D-03  1.51529D-07  1.18680D-07 -9.21250D+00  2.59601D-07
+   58   -1.92408D-02 -1.25952D-02  6.08246D-08  2.84552D+00  8.23532D+00 -9.28094D-08  1.54756D-02  1.43628D-02  6.06301D-08  1.91452D+00
+   59   -2.93022D-02 -1.54394D-02  8.89504D-08 -3.57282D+00 -4.53345D+00  2.61201D-08  1.36246D-03  1.19700D-02  5.26002D-08 -1.41107D-01
+   60    6.75336D-09 -8.21317D-08 -4.00654D-03 -1.33383D-07  3.63370D-08  1.61674D+00  1.62530D-07  8.45505D-08  1.64976D-02  2.44820D-07
 
 
               41           42           43           44           45           46           47           48           49           50
    ----- ----- ----- ----- -----
    41    8.59875D+01
-   42    1.34798D-08  2.99937D+01
-   43   -9.48198D-03  5.79359D-08  7.25691D+01
-   44   -1.90100D-02  3.75182D-08 -8.85240D+00  7.42920D+01
-   45    5.09673D-09  1.35103D-03 -7.04103D-08  4.40174D-08  9.49621D+00
-   46    9.25890D+00  3.64819D-08  2.22327D-02 -4.09563D-02  9.00143D-10  7.25691D+01
-   47    2.37426D+00  8.11468D-08 -4.09560D-02  1.72744D-02 -1.40590D-08 -8.85240D+00  7.42920D+01
-   48    3.60562D-08  1.64765D+00  1.34799D-08  2.78713D-08  8.62527D-04  3.11661D-08 -1.40491D-07  9.49621D+00
-   49   -2.65148D-02 -1.26667D-07 -1.15042D+02 -1.70493D+01  4.34896D-08 -2.14058D-02 -2.96515D-02 -6.03901D-08  4.10722D+02
-   50   -6.83693D-03 -2.12329D-07 -1.76173D+01 -2.32520D+01 -3.67448D-08 -4.96068D-04  1.52084D-03  2.32483D-08  6.01951D+01  7.17929D+01
-   51    8.25535D-08  1.99039D-03  9.46193D-08 -5.53467D-08 -1.11479D+01 -1.15643D-07 -6.46022D-09 -2.99346D-03  6.13556D-08  1.98598D-07
-   52    2.24398D+00 -1.62892D-07 -2.14061D-02 -2.96512D-02  1.48419D-08 -1.15042D+02 -1.70493D+01 -7.14459D-08 -6.55011D-02 -5.10955D-03
-   53   -3.71534D+00 -4.03543D-08 -4.96199D-04  1.52081D-03 -3.55106D-08 -1.76173D+01 -2.32520D+01  3.68388D-08 -5.11058D-03 -3.54012D-03
-   54    1.16570D-07  1.39446D+01  3.95709D-08 -4.08327D-08 -2.99348D-03 -1.78013D-07  9.84740D-08 -1.11479D+01 -1.54352D-07  9.49989D-08
-   55    1.43624D-02  1.87300D-09 -2.89083D+01 -2.92937D+01  7.13300D-08  1.07988D-02  1.30958D-02  9.75937D-09 -1.13405D+00 -2.96585D+01
-   56    1.19696D-02  9.65344D-09 -2.83531D+01 -1.09348D+02 -2.50723D-09  1.09918D-02  1.33373D-02  2.75213D-08  7.45814D+00  1.82241D+00
-   57    1.30687D-07  1.64975D-02  1.21210D-07 -9.26911D-08 -1.02031D+01 -4.53927D-08 -1.94415D-08 -2.85164D-03 -3.59456D-08  1.54741D-07
-   58   -5.08783D-02  9.59838D-08  1.07989D-02  1.30961D-02  1.34400D-09 -2.89083D+01 -2.92937D+01  1.48473D-08  3.00003D-02 -3.60580D-04
-   59    1.64625D+00  1.09808D-07  1.09917D-02  1.33370D-02  3.39709D-08 -2.83531D+01 -1.09348D+02  7.19122D-08  3.00253D-02  3.83244D-03
-   60    9.43141D-08 -9.21250D+00 -2.47219D-08 -5.60326D-08 -2.85161D-03 -1.16448D-07  1.10343D-07 -1.02031D+01  3.04679D-08  1.78875D-07
+   42   -8.55459D-09  2.99937D+01
+   43   -9.48203D-03  2.55976D-08  7.25691D+01
+   44   -1.90100D-02 -1.45851D-08 -8.85240D+00  7.42920D+01
+   45    1.50562D-08  1.35102D-03  3.26921D-08 -1.23244D-08  9.49621D+00
+   46    9.25890D+00  3.25497D-08  2.22327D-02 -4.09563D-02  2.58679D-09  7.25691D+01
+   47    2.37426D+00 -7.02038D-09 -4.09559D-02  1.72744D-02  3.76576D-08 -8.85240D+00  7.42920D+01
+   48    9.82066D-09  1.64765D+00  4.60981D-09  4.26909D-09  8.62542D-04  1.68645D-08 -8.88844D-09  9.49621D+00
+   49   -2.65149D-02 -9.64825D-08 -1.15042D+02 -1.70493D+01  1.10047D-07 -2.14061D-02 -2.96516D-02  1.35411D-07  4.10722D+02
+   50   -6.83684D-03 -1.13706D-07 -1.76173D+01 -2.32520D+01  4.82875D-08 -4.96216D-04  1.52067D-03  6.36492D-08  6.01951D+01  7.17929D+01
+   51    1.50794D-08  1.99044D-03 -9.40780D-09  4.55628D-09 -1.11479D+01 -3.75699D-08 -8.20729D-08 -2.99343D-03 -6.59781D-08  1.85515D-07
+   52    2.24398D+00 -1.04652D-07 -2.14058D-02 -2.96514D-02  1.16948D-07 -1.15042D+02 -1.70493D+01  1.13949D-07 -6.55011D-02 -5.10955D-03
+   53   -3.71534D+00 -5.14294D-08 -4.96077D-04  1.52073D-03  6.61978D-08 -1.76173D+01 -2.32520D+01  6.83288D-08 -5.11062D-03 -3.54011D-03
+   54    6.98829D-08  1.39446D+01  1.77503D-08 -3.91148D-08 -2.99338D-03 -5.87747D-08 -2.12408D-08 -1.11479D+01 -2.88828D-07  5.65041D-08
+   55    1.43625D-02  1.84375D-07 -2.89083D+01 -2.92937D+01 -9.36026D-08  1.07989D-02  1.30958D-02 -7.67324D-08 -1.13405D+00 -2.96585D+01
+   56    1.19698D-02  1.33315D-07 -2.83531D+01 -1.09348D+02 -1.02649D-07  1.09921D-02  1.33372D-02 -1.03697D-07  7.45814D+00  1.82241D+00
+   57    3.90889D-08  1.64976D-02 -3.97449D-09  3.06788D-08 -1.02031D+01 -4.37020D-08 -2.70939D-08 -2.85160D-03 -1.23315D-07  9.26699D-08
+   58   -5.08783D-02  2.15235D-07  1.07988D-02  1.30961D-02 -8.26108D-08 -2.89083D+01 -2.92937D+01 -6.71094D-08  3.00005D-02 -3.60473D-04
+   59    1.64625D+00  1.66616D-07  1.09914D-02  1.33372D-02 -7.64022D-08 -2.83531D+01 -1.09348D+02 -1.10360D-07  3.00255D-02  3.83237D-03
+   60    2.61691D-08 -9.21250D+00  4.74665D-09 -9.20729D-09 -2.85155D-03 -2.77293D-08  7.30073D-09 -1.02031D+01 -2.13482D-07  4.80994D-08
 
 
               51           52           53           54           55           56           57           58           59           60
    ----- ----- ----- ----- -----
    51    2.48989D+01
-   52    2.26329D-07  4.10722D+02
-   53    9.46992D-08  6.01951D+01  7.17929D+01
-   54    8.02291D-03  1.37094D-07 -1.97163D-07  2.48989D+01
-   55   -6.76629D-08  3.00002D-02 -3.60849D-04  1.05361D-07  9.18342D+01
-   56   -7.89450D-08  3.00266D-02  3.83231D-03  7.11218D-08  9.99966D+01  3.89498D+02
-   57    2.21075D+00  1.96505D-07 -2.37229D-07 -2.25616D-02  1.35227D-07  1.15370D-07  2.48213D+01
-   58   -2.45083D-08 -1.13405D+00 -2.96585D+01  8.74113D-08 -4.51994D-03 -1.94394D-02  9.78836D-08  9.18342D+01
-   59   -1.17397D-07  7.45814D+00  1.82241D+00  8.59016D-08 -1.94325D-02 -2.26017D-02  1.49371D-07  9.99966D+01  3.89498D+02
-   60   -2.25617D-02  1.19397D-07 -1.57679D-07  2.21075D+00  1.51433D-07  9.60317D-08  4.02254D-02 -1.36635D-07 -5.97158D-08  2.48213D+01
+   52    6.84564D-08  4.10722D+02
+   53    8.19833D-08  6.01951D+01  7.17929D+01
+   54    8.02286D-03 -2.00981D-08  1.42347D-09  2.48989D+01
+   55    1.23340D-08  3.00001D-02 -3.60682D-04 -6.01000D-08  9.18342D+01
+   56   -4.98150D-08  3.00264D-02  3.83256D-03  1.12411D-08  9.99966D+01  3.89498D+02
+   57    2.21075D+00 -7.64127D-09 -3.59544D-08 -2.25618D-02  1.08087D-07  1.63859D-07  2.48213D+01
+   58   -2.11466D-08 -1.13405D+00 -2.96585D+01  4.89385D-08 -4.51974D-03 -1.94395D-02 -2.70075D-08  9.18342D+01
+   59    1.23434D-08  7.45814D+00  1.82241D+00  5.30428D-08 -1.94322D-02 -2.26017D-02 -8.54125D-09  9.99966D+01  3.89498D+02
+   60   -2.25618D-02 -6.18527D-10 -3.72288D-08  2.21075D+00  5.20374D-08  2.03803D-07  4.02255D-02  1.16456D-07  1.38211D-07  2.48213D+01
 
  center of mass
  --------------
@@ -1974,9 +2731,9 @@ Iterative solution of linear equations
 
  moments of inertia (a.u.)
  ------------------
-        2631.731379210398          -0.000000000000           0.000000000000
-          -0.000000000000         390.819001468288           0.000000000000
-           0.000000000000           0.000000000000        3022.550380678686
+        2631.731379210404           0.000000000000           0.000000000000
+           0.000000000000         390.819001468288           0.000000000000
+           0.000000000000           0.000000000000        3022.550380678692
 
  Rotational Constants
  --------------------
@@ -2011,393 +2768,393 @@ Iterative solution of linear equations
 
                     1           2           3           4           5           6
  
- P.Frequency       -0.00       -0.00       -0.00        0.00        0.00        0.00
+ P.Frequency       -0.00        0.00        0.00        0.00        0.00        0.00
  
-           1     0.09949    -0.00000    -0.00000    -0.00000     0.01221    -0.00171
-           2    -0.00244     0.00000     0.00000     0.00000    -0.00025     0.08802
-           3     0.00000    -0.02062    -0.08887    -0.05089    -0.00000    -0.00000
-           4     0.06315     0.00000     0.00000     0.00000    -0.07763     0.00603
-           5     0.00365    -0.00000    -0.00000    -0.00000     0.01480     0.08673
-           6     0.00000    -0.07484     0.00861    -0.07238    -0.00000    -0.00000
-           7     0.08760     0.00000    -0.00000    -0.00000    -0.01717     0.00082
-           8    -0.01631     0.00000     0.00000     0.00000    -0.03455     0.09098
-           9    -0.00000     0.05877    -0.07218    -0.12325     0.00000    -0.00000
-          10     0.07504    -0.00000     0.00000     0.00000    -0.04824     0.00350
-          11     0.01752    -0.00000    -0.00000    -0.00000     0.04910     0.08377
-          12    -0.00000    -0.15424    -0.00808    -0.00002     0.00000    -0.00000
-          13     0.06983    -0.00000     0.00000     0.00000    -0.06112     0.00461
-          14    -0.01336     0.00000     0.00000     0.00000    -0.02724     0.09035
-          15     0.00000     0.03239    -0.02451    -0.13385    -0.00000    -0.00000
-          16     0.09281     0.00000    -0.00000    -0.00000    -0.00429    -0.00029
-          17     0.01457    -0.00000    -0.00000    -0.00000     0.04180     0.08440
-          18     0.00000    -0.12785    -0.05575     0.01058    -0.00000    -0.00000
-          19     0.09248     0.00000     0.00000    -0.00000    -0.00511    -0.00021
-          20    -0.02956     0.00000    -0.00000     0.00000    -0.06730     0.09379
-          21    -0.00000     0.14215    -0.09716    -0.17156     0.00000    -0.00000
-          22     0.07016    -0.00000     0.00000     0.00000    -0.06030     0.00454
-          23     0.03077    -0.00000     0.00000    -0.00000     0.08185     0.08096
-          24    -0.00000    -0.23762     0.01690     0.04829     0.00000    -0.00000
-          25     0.06093    -0.00000    -0.00000     0.00000    -0.08311     0.00650
-          26    -0.02429     0.00000     0.00000     0.00000    -0.05427     0.09267
-          27     0.00000     0.09516    -0.01254    -0.19026    -0.00000    -0.00000
-          28     0.10171     0.00000     0.00000    -0.00000     0.01770    -0.00218
-          29     0.02550    -0.00000    -0.00000    -0.00000     0.06882     0.08208
-          30     0.00000    -0.19062    -0.06772     0.06699    -0.00000    -0.00000
-          31     0.04430     0.00000     0.00000     0.00000    -0.12425     0.01004
-          32     0.00747    -0.00000    -0.00000    -0.00000     0.02425     0.08591
-          33     0.00000    -0.10706     0.05985    -0.08078    -0.00000    -0.00000
-          34     0.11835    -0.00000    -0.00000    -0.00000     0.05884    -0.00572
-          35    -0.00626     0.00000     0.00000     0.00000    -0.00970     0.08884
-          36     0.00000     0.01160    -0.14011    -0.04249    -0.00000    -0.00000
-          37     0.04107     0.00000     0.00000     0.00000    -0.13222     0.01073
-          38     0.02124     0.00000     0.00000     0.00000     0.05831     0.08298
-          39    -0.00000    -0.19289     0.08116    -0.02819     0.00000    -0.00000
-          40     0.12157    -0.00000    -0.00000    -0.00000     0.06681    -0.00641
-          41    -0.02003    -0.00000    -0.00000    -0.00000    -0.04375     0.09177
-          42    -0.00000     0.09743    -0.16142    -0.09508     0.00000    -0.00000
-          43     0.03145    -0.00000    -0.00000    -0.00000    -0.15601     0.01277
-          44    -0.00407    -0.00000    -0.00000    -0.00000    -0.00429     0.08837
-          45    -0.00000    -0.04237     0.08119    -0.14477     0.00000     0.00000
-          46     0.13119     0.00000     0.00000     0.00000     0.09059    -0.00845
-          47     0.00528     0.00000     0.00000     0.00000     0.01884     0.08638
-          48    -0.00000    -0.05309    -0.16145     0.02150     0.00000     0.00000
-          49     0.03377    -0.00000    -0.00000    -0.00000    -0.15028     0.01228
-          50    -0.01796    -0.00000    -0.00000    -0.00000    -0.03863     0.09133
-          51    -0.00000     0.04374     0.06204    -0.19900    -0.00000     0.00000
-          52     0.12888     0.00000     0.00000     0.00000     0.08487    -0.00796
-          53     0.01917     0.00000     0.00000     0.00000     0.05318     0.08342
-          54    -0.00000    -0.13921    -0.14230     0.07573     0.00000     0.00000
-          55     0.01796    -0.00000    -0.00000    -0.00000    -0.18936     0.01565
-          56    -0.00001    -0.00000    -0.00000    -0.00000     0.00575     0.08751
-          57     0.00000    -0.07353     0.11911    -0.14533     0.00000     0.00000
-          58     0.14468     0.00000     0.00000     0.00000     0.12395    -0.01132
-          59     0.00122     0.00000     0.00000     0.00000     0.00881     0.08724
-          60     0.00000    -0.02194    -0.19937     0.02206     0.00000     0.00000
+           1     0.00000    -0.00000    -0.00000     0.09949    -0.00171     0.01221
+           2    -0.00000     0.00000     0.00000    -0.00244     0.08802    -0.00025
+           3     0.08887    -0.05089    -0.02062    -0.00000    -0.00000     0.00000
+           4    -0.00000     0.00000     0.00000     0.06315     0.00603    -0.07763
+           5    -0.00000    -0.00000    -0.00000     0.00365     0.08673     0.01480
+           6    -0.00861    -0.07238    -0.07484    -0.00000     0.00000     0.00000
+           7     0.00000    -0.00000    -0.00000     0.08760     0.00082    -0.01717
+           8    -0.00000     0.00000     0.00000    -0.01631     0.09098    -0.03455
+           9     0.07218    -0.12325     0.05877    -0.00000     0.00000    -0.00000
+          10     0.00000     0.00000     0.00000     0.07504     0.00350    -0.04824
+          11    -0.00000    -0.00000    -0.00000     0.01752     0.08377     0.04910
+          12     0.00808    -0.00002    -0.15424    -0.00000     0.00000    -0.00000
+          13    -0.00000     0.00000     0.00000     0.06983     0.00461    -0.06112
+          14    -0.00000     0.00000     0.00000    -0.01336     0.09035    -0.02724
+          15     0.02451    -0.13385     0.03239     0.00000    -0.00000    -0.00000
+          16     0.00000    -0.00000    -0.00000     0.09281    -0.00029    -0.00429
+          17    -0.00000    -0.00000    -0.00000     0.01457     0.08440     0.04180
+          18     0.05575     0.01058    -0.12785     0.00000    -0.00000    -0.00000
+          19     0.00000    -0.00000    -0.00000     0.09248    -0.00021    -0.00511
+          20    -0.00000     0.00000     0.00000    -0.02956     0.09379    -0.06730
+          21     0.09716    -0.17156     0.14215    -0.00000    -0.00000    -0.00000
+          22    -0.00000     0.00000     0.00000     0.07016     0.00454    -0.06030
+          23     0.00000    -0.00000    -0.00000     0.03077     0.08096     0.08185
+          24    -0.01690     0.04829    -0.23762    -0.00000    -0.00000    -0.00000
+          25    -0.00000     0.00000     0.00000     0.06093     0.00650    -0.08311
+          26    -0.00000     0.00000     0.00000    -0.02429     0.09267    -0.05427
+          27     0.01254    -0.19026     0.09516     0.00000     0.00000    -0.00000
+          28     0.00000    -0.00000    -0.00000     0.10171    -0.00218     0.01770
+          29     0.00000    -0.00000    -0.00000     0.02550     0.08208     0.06882
+          30     0.06772     0.06699    -0.19062     0.00000     0.00000    -0.00000
+          31    -0.00000     0.00000     0.00000     0.04430     0.01004    -0.12425
+          32    -0.00000     0.00000     0.00000     0.00747     0.08591     0.02425
+          33    -0.05985    -0.08078    -0.10706    -0.00000    -0.00000     0.00000
+          34    -0.00000    -0.00000    -0.00000     0.11835    -0.00572     0.05884
+          35     0.00000     0.00000    -0.00000    -0.00626     0.08884    -0.00970
+          36     0.14011    -0.04249     0.01160     0.00000    -0.00000     0.00000
+          37    -0.00000    -0.00000     0.00000     0.04107     0.01073    -0.13222
+          38    -0.00000     0.00000     0.00000     0.02124     0.08298     0.05831
+          39    -0.08116    -0.02819    -0.19289     0.00000     0.00000    -0.00000
+          40    -0.00000    -0.00000    -0.00000     0.12157    -0.00641     0.06681
+          41     0.00000    -0.00000    -0.00000    -0.02003     0.09177    -0.04375
+          42     0.16142    -0.09508     0.09743     0.00000    -0.00000    -0.00000
+          43     0.00000    -0.00000    -0.00000     0.03145     0.01277    -0.15601
+          44     0.00000    -0.00000    -0.00000    -0.00407     0.08837    -0.00429
+          45    -0.08119    -0.14477    -0.04237    -0.00000     0.00000    -0.00000
+          46    -0.00000     0.00000     0.00000     0.13119    -0.00845     0.09059
+          47     0.00000     0.00000     0.00000     0.00528     0.08638     0.01884
+          48     0.16145     0.02150    -0.05309    -0.00000     0.00000    -0.00000
+          49    -0.00000    -0.00000    -0.00000     0.03377     0.01228    -0.15028
+          50     0.00000    -0.00000    -0.00000    -0.01796     0.09133    -0.03863
+          51    -0.06204    -0.19900     0.04374     0.00000    -0.00000     0.00000
+          52    -0.00000    -0.00000     0.00000     0.12888    -0.00796     0.08487
+          53     0.00000     0.00000     0.00000     0.01917     0.08342     0.05318
+          54     0.14230     0.07573    -0.13921     0.00000    -0.00000     0.00000
+          55     0.00000    -0.00000    -0.00000     0.01796     0.01565    -0.18936
+          56    -0.00000    -0.00000    -0.00000    -0.00001     0.08751     0.00575
+          57    -0.11911    -0.14533    -0.07353     0.00000    -0.00000    -0.00000
+          58     0.00000     0.00000     0.00000     0.14468    -0.01132     0.12395
+          59     0.00000     0.00000     0.00000     0.00122     0.08724     0.00881
+          60     0.19937     0.02206    -0.02194    -0.00000    -0.00000    -0.00000
 
                     7           8           9          10          11          12
  
  P.Frequency       49.01       81.56      151.70      181.04      265.73      300.97
  
-           1    -0.00000    -0.00000    -0.00000     0.05680    -0.06713    -0.00000
-           2     0.00000     0.00000    -0.00000     0.01059     0.02425     0.00000
-           3    -0.04456    -0.05431     0.02076     0.00000     0.00000    -0.11865
-           4     0.00000    -0.00000    -0.00000     0.05680     0.06713     0.00000
-           5    -0.00000    -0.00000    -0.00000     0.01059    -0.02425    -0.00000
-           6    -0.04456     0.05431     0.02076     0.00000    -0.00000     0.11865
-           7    -0.00000    -0.00000    -0.00000     0.06200    -0.03561    -0.00000
-           8     0.00000    -0.00000     0.00000     0.01370     0.05532     0.00000
-           9    -0.05718     0.02641     0.05684     0.00000    -0.00000    -0.07809
-          10     0.00000    -0.00000    -0.00000     0.06200     0.03561     0.00000
-          11    -0.00000    -0.00000    -0.00000     0.01370    -0.05532    -0.00000
-          12    -0.05718    -0.02641     0.05684     0.00000    -0.00000     0.07809
-          13     0.00000    -0.00000    -0.00000     0.06101     0.04507     0.00000
+           1    -0.00000     0.00000     0.00000     0.05680    -0.06713    -0.00000
+           2     0.00000     0.00000     0.00000     0.01059     0.02425     0.00000
+           3    -0.04456     0.05431    -0.02076    -0.00000     0.00000    -0.11865
+           4     0.00000     0.00000     0.00000     0.05680     0.06713     0.00000
+           5    -0.00000     0.00000     0.00000     0.01059    -0.02425    -0.00000
+           6    -0.04456    -0.05431    -0.02076     0.00000    -0.00000     0.11865
+           7    -0.00000     0.00000     0.00000     0.06200    -0.03561    -0.00000
+           8     0.00000     0.00000     0.00000     0.01370     0.05532     0.00000
+           9    -0.05718    -0.02641    -0.05684     0.00000     0.00000    -0.07809
+          10     0.00000     0.00000     0.00000     0.06200     0.03561     0.00000
+          11    -0.00000    -0.00000     0.00000     0.01370    -0.05532    -0.00000
+          12    -0.05718     0.02641    -0.05684     0.00000    -0.00000     0.07809
+          13     0.00000     0.00000     0.00000     0.06101     0.04507     0.00000
           14     0.00000     0.00000     0.00000     0.00650     0.03728     0.00000
-          15    -0.05325     0.08381     0.06573     0.00000     0.00000     0.06449
-          16    -0.00000    -0.00000    -0.00000     0.06101    -0.04507     0.00000
-          17    -0.00000    -0.00000    -0.00000     0.00650    -0.03728    -0.00000
-          18    -0.05325    -0.08381     0.06573     0.00000     0.00000    -0.06449
-          19    -0.00000    -0.00000    -0.00000     0.06246    -0.05345    -0.00000
-          20     0.00000    -0.00000     0.00000     0.01388     0.10416     0.00000
-          21    -0.06186     0.05251     0.04389     0.00000    -0.00000    -0.11936
-          22     0.00000    -0.00000    -0.00000     0.06246     0.05345     0.00000
-          23    -0.00000    -0.00000    -0.00000     0.01388    -0.10416    -0.00000
-          24    -0.06186    -0.05251     0.04389     0.00000    -0.00000     0.11936
-          25     0.00000    -0.00000    -0.00000     0.05943     0.08285     0.00000
+          15    -0.05325    -0.08381    -0.06573     0.00000     0.00000     0.06449
+          16    -0.00000     0.00000     0.00000     0.06101    -0.04507    -0.00000
+          17    -0.00000    -0.00000     0.00000     0.00650    -0.03728    -0.00000
+          18    -0.05325     0.08381    -0.06573     0.00000     0.00000    -0.06449
+          19    -0.00000     0.00000     0.00000     0.06246    -0.05345    -0.00000
+          20     0.00000     0.00000     0.00000     0.01388     0.10416     0.00000
+          21    -0.06186    -0.05251    -0.04389     0.00000     0.00000    -0.11936
+          22     0.00000     0.00000     0.00000     0.06246     0.05345     0.00000
+          23    -0.00000    -0.00000     0.00000     0.01388    -0.10416    -0.00000
+          24    -0.06186     0.05251    -0.04389     0.00000    -0.00000     0.11936
+          25     0.00000     0.00000     0.00000     0.05943     0.08285     0.00000
           26     0.00000     0.00000     0.00000     0.00257     0.08107     0.00000
-          27    -0.05763     0.15824     0.05764     0.00000     0.00000     0.08254
-          28    -0.00000    -0.00000    -0.00000     0.05943    -0.08285    -0.00000
+          27    -0.05763    -0.15824    -0.05764     0.00000     0.00000     0.08254
+          28    -0.00000     0.00000     0.00000     0.05943    -0.08285    -0.00000
           29    -0.00000    -0.00000    -0.00000     0.00257    -0.08107    -0.00000
-          30    -0.05763    -0.15824     0.05764     0.00000     0.00000    -0.08254
-          31     0.00000     0.00000     0.00000    -0.03067     0.03035     0.00000
-          32    -0.00000    -0.00000    -0.00000     0.02877    -0.02383    -0.00000
-          33    -0.01337     0.08796    -0.12600    -0.00000     0.00000    -0.03583
-          34    -0.00000     0.00000     0.00000    -0.03067    -0.03035    -0.00000
-          35     0.00000    -0.00000    -0.00000     0.02877     0.02383     0.00000
-          36    -0.01337    -0.08796    -0.12600    -0.00000     0.00000     0.03583
-          37     0.00000     0.00000     0.00000    -0.05164     0.01294    -0.00000
-          38     0.00000    -0.00000    -0.00000     0.11824     0.04829     0.00000
-          39    -0.11916     0.24970    -0.35624    -0.00000     0.00000    -0.25914
-          40    -0.00000     0.00000     0.00000    -0.05164    -0.01294    -0.00000
-          41    -0.00000    -0.00000    -0.00000     0.11824    -0.04829     0.00000
-          42    -0.11916    -0.24970    -0.35624    -0.00000     0.00000     0.25914
-          43    -0.00000     0.00000     0.00000    -0.12652    -0.06653    -0.00000
-          44    -0.00000     0.00000     0.00000    -0.05551    -0.11205    -0.00000
-          45     0.15097    -0.09310    -0.00429    -0.00000    -0.00000    -0.02058
-          46     0.00000     0.00000     0.00000    -0.12652     0.06653    -0.00000
-          47     0.00000     0.00000     0.00000    -0.05551     0.11205     0.00000
-          48     0.15097     0.09310    -0.00429     0.00000    -0.00000     0.02058
-          49    -0.00000     0.00000     0.00000    -0.10885    -0.04627    -0.00000
-          50    -0.00000     0.00000     0.00000    -0.15868    -0.22734    -0.00000
-          51     0.27576    -0.28206     0.24306     0.00000    -0.00000     0.20810
-          52    -0.00000     0.00000     0.00000    -0.10885     0.04627    -0.00000
-          53     0.00000     0.00000     0.00000    -0.15868     0.22734     0.00000
-          54     0.27576     0.28206     0.24306     0.00000    -0.00000    -0.20810
-          55    -0.00000     0.00000     0.00000    -0.23085    -0.18384    -0.00000
-          56    -0.00000    -0.00000     0.00000    -0.02427    -0.07745    -0.00000
-          57     0.16996    -0.06336    -0.14359    -0.00000     0.00000    -0.23346
-          58     0.00000     0.00000     0.00000    -0.23085     0.18384    -0.00000
-          59     0.00000     0.00000     0.00000    -0.02427     0.07745     0.00000
-          60     0.16996     0.06336    -0.14359    -0.00000    -0.00000     0.23346
+          30    -0.05763     0.15824    -0.05764     0.00000     0.00000    -0.08254
+          31    -0.00000    -0.00000    -0.00000    -0.03067     0.03035     0.00000
+          32     0.00000     0.00000     0.00000     0.02877    -0.02383    -0.00000
+          33    -0.01337    -0.08796     0.12600    -0.00000     0.00000    -0.03583
+          34    -0.00000    -0.00000    -0.00000    -0.03067    -0.03035    -0.00000
+          35    -0.00000     0.00000     0.00000     0.02877     0.02383     0.00000
+          36    -0.01337     0.08796     0.12600    -0.00000    -0.00000     0.03583
+          37    -0.00000    -0.00000    -0.00000    -0.05164     0.01294     0.00000
+          38     0.00000     0.00000     0.00000     0.11824     0.04829     0.00000
+          39    -0.11916    -0.24970     0.35624    -0.00000     0.00000    -0.25914
+          40    -0.00000    -0.00000    -0.00000    -0.05164    -0.01294    -0.00000
+          41    -0.00000     0.00000     0.00000     0.11824    -0.04829    -0.00000
+          42    -0.11916     0.24970     0.35624    -0.00000    -0.00000     0.25914
+          43    -0.00000    -0.00000    -0.00000    -0.12652    -0.06653    -0.00000
+          44    -0.00000    -0.00000    -0.00000    -0.05551    -0.11205    -0.00000
+          45     0.15097     0.09310     0.00429    -0.00000    -0.00000    -0.02058
+          46     0.00000    -0.00000    -0.00000    -0.12652     0.06653     0.00000
+          47     0.00000    -0.00000    -0.00000    -0.05551     0.11205     0.00000
+          48     0.15097    -0.09310     0.00429     0.00000    -0.00000     0.02058
+          49    -0.00000    -0.00000    -0.00000    -0.10885    -0.04627    -0.00000
+          50    -0.00000    -0.00000    -0.00000    -0.15868    -0.22734    -0.00000
+          51     0.27576     0.28206    -0.24306     0.00000    -0.00000     0.20810
+          52    -0.00000    -0.00000    -0.00000    -0.10885     0.04627     0.00000
+          53     0.00000    -0.00000    -0.00000    -0.15868     0.22734     0.00000
+          54     0.27576    -0.28206    -0.24306     0.00000     0.00000    -0.20810
+          55    -0.00000    -0.00000    -0.00000    -0.23085    -0.18384    -0.00000
+          56    -0.00000    -0.00000    -0.00000    -0.02427    -0.07745    -0.00000
+          57     0.16996     0.06336     0.14359    -0.00000     0.00000    -0.23346
+          58     0.00000    -0.00000    -0.00000    -0.23085     0.18384     0.00000
+          59     0.00000    -0.00000    -0.00000    -0.02427     0.07745     0.00000
+          60     0.16996    -0.06336     0.14359    -0.00000    -0.00000     0.23346
 
                    13          14          15          16          17          18
  
  P.Frequency      407.92      424.39      468.98      487.92      578.84      657.33
  
-           1     0.06234     0.00000     0.00000    -0.02307     0.03795    -0.00000
+           1     0.06234     0.00000     0.00000    -0.02307     0.03795     0.00000
            2     0.06103     0.00000    -0.00000     0.03328    -0.06914    -0.00000
-           3     0.00000     0.01085    -0.13221    -0.00000     0.00000     0.02719
-           4    -0.06234    -0.00000    -0.00000    -0.02307    -0.03795     0.00000
+           3    -0.00000     0.01085     0.13221     0.00000    -0.00000    -0.02719
+           4    -0.06234    -0.00000     0.00000    -0.02307    -0.03795    -0.00000
            5    -0.06103    -0.00000    -0.00000     0.03328     0.06914     0.00000
-           6     0.00000     0.01085    -0.13221    -0.00000     0.00000    -0.02719
-           7     0.00251    -0.00000     0.00000    -0.04171     0.07928    -0.00000
-           8    -0.02401    -0.00000    -0.00000     0.04783    -0.03827    -0.00000
-           9    -0.00000     0.12087     0.06191     0.00000    -0.00000    -0.08217
-          10    -0.00251     0.00000     0.00000    -0.04171    -0.07928     0.00000
-          11     0.02401     0.00000     0.00000     0.04783     0.03827     0.00000
-          12    -0.00000     0.12087     0.06191     0.00000    -0.00000     0.08217
-          13    -0.07035     0.00000     0.00000    -0.04286    -0.01391     0.00000
-          14    -0.02928    -0.00000    -0.00000     0.05699    -0.01300    -0.00000
-          15     0.00000    -0.12494     0.03988    -0.00000     0.00000     0.07876
-          16     0.07035     0.00000     0.00000    -0.04286     0.01391    -0.00000
-          17     0.02928     0.00000    -0.00000     0.05699     0.01300     0.00000
-          18     0.00000    -0.12494     0.03988    -0.00000     0.00000    -0.07876
-          19     0.03778    -0.00000     0.00000    -0.04590     0.08496    -0.00000
-          20    -0.11569    -0.00000    -0.00000     0.05444    -0.05175    -0.00000
-          21    -0.00000     0.23240     0.22744     0.00000    -0.00000    -0.11223
-          22    -0.03778     0.00000    -0.00000    -0.04590    -0.08496     0.00000
-          23     0.11569     0.00000     0.00000     0.05444     0.05175     0.00000
-          24    -0.00000     0.23240     0.22744     0.00000    -0.00000     0.11223
-          25    -0.07247     0.00000    -0.00000    -0.04413    -0.09395     0.00000
-          26    -0.03305    -0.00000    -0.00000     0.05565    -0.11017    -0.00000
-          27     0.00000    -0.28135     0.19194     0.00000     0.00000     0.13548
-          28     0.07247    -0.00000     0.00000    -0.04413     0.09395    -0.00000
-          29     0.03305     0.00000     0.00000     0.05565     0.11017     0.00000
-          30     0.00000    -0.28135     0.19194     0.00000     0.00000    -0.13548
-          31     0.00239     0.00000    -0.00000     0.09736     0.10221     0.00000
-          32    -0.11048    -0.00000    -0.00000    -0.01406     0.05564     0.00000
-          33     0.00000    -0.00252    -0.04259    -0.00000     0.00000    -0.09673
-          34    -0.00239    -0.00000    -0.00000     0.09736    -0.10221    -0.00000
+           6    -0.00000     0.01085     0.13221     0.00000    -0.00000     0.02719
+           7     0.00251     0.00000     0.00000    -0.04171     0.07928     0.00000
+           8    -0.02401    -0.00000    -0.00000     0.04783    -0.03827     0.00000
+           9    -0.00000     0.12087    -0.06191    -0.00000    -0.00000     0.08217
+          10    -0.00251     0.00000     0.00000    -0.04171    -0.07928    -0.00000
+          11     0.02401     0.00000    -0.00000     0.04783     0.03827    -0.00000
+          12    -0.00000     0.12087    -0.06191    -0.00000    -0.00000    -0.08217
+          13    -0.07035    -0.00000     0.00000    -0.04286    -0.01391    -0.00000
+          14    -0.02928     0.00000    -0.00000     0.05699    -0.01300     0.00000
+          15     0.00000    -0.12494    -0.03988    -0.00000     0.00000    -0.07876
+          16     0.07035     0.00000     0.00000    -0.04286     0.01391     0.00000
+          17     0.02928     0.00000    -0.00000     0.05699     0.01300    -0.00000
+          18     0.00000    -0.12494    -0.03988    -0.00000     0.00000     0.07876
+          19     0.03778     0.00000     0.00000    -0.04590     0.08496     0.00000
+          20    -0.11569    -0.00000    -0.00000     0.05444    -0.05175     0.00000
+          21    -0.00000     0.23240    -0.22744    -0.00000    -0.00000     0.11223
+          22    -0.03778    -0.00000     0.00000    -0.04590    -0.08496    -0.00000
+          23     0.11569     0.00000    -0.00000     0.05444     0.05175    -0.00000
+          24    -0.00000     0.23240    -0.22744    -0.00000    -0.00000    -0.11223
+          25    -0.07247    -0.00000     0.00000    -0.04413    -0.09395    -0.00000
+          26    -0.03305    -0.00000    -0.00000     0.05565    -0.11017     0.00000
+          27     0.00000    -0.28135    -0.19194    -0.00000     0.00000    -0.13548
+          28     0.07247     0.00000     0.00000    -0.04413     0.09395     0.00000
+          29     0.03305     0.00000    -0.00000     0.05565     0.11017    -0.00000
+          30     0.00000    -0.28135    -0.19194    -0.00000     0.00000     0.13548
+          31     0.00239     0.00000    -0.00000     0.09736     0.10221    -0.00000
+          32    -0.11048    -0.00000     0.00000    -0.01406     0.05564     0.00000
+          33     0.00000    -0.00252     0.04259     0.00000    -0.00000     0.09673
+          34    -0.00239    -0.00000    -0.00000     0.09736    -0.10221     0.00000
           35     0.11048     0.00000     0.00000    -0.01406    -0.05564     0.00000
-          36     0.00000    -0.00252    -0.04259    -0.00000     0.00000     0.09673
-          37     0.01264     0.00000    -0.00000     0.09900     0.10805     0.00000
-          38    -0.16284    -0.00000    -0.00000    -0.02943     0.02985     0.00000
-          39    -0.00000    -0.01386     0.13640     0.00000     0.00000     0.13034
+          36     0.00000    -0.00252     0.04259     0.00000    -0.00000    -0.09673
+          37     0.01264     0.00000    -0.00000     0.09900     0.10805    -0.00000
+          38    -0.16284    -0.00000     0.00000    -0.02943     0.02985     0.00000
+          39     0.00000    -0.01386    -0.13640    -0.00000     0.00000    -0.13034
           40    -0.01264    -0.00000    -0.00000     0.09900    -0.10805    -0.00000
           41     0.16284     0.00000     0.00000    -0.02943    -0.02985     0.00000
-          42    -0.00000    -0.01386     0.13640     0.00000     0.00000    -0.13034
-          43     0.03927    -0.00000     0.00000     0.01769     0.01308     0.00000
+          42     0.00000    -0.01386    -0.13640    -0.00000    -0.00000     0.13034
+          43     0.03927     0.00000    -0.00000     0.01769     0.01308    -0.00000
           44    -0.09044    -0.00000     0.00000    -0.10303    -0.03510     0.00000
-          45    -0.00000     0.00074     0.01871     0.00000    -0.00000     0.01618
-          46    -0.03927    -0.00000    -0.00000     0.01769    -0.01308    -0.00000
+          45     0.00000     0.00074    -0.01871    -0.00000     0.00000    -0.01618
+          46    -0.03927    -0.00000    -0.00000     0.01769    -0.01308     0.00000
           47     0.09044     0.00000     0.00000    -0.10303     0.03510     0.00000
-          48    -0.00000     0.00074     0.01871     0.00000    -0.00000    -0.01618
-          49     0.03607    -0.00000     0.00000     0.04794     0.04996     0.00000
-          50    -0.06588    -0.00000     0.00000    -0.27471    -0.25313    -0.00000
-          51    -0.00000     0.02872    -0.16235    -0.00000    -0.00000    -0.20776
-          52    -0.03607    -0.00000    -0.00000     0.04794    -0.04996    -0.00000
+          48     0.00000     0.00074    -0.01871    -0.00000     0.00000     0.01618
+          49     0.03607     0.00000    -0.00000     0.04794     0.04996    -0.00000
+          50    -0.06588    -0.00000     0.00000    -0.27471    -0.25313     0.00000
+          51    -0.00000     0.02872     0.16235     0.00000    -0.00000     0.20776
+          52    -0.03607    -0.00000    -0.00000     0.04794    -0.04996     0.00000
           53     0.06588     0.00000     0.00000    -0.27471     0.25313     0.00000
-          54    -0.00000     0.02872    -0.16235    -0.00000    -0.00000     0.20776
-          55     0.06840    -0.00000     0.00000    -0.14510    -0.19197    -0.00000
+          54    -0.00000     0.02872     0.16235     0.00000    -0.00000    -0.20776
+          55     0.06840     0.00000     0.00000    -0.14510    -0.19197    -0.00000
           56    -0.10052    -0.00000     0.00000    -0.05617     0.02535     0.00000
-          57    -0.00000    -0.02540     0.25320     0.00000     0.00000     0.35697
-          58    -0.06840     0.00000     0.00000    -0.14510     0.19197     0.00000
+          57     0.00000    -0.02540    -0.25320    -0.00000     0.00000    -0.35697
+          58    -0.06840    -0.00000     0.00000    -0.14510     0.19197     0.00000
           59     0.10052     0.00000     0.00000    -0.05617    -0.02535     0.00000
-          60    -0.00000    -0.02540     0.25320     0.00000     0.00000    -0.35697
+          60     0.00000    -0.02540    -0.25320    -0.00000     0.00000     0.35697
 
                    19          20          21          22          23          24
  
  P.Frequency      673.47      707.33      735.11      810.68      862.52      895.31
  
-           1    -0.04041     0.00000     0.00161    -0.00000    -0.00735    -0.00000
-           2    -0.00025    -0.00000     0.01016    -0.00000    -0.03625    -0.00000
-           3     0.00000    -0.06850     0.00000    -0.14259     0.00000    -0.00191
-           4     0.04041    -0.00000     0.00161     0.00000     0.00735    -0.00000
-           5     0.00025     0.00000     0.01016    -0.00000     0.03625     0.00000
-           6     0.00000    -0.06850     0.00000     0.14259     0.00000     0.00191
-           7    -0.08896     0.00000    -0.03820     0.00000     0.11600     0.00000
+           1    -0.04041    -0.00000     0.00161    -0.00000    -0.00735    -0.00000
+           2    -0.00025     0.00000     0.01016     0.00000    -0.03625    -0.00000
+           3    -0.00000     0.06850    -0.00000    -0.14259    -0.00000    -0.00191
+           4     0.04041     0.00000     0.00161     0.00000     0.00735    -0.00000
+           5     0.00025     0.00000     0.01016     0.00000     0.03625     0.00000
+           6     0.00000     0.06850    -0.00000     0.14259    -0.00000     0.00191
+           7    -0.08896    -0.00000    -0.03820    -0.00000     0.11600     0.00000
            8    -0.09853    -0.00000    -0.07522    -0.00000     0.00186     0.00000
-           9    -0.00000    -0.01327     0.00000     0.05830    -0.00000    -0.06379
-          10     0.08896    -0.00000    -0.03820    -0.00000    -0.11600    -0.00000
-          11     0.09853    -0.00000    -0.07522    -0.00000    -0.00186     0.00000
-          12    -0.00000    -0.01327     0.00000    -0.05830    -0.00000     0.06379
+           9     0.00000     0.01327     0.00000     0.05830     0.00000    -0.06379
+          10     0.08896     0.00000    -0.03820     0.00000    -0.11600    -0.00000
+          11     0.09853    -0.00000    -0.07522    -0.00000    -0.00186    -0.00000
+          12    -0.00000     0.01327     0.00000    -0.05830    -0.00000     0.06379
           13     0.06162     0.00000    -0.01409     0.00000     0.11778     0.00000
-          14    -0.12263     0.00000    -0.07362    -0.00000    -0.03435    -0.00000
-          15     0.00000    -0.01708    -0.00000    -0.05701     0.00000    -0.07018
+          14    -0.12263    -0.00000    -0.07362    -0.00000    -0.03435    -0.00000
+          15    -0.00000     0.01708    -0.00000    -0.05701     0.00000    -0.07018
           16    -0.06162    -0.00000    -0.01409    -0.00000    -0.11778    -0.00000
-          17     0.12263    -0.00000    -0.07362     0.00000     0.03435     0.00000
-          18     0.00000    -0.01708     0.00000     0.05701    -0.00000     0.07018
-          19    -0.10493     0.00000    -0.01932    -0.00000     0.08784     0.00000
-          20    -0.05681    -0.00000    -0.12590    -0.00000     0.09836     0.00000
-          21     0.00000     0.25586    -0.00000     0.15554    -0.00000     0.43357
-          22     0.10493    -0.00000    -0.01932     0.00000    -0.08784    -0.00000
+          17     0.12263     0.00000    -0.07362     0.00000     0.03435     0.00000
+          18     0.00000     0.01708    -0.00000     0.05701    -0.00000     0.07018
+          19    -0.10493    -0.00000    -0.01932    -0.00000     0.08784     0.00000
+          20    -0.05681    -0.00000    -0.12590     0.00000     0.09836     0.00000
+          21     0.00000    -0.25586     0.00000     0.15554    -0.00000     0.43357
+          22     0.10493     0.00000    -0.01932     0.00000    -0.08784    -0.00000
           23     0.05681    -0.00000    -0.12590    -0.00000    -0.09836    -0.00000
-          24    -0.00000     0.25586    -0.00000    -0.15554     0.00000    -0.43357
-          25     0.08401    -0.00000    -0.04802     0.00000     0.07285    -0.00000
+          24    -0.00000    -0.25586     0.00000    -0.15554     0.00000    -0.43357
+          25     0.08401     0.00000    -0.04802     0.00000     0.07285    -0.00000
           26    -0.09553    -0.00000    -0.11192    -0.00000    -0.10068    -0.00000
-          27     0.00000     0.25282     0.00000    -0.15437    -0.00000     0.44780
-          28    -0.08401     0.00000    -0.04802    -0.00000    -0.07285    -0.00000
-          29     0.09553    -0.00000    -0.11192     0.00000     0.10068    -0.00000
-          30     0.00000     0.25282    -0.00000     0.15437     0.00000    -0.44780
-          31     0.02094     0.00000     0.07198     0.00000    -0.03706    -0.00000
+          27    -0.00000    -0.25282    -0.00000    -0.15437    -0.00000     0.44780
+          28    -0.08401    -0.00000    -0.04802    -0.00000    -0.07285    -0.00000
+          29     0.09553    -0.00000    -0.11192    -0.00000     0.10068     0.00000
+          30     0.00000    -0.25282    -0.00000     0.15437     0.00000    -0.44780
+          31     0.02094     0.00000     0.07198    -0.00000    -0.03706    -0.00000
           32     0.00440     0.00000     0.10255     0.00000    -0.05192    -0.00000
-          33     0.00000     0.09532    -0.00000    -0.06770    -0.00000    -0.00045
-          34    -0.02094    -0.00000     0.07198     0.00000     0.03706     0.00000
+          33     0.00000    -0.09532     0.00000    -0.06770     0.00000    -0.00045
+          34    -0.02094     0.00000     0.07198     0.00000     0.03706     0.00000
           35    -0.00440     0.00000     0.10255     0.00000     0.05192     0.00000
-          36    -0.00000     0.09532    -0.00000     0.06770    -0.00000     0.00045
-          37     0.02190     0.00000     0.07555     0.00000    -0.04010    -0.00000
+          36    -0.00000    -0.09532     0.00000     0.06770     0.00000     0.00045
+          37     0.02190     0.00000     0.07555    -0.00000    -0.04010    -0.00000
           38     0.00029     0.00000     0.10591     0.00000    -0.05475    -0.00000
-          39    -0.00000    -0.14974     0.00000     0.08848     0.00000    -0.00156
-          40    -0.02190    -0.00000     0.07555     0.00000     0.04010     0.00000
+          39    -0.00000     0.14974    -0.00000     0.08848    -0.00000    -0.00156
+          40    -0.02190     0.00000     0.07555     0.00000     0.04010     0.00000
           41    -0.00029     0.00000     0.10591     0.00000     0.05475     0.00000
-          42     0.00000    -0.14974     0.00000    -0.08848     0.00000     0.00156
+          42     0.00000     0.14974    -0.00000    -0.08848     0.00000     0.00156
           43     0.01523    -0.00000    -0.00669    -0.00000     0.00137     0.00000
-          44    -0.00832    -0.00000     0.05020    -0.00000    -0.03528    -0.00000
-          45    -0.00000    -0.01415    -0.00000     0.00629     0.00000     0.00160
-          46    -0.01523     0.00000    -0.00669    -0.00000    -0.00137     0.00000
+          44    -0.00832     0.00000     0.05020    -0.00000    -0.03528    -0.00000
+          45    -0.00000     0.01415    -0.00000     0.00629     0.00000     0.00160
+          46    -0.01523    -0.00000    -0.00669    -0.00000    -0.00137     0.00000
           47     0.00832     0.00000     0.05021     0.00000     0.03528     0.00000
-          48     0.00000    -0.01415     0.00000    -0.00629     0.00000    -0.00160
+          48     0.00000     0.01415    -0.00000    -0.00629     0.00000    -0.00160
           49     0.02125     0.00000     0.02470    -0.00000    -0.02022    -0.00000
-          50    -0.04484    -0.00000    -0.14774    -0.00000     0.09895     0.00000
-          51     0.00000     0.20973     0.00000    -0.11568    -0.00000     0.01148
+          50    -0.04484    -0.00000    -0.14774     0.00000     0.09895     0.00000
+          51     0.00000    -0.20973     0.00000    -0.11568    -0.00000     0.01148
           52    -0.02125     0.00000     0.02470    -0.00000     0.02022     0.00000
-          53     0.04484     0.00000    -0.14774    -0.00000    -0.09895    -0.00000
-          54    -0.00000     0.20973    -0.00000     0.11568    -0.00000    -0.01148
-          55    -0.01397    -0.00000    -0.20681    -0.00000     0.15092     0.00000
-          56     0.00016     0.00000     0.11208     0.00000    -0.08153    -0.00000
-          57    -0.00000    -0.35822     0.00000     0.22488     0.00000    -0.01745
-          58     0.01397     0.00000    -0.20681    -0.00000    -0.15092    -0.00000
+          53     0.04484    -0.00000    -0.14774    -0.00000    -0.09895    -0.00000
+          54    -0.00000    -0.20973     0.00000     0.11568    -0.00000    -0.01148
+          55    -0.01397    -0.00000    -0.20681     0.00000     0.15092     0.00000
+          56     0.00016     0.00000     0.11208    -0.00000    -0.08153    -0.00000
+          57    -0.00000     0.35822    -0.00000     0.22488    -0.00000    -0.01745
+          58     0.01397    -0.00000    -0.20681    -0.00000    -0.15092    -0.00000
           59    -0.00016     0.00000     0.11208     0.00000     0.08153     0.00000
-          60     0.00000    -0.35822     0.00000    -0.22488     0.00000     0.01745
+          60     0.00000     0.35822    -0.00000    -0.22488    -0.00000     0.01745
 
                    25          26          27          28          29          30
  
  P.Frequency      896.43      980.90      980.97     1017.73     1036.48     1073.56
  
-           1    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00791
-           2    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.02569
-           3    -0.09617    -0.00358    -0.00464     0.01789     0.00053    -0.00000
-           4     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00791
+           1     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00791
+           2    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.02569
+           3     0.09617     0.00358    -0.00464     0.01789    -0.00053    -0.00000
+           4    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00791
            5     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.02569
-           6    -0.09617     0.00358    -0.00464    -0.01789     0.00053     0.00000
-           7     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.12357
-           8    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00035
-           9     0.05631     0.00024    -0.00041    -0.06692    -0.07538     0.00000
-          10    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.12357
-          11     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00035
-          12     0.05631    -0.00024    -0.00041     0.06692    -0.07538    -0.00000
-          13     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.11039
-          14    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.03538
-          15     0.06224     0.00056     0.00351     0.06497     0.07373     0.00000
-          16    -0.00000    -0.00000    -0.00000    -0.00000     0.00000    -0.11039
-          17     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.03538
-          18     0.06224    -0.00056     0.00351    -0.06497     0.07373     0.00000
-          19     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.18868
-          20     0.00000    -0.00000    -0.00000    -0.00000     0.00000    -0.15964
-          21    -0.34857    -0.00052     0.00596     0.44985     0.43580    -0.00000
-          22    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.18868
-          23    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.15964
-          24    -0.34856     0.00052     0.00596    -0.44985     0.43580     0.00000
-          25     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.23833
-          26    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.11370
-          27    -0.35802    -0.00833    -0.01854    -0.42837    -0.41633    -0.00000
-          28    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.23833
-          29     0.00000     0.00000     0.00000     0.00000     0.00000    -0.11370
-          30    -0.35802     0.00833    -0.01854     0.42837    -0.41633     0.00000
-          31    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00307
-          32    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00132
-          33     0.04810    -0.03558     0.03601     0.00977    -0.00064    -0.00000
-          34     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00307
-          35     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00132
-          36     0.04810     0.03558     0.03601    -0.00977    -0.00064     0.00000
-          37    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00224
-          38    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.02111
-          39    -0.02854     0.01386    -0.01384     0.02008    -0.00305    -0.00000
-          40     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00224
-          41     0.00000     0.00000     0.00000     0.00000     0.00000    -0.02111
-          42    -0.02854    -0.01386    -0.01384    -0.02008    -0.00305    -0.00000
-          43     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00628
-          44    -0.00000     0.00000     0.00000     0.00000     0.00000     0.01723
-          45    -0.00156     0.10289    -0.10289    -0.00109     0.00247     0.00000
-          46    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00628
-          47     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.01723
-          48    -0.00156    -0.10290    -0.10289     0.00109     0.00247    -0.00000
-          49     0.00000    -0.00000     0.00000     0.00000     0.00000     0.01793
-          50     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.05610
-          51     0.05826    -0.42482     0.42437     0.02240    -0.01922    -0.00000
-          52    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.01793
-          53    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.05610
-          54     0.05826     0.42485     0.42434    -0.02240    -0.01922    -0.00000
-          55     0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.07143
-          56    -0.00000     0.00000    -0.00000     0.00000     0.00000     0.04151
-          57    -0.14368    -0.41721     0.41664    -0.02850    -0.00556    -0.00000
-          58    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.07143
-          59     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.04151
-          60    -0.14368     0.41724     0.41661     0.02850    -0.00556     0.00000
+           6     0.09617    -0.00358    -0.00464    -0.01789    -0.00053    -0.00000
+           7     0.00000     0.00000     0.00000     0.00000     0.00000     0.12357
+           8    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00035
+           9    -0.05631    -0.00024    -0.00041    -0.06692     0.07538     0.00000
+          10    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.12357
+          11    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00035
+          12    -0.05631     0.00024    -0.00041     0.06692     0.07538    -0.00000
+          13    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.11039
+          14     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.03538
+          15    -0.06224    -0.00056     0.00351     0.06497    -0.07373     0.00000
+          16    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.11039
+          17    -0.00000     0.00000     0.00000     0.00000     0.00000     0.03538
+          18    -0.06224     0.00056     0.00351    -0.06497    -0.07373     0.00000
+          19     0.00000    -0.00000     0.00000     0.00000     0.00000     0.18868
+          20    -0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.15964
+          21     0.34857     0.00052     0.00596     0.44985    -0.43580    -0.00000
+          22     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.18868
+          23    -0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.15964
+          24     0.34856    -0.00052     0.00596    -0.44985    -0.43580     0.00000
+          25    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.23833
+          26    -0.00000    -0.00000    -0.00000    -0.00000     0.00000    -0.11370
+          27     0.35802     0.00833    -0.01854    -0.42837     0.41633     0.00000
+          28    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.23833
+          29    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.11370
+          30     0.35802    -0.00833    -0.01854     0.42837     0.41633    -0.00000
+          31     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00307
+          32     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00132
+          33    -0.04810     0.03558     0.03601     0.00977     0.00064    -0.00000
+          34     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00307
+          35     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00132
+          36    -0.04810    -0.03558     0.03601    -0.00977     0.00064    -0.00000
+          37     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00224
+          38     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.02111
+          39     0.02854    -0.01386    -0.01384     0.02008     0.00305     0.00000
+          40     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00224
+          41     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.02111
+          42     0.02854     0.01386    -0.01384    -0.02008     0.00305     0.00000
+          43    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00628
+          44     0.00000     0.00000     0.00000    -0.00000     0.00000     0.01723
+          45     0.00156    -0.10290    -0.10289    -0.00109    -0.00247     0.00000
+          46    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00628
+          47     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.01723
+          48     0.00156     0.10289    -0.10289     0.00109    -0.00247     0.00000
+          49    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.01793
+          50     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.05610
+          51    -0.05826     0.42485     0.42434     0.02240     0.01922     0.00000
+          52    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.01793
+          53    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.05610
+          54    -0.05826    -0.42482     0.42437    -0.02240     0.01922     0.00000
+          55    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.07143
+          56     0.00000     0.00000     0.00000    -0.00000     0.00000     0.04151
+          57     0.14368     0.41724     0.41661    -0.02850     0.00556    -0.00000
+          58    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.07143
+          59     0.00000     0.00000    -0.00000     0.00000     0.00000     0.04151
+          60     0.14368    -0.41721     0.41664     0.02850     0.00556    -0.00000
 
                    31          32          33          34          35          36
  
  P.Frequency     1102.04     1107.66     1107.69     1110.62     1203.74     1260.97
  
-           1     0.04695    -0.00000     0.00000     0.01906     0.02863    -0.00340
-           2     0.02535     0.00000     0.00000     0.05342    -0.04213    -0.06554
-           3    -0.00000    -0.00193     0.00087    -0.00000     0.00000    -0.00000
-           4     0.04695    -0.00000    -0.00000    -0.01906     0.02863     0.00340
-           5     0.02535    -0.00000    -0.00000    -0.05342    -0.04213     0.06554
-           6     0.00000     0.00193     0.00087    -0.00000     0.00000    -0.00000
-           7    -0.02099     0.00000     0.00000     0.01976    -0.02728    -0.03671
-           8    -0.01934     0.00000     0.00000     0.02743    -0.04693     0.02372
-           9     0.00000    -0.00248     0.00297    -0.00000    -0.00000     0.00000
-          10    -0.02099     0.00000    -0.00000    -0.01976    -0.02728     0.03671
-          11    -0.01934    -0.00000    -0.00000    -0.02743    -0.04693    -0.02372
-          12     0.00000     0.00248     0.00297    -0.00000     0.00000    -0.00000
-          13    -0.04804     0.00000     0.00000     0.03976    -0.01629    -0.03141
-          14     0.00570    -0.00000    -0.00000    -0.01821     0.07108    -0.00829
-          15    -0.00000    -0.00234    -0.00308    -0.00000    -0.00000    -0.00000
-          16    -0.04804    -0.00000    -0.00000    -0.03976    -0.01629     0.03141
-          17     0.00570     0.00000     0.00000     0.01821     0.07108     0.00829
-          18    -0.00000     0.00234    -0.00308    -0.00000     0.00000     0.00000
-          19     0.03415     0.00000     0.00000     0.01348     0.06976    -0.18957
-          20    -0.17695     0.00000     0.00000     0.05635    -0.33442     0.42657
-          21    -0.00000     0.02424    -0.00462    -0.00000     0.00000    -0.00000
-          22     0.03415    -0.00000    -0.00000    -0.01348     0.06976     0.18957
-          23    -0.17695     0.00000    -0.00000    -0.05635    -0.33442    -0.42657
-          24    -0.00000    -0.02424    -0.00462    -0.00000     0.00000    -0.00000
-          25    -0.05563     0.00000     0.00000     0.08428     0.24896    -0.27152
-          26     0.00504    -0.00000     0.00000     0.02712     0.40593    -0.29734
-          27     0.00000    -0.01630    -0.00364     0.00000     0.00000     0.00000
-          28    -0.05563    -0.00000    -0.00000    -0.08428     0.24896     0.27152
-          29     0.00504    -0.00000    -0.00000    -0.02712     0.40593     0.29734
-          30     0.00000     0.01630    -0.00364     0.00000    -0.00000     0.00000
-          31     0.04505    -0.00000    -0.00000    -0.04318    -0.00748    -0.02482
-          32     0.02723    -0.00000    -0.00000    -0.02355    -0.00840    -0.02168
-          33     0.00000     0.05883     0.05838    -0.00000     0.00000     0.00000
-          34     0.04505    -0.00000     0.00000     0.04318    -0.00748     0.02482
-          35     0.02723    -0.00000     0.00000     0.02355    -0.00840     0.02168
-          36    -0.00000    -0.05883     0.05838    -0.00000    -0.00000     0.00000
-          37    -0.01470     0.00000     0.00000     0.01431    -0.00167    -0.00830
-          38     0.29025    -0.00000    -0.00000    -0.27113    -0.02883    -0.11123
-          39    -0.00000    -0.55163    -0.55235     0.00000    -0.00000    -0.00000
-          40    -0.01470     0.00000    -0.00000    -0.01431    -0.00167     0.00830
-          41     0.29025    -0.00000     0.00000     0.27113    -0.02883     0.11123
-          42     0.00000     0.55163    -0.55235     0.00000     0.00000    -0.00000
-          43    -0.03775     0.00000     0.00000     0.03463     0.00346     0.00807
-          44    -0.05944     0.00000     0.00000     0.07151     0.02145    -0.00126
-          45    -0.00000    -0.00488    -0.00480     0.00000     0.00000    -0.00000
-          46    -0.03775     0.00000    -0.00000    -0.03463     0.00346    -0.00807
-          47    -0.05944     0.00000    -0.00000    -0.07151     0.02145     0.00126
-          48     0.00000     0.00488    -0.00480     0.00000     0.00000    -0.00000
-          49    -0.09351     0.00000     0.00000     0.09075     0.01215     0.01809
-          50     0.28921    -0.00000    -0.00000    -0.28509    -0.03880    -0.05448
-          51    -0.00000    -0.31291    -0.31353     0.00000    -0.00000     0.00000
-          52    -0.09351     0.00000    -0.00000    -0.09075     0.01215    -0.01809
-          53     0.28921    -0.00000     0.00000     0.28509    -0.03880     0.05448
-          54     0.00000     0.31291    -0.31353     0.00000    -0.00000     0.00000
-          55     0.30574    -0.00000    -0.00000    -0.33076    -0.10350     0.00609
-          56    -0.16345     0.00000     0.00000     0.18342     0.05501    -0.00223
-          57     0.00000     0.22667     0.22715    -0.00000    -0.00000     0.00000
-          58     0.30574    -0.00000     0.00000     0.33076    -0.10350    -0.00609
-          59    -0.16345     0.00000    -0.00000    -0.18342     0.05501     0.00223
-          60    -0.00000    -0.22667     0.22715    -0.00000    -0.00000     0.00000
+           1    -0.04695    -0.00000     0.00000     0.01906    -0.02863    -0.00340
+           2    -0.02535     0.00000     0.00000     0.05342     0.04213    -0.06554
+           3    -0.00000     0.00193    -0.00087     0.00000     0.00000    -0.00000
+           4    -0.04695    -0.00000     0.00000    -0.01906    -0.02863     0.00340
+           5    -0.02535    -0.00000     0.00000    -0.05342     0.04213     0.06554
+           6     0.00000    -0.00193    -0.00087     0.00000    -0.00000    -0.00000
+           7     0.02099     0.00000    -0.00000     0.01976     0.02728    -0.03671
+           8     0.01934     0.00000    -0.00000     0.02743     0.04693     0.02372
+           9    -0.00000     0.00248    -0.00297     0.00000     0.00000    -0.00000
+          10     0.02099     0.00000    -0.00000    -0.01976     0.02728     0.03671
+          11     0.01934     0.00000    -0.00000    -0.02743     0.04693    -0.02372
+          12    -0.00000    -0.00248    -0.00297     0.00000    -0.00000    -0.00000
+          13     0.04804     0.00000    -0.00000     0.03976     0.01629    -0.03141
+          14    -0.00570    -0.00000    -0.00000    -0.01821    -0.07108    -0.00829
+          15     0.00000     0.00234     0.00308    -0.00000    -0.00000     0.00000
+          16     0.04804     0.00000    -0.00000    -0.03976     0.01629     0.03141
+          17    -0.00570     0.00000    -0.00000     0.01821    -0.07108     0.00829
+          18     0.00000    -0.00234     0.00308    -0.00000    -0.00000     0.00000
+          19    -0.03415     0.00000     0.00000     0.01348    -0.06976    -0.18957
+          20     0.17695     0.00000    -0.00000     0.05635     0.33442     0.42657
+          21     0.00000    -0.02423     0.00462     0.00000    -0.00000    -0.00000
+          22    -0.03415    -0.00000    -0.00000    -0.01348    -0.06976     0.18957
+          23     0.17695     0.00000    -0.00000    -0.05635     0.33442    -0.42657
+          24     0.00000     0.02424     0.00462    -0.00000     0.00000     0.00000
+          25     0.05563     0.00000    -0.00000     0.08428    -0.24896    -0.27152
+          26    -0.00504     0.00000     0.00000     0.02712    -0.40593    -0.29734
+          27    -0.00000     0.01630     0.00364     0.00000     0.00000    -0.00000
+          28     0.05563     0.00000    -0.00000    -0.08428    -0.24896     0.27152
+          29    -0.00504     0.00000     0.00000    -0.02712    -0.40593     0.29734
+          30     0.00000    -0.01630     0.00364     0.00000     0.00000     0.00000
+          31    -0.04505    -0.00000     0.00000    -0.04318     0.00748    -0.02482
+          32    -0.02723    -0.00000     0.00000    -0.02355     0.00840    -0.02168
+          33    -0.00000    -0.05883    -0.05838     0.00000    -0.00000     0.00000
+          34    -0.04505    -0.00000     0.00000     0.04318     0.00748     0.02482
+          35    -0.02723    -0.00000     0.00000     0.02355     0.00840     0.02168
+          36    -0.00000     0.05883    -0.05839    -0.00000     0.00000     0.00000
+          37     0.01470     0.00000    -0.00000     0.01431     0.00167    -0.00830
+          38    -0.29025    -0.00000     0.00000    -0.27113     0.02883    -0.11123
+          39     0.00000     0.55166     0.55232    -0.00000     0.00000     0.00000
+          40     0.01470     0.00000    -0.00000    -0.01431     0.00167     0.00830
+          41    -0.29025    -0.00000     0.00000     0.27113     0.02883     0.11123
+          42     0.00000    -0.55160     0.55239     0.00000    -0.00000     0.00000
+          43     0.03775     0.00000    -0.00000     0.03463    -0.00346     0.00807
+          44     0.05944     0.00000    -0.00000     0.07151    -0.02145    -0.00126
+          45     0.00000     0.00488     0.00480     0.00000    -0.00000    -0.00000
+          46     0.03775     0.00000    -0.00000    -0.03463    -0.00346    -0.00807
+          47     0.05944     0.00000    -0.00000    -0.07151    -0.02145     0.00126
+          48     0.00000    -0.00488     0.00480     0.00000    -0.00000    -0.00000
+          49     0.09351     0.00000    -0.00000     0.09075    -0.01215     0.01809
+          50    -0.28921    -0.00000     0.00000    -0.28509     0.03880    -0.05448
+          51     0.00000     0.31293     0.31351    -0.00000    -0.00000     0.00000
+          52     0.09351     0.00000    -0.00000    -0.09075    -0.01215    -0.01809
+          53    -0.28921    -0.00000     0.00000     0.28509     0.03880     0.05448
+          54     0.00000    -0.31290     0.31355    -0.00000    -0.00000     0.00000
+          55    -0.30574    -0.00000     0.00000    -0.33076     0.10350     0.00609
+          56     0.16345     0.00000    -0.00000     0.18342    -0.05501    -0.00223
+          57    -0.00000    -0.22668    -0.22714     0.00000    -0.00000     0.00000
+          58    -0.30574    -0.00000     0.00000     0.33076     0.10350    -0.00609
+          59     0.16345     0.00000    -0.00000    -0.18342    -0.05501     0.00223
+          60    -0.00000     0.22666    -0.22717    -0.00000     0.00000     0.00000
 
                    37          38          39          40          41          42
  
@@ -2405,259 +3162,259 @@ Iterative solution of linear equations
  
            1    -0.04119     0.00127     0.12417    -0.07790     0.01964     0.04521
            2     0.12977    -0.12800     0.03520    -0.01093    -0.01046    -0.00155
-           3     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
+           3     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
            4    -0.04119    -0.00127     0.12417     0.07790     0.01964    -0.04521
            5     0.12977     0.12800     0.03520     0.01093    -0.01046     0.00155
-           6     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+           6    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
            7     0.00046    -0.03751    -0.05352    -0.00609     0.00048     0.01031
            8    -0.04829    -0.05691     0.08213     0.01241     0.02855    -0.01866
-           9     0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
+           9    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
           10     0.00046     0.03751    -0.05352     0.00609     0.00048    -0.01031
           11    -0.04829     0.05691     0.08213    -0.01241     0.02855     0.01866
-          12     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+          12    -0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
           13     0.05548     0.00314    -0.04647     0.01121    -0.01627    -0.01266
           14     0.01803     0.07015    -0.06651     0.03346    -0.02300    -0.01385
-          15    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          15     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           16     0.05548    -0.00314    -0.04647    -0.01121    -0.01627     0.01266
           17     0.01803    -0.07015    -0.06651    -0.03346    -0.02300     0.01385
-          18    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          18     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           19     0.10587    -0.03051     0.03564     0.12098     0.01549    -0.07904
           20    -0.32500    -0.11310    -0.16309    -0.33192    -0.00678     0.22499
-          21     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
+          21     0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.00000
           22     0.10587     0.03051     0.03564    -0.12098     0.01549     0.07904
           23    -0.32500     0.11310    -0.16309     0.33192    -0.00678    -0.22499
-          24     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+          24     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           25    -0.06395     0.12513    -0.03793    -0.23084     0.02576     0.14533
           26    -0.12723     0.23430    -0.05324    -0.25695     0.02695     0.17772
-          27    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          27     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
           28    -0.06395    -0.12513    -0.03793     0.23084     0.02576    -0.14533
           29    -0.12723    -0.23429    -0.05324     0.25695     0.02695    -0.17772
-          30    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          30     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
           31    -0.02904    -0.04528    -0.04595    -0.05239     0.06164    -0.04602
           32    -0.01723    -0.03076    -0.03338    -0.02821     0.01096    -0.00034
-          33    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
+          33     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
           34    -0.02904     0.04528    -0.04595     0.05239     0.06164     0.04602
           35    -0.01723     0.03076    -0.03338     0.02821     0.01096     0.00034
-          36     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          36    -0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
           37     0.00840    -0.00838    -0.04728    -0.11368     0.18734    -0.15725
           38    -0.21087    -0.22650    -0.04887     0.21177    -0.48959     0.44331
-          39     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          39    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
           40     0.00840     0.00838    -0.04728     0.11368     0.18734     0.15725
           41    -0.21087     0.22650    -0.04887    -0.21177    -0.48959    -0.44331
-          42    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
+          42    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
           43     0.00426     0.01681     0.02584     0.04336    -0.07098     0.06146
           44    -0.01941    -0.01485     0.01210     0.00813     0.01040    -0.01493
-          45     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          45    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
           46     0.00426    -0.01681     0.02584    -0.04336    -0.07098    -0.06146
           47    -0.01941     0.01485     0.01210    -0.00813     0.01040     0.01493
           48    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
           49     0.01092     0.03261     0.04981     0.07921    -0.12421     0.10438
           50    -0.04586    -0.09139    -0.11906    -0.17634     0.26383    -0.21406
-          51    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          51     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           52     0.01092    -0.03261     0.04981    -0.07921    -0.12421    -0.10438
           53    -0.04586     0.09139    -0.11906     0.17634     0.26383     0.21406
-          54    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          54    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
           55     0.05820     0.00434    -0.04881    -0.01601    -0.03896     0.03853
           56    -0.03966    -0.01588     0.03266     0.02236     0.00981    -0.01631
-          57    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
+          57     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
           58     0.05820    -0.00434    -0.04881     0.01601    -0.03896    -0.03853
           59    -0.03966     0.01588     0.03266    -0.02236     0.00981     0.01631
-          60     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          60     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
 
                    43          44          45          46          47          48
  
  P.Frequency     1514.54     1565.41     1575.24     1639.65     1690.93     1738.51
  
-           1     0.08527     0.01922     0.03916     0.02451    -0.13386    -0.00458
-           2    -0.00349     0.02695    -0.01787     0.10213     0.01396    -0.08068
-           3     0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.00000
-           4     0.08527    -0.01922     0.03916     0.02451     0.13386     0.00458
-           5    -0.00349    -0.02695    -0.01787     0.10213    -0.01396     0.08068
-           6     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
-           7    -0.04360    -0.01122    -0.00024     0.05014     0.07415    -0.01530
-           8    -0.07878     0.02449    -0.03520    -0.07384    -0.05243     0.12506
-           9    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          10    -0.04360     0.01122    -0.00024     0.05014    -0.07415     0.01530
-          11    -0.07878    -0.02449    -0.03520    -0.07384     0.05243    -0.12506
-          12     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
-          13     0.00986     0.01487    -0.02099    -0.07262    -0.09008    -0.04487
-          14     0.09862    -0.00334     0.02237    -0.04321    -0.02878    -0.11057
-          15    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-          16     0.00986    -0.01487    -0.02099    -0.07262     0.09008     0.04487
-          17     0.09862     0.00334     0.02237    -0.04321     0.02878     0.11057
-          18    -0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-          19    -0.14081     0.01375    -0.06085    -0.07317     0.01800     0.08716
-          20     0.14094    -0.04299     0.11829     0.28374     0.12921    -0.13556
-          21     0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
-          22    -0.14081    -0.01375    -0.06085    -0.07317    -0.01800    -0.08716
-          23     0.14094     0.04299     0.11829     0.28374    -0.12921     0.13556
-          24    -0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
-          25    -0.24353    -0.00270    -0.01876     0.14393     0.03698     0.12756
-          26    -0.19038    -0.02963     0.03543     0.23625     0.14250     0.08869
-          27     0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
-          28    -0.24353     0.00270    -0.01876     0.14393    -0.03698    -0.12756
-          29    -0.19038     0.02963     0.03543     0.23625    -0.14250    -0.08869
-          30    -0.00000     0.00000     0.00000    -0.00000     0.00000    -0.00000
-          31     0.00043    -0.02441    -0.02827    -0.01305    -0.00315     0.00495
-          32    -0.04378     0.08496     0.06811    -0.02165    -0.01480    -0.02290
-          33    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          34     0.00043     0.02441    -0.02827    -0.01305     0.00315    -0.00495
-          35    -0.04378    -0.08496     0.06811    -0.02165     0.01480     0.02290
-          36    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          37     0.00014     0.03396     0.03510    -0.01750     0.01293    -0.00561
-          38    -0.03125    -0.17967    -0.21584    -0.01816    -0.07353     0.02444
-          39     0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
-          40     0.00014    -0.03396     0.03510    -0.01750    -0.01293     0.00561
-          41    -0.03125     0.17967    -0.21584    -0.01816     0.07353    -0.02444
-          42     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
-          43    -0.00641    -0.01998    -0.02357     0.01332    -0.01811    -0.00650
-          44     0.02123    -0.00061     0.00872    -0.01177     0.02547     0.00948
-          45    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
-          46    -0.00641     0.01998    -0.02357     0.01332     0.01811     0.00650
-          47     0.02123     0.00061     0.00872    -0.01177    -0.02547    -0.00948
-          48    -0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
-          49    -0.02288     0.05068     0.04685     0.00222     0.00195    -0.00215
-          50     0.08858    -0.36160    -0.35912     0.05793    -0.10371    -0.02693
-          51     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
-          52    -0.02288    -0.05068     0.04685     0.00222    -0.00195     0.00215
-          53     0.08858     0.36160    -0.35912     0.05793     0.10371     0.02693
-          54    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          55    -0.13521     0.42767     0.40142    -0.08291     0.07996     0.01543
-          56     0.06598    -0.14591    -0.12813     0.01580    -0.00179     0.00410
-          57    -0.00000    -0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          58    -0.13521    -0.42767     0.40142    -0.08291    -0.07996    -0.01543
-          59     0.06598     0.14591    -0.12813     0.01580     0.00179    -0.00410
-          60     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
+           1     0.08527     0.01922    -0.03916     0.02451    -0.13386    -0.00458
+           2    -0.00349     0.02695     0.01787     0.10213     0.01396    -0.08068
+           3    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+           4     0.08527    -0.01922    -0.03916     0.02451     0.13386     0.00458
+           5    -0.00349    -0.02695     0.01787     0.10213    -0.01396     0.08068
+           6     0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+           7    -0.04360    -0.01122     0.00024     0.05014     0.07415    -0.01530
+           8    -0.07878     0.02449     0.03520    -0.07384    -0.05243     0.12506
+           9     0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
+          10    -0.04360     0.01122     0.00024     0.05014    -0.07415     0.01530
+          11    -0.07878    -0.02449     0.03520    -0.07384     0.05243    -0.12506
+          12     0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          13     0.00986     0.01487     0.02099    -0.07262    -0.09008    -0.04487
+          14     0.09862    -0.00334    -0.02237    -0.04321    -0.02878    -0.11057
+          15    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          16     0.00986    -0.01487     0.02099    -0.07262     0.09008     0.04487
+          17     0.09862     0.00334    -0.02237    -0.04321     0.02878     0.11057
+          18    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          19    -0.14081     0.01375     0.06085    -0.07317     0.01800     0.08716
+          20     0.14094    -0.04299    -0.11829     0.28374     0.12921    -0.13556
+          21     0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
+          22    -0.14081    -0.01375     0.06085    -0.07317    -0.01800    -0.08716
+          23     0.14094     0.04299    -0.11829     0.28374    -0.12921     0.13556
+          24     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          25    -0.24353    -0.00270     0.01876     0.14393     0.03698     0.12756
+          26    -0.19038    -0.02963    -0.03543     0.23625     0.14250     0.08869
+          27    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          28    -0.24353     0.00270     0.01876     0.14393    -0.03698    -0.12756
+          29    -0.19038     0.02963    -0.03543     0.23625    -0.14250    -0.08869
+          30    -0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00000
+          31     0.00043    -0.02441     0.02827    -0.01305    -0.00315     0.00495
+          32    -0.04378     0.08496    -0.06811    -0.02165    -0.01480    -0.02290
+          33    -0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          34     0.00043     0.02441     0.02827    -0.01305     0.00315    -0.00495
+          35    -0.04378    -0.08496    -0.06811    -0.02165     0.01480     0.02290
+          36     0.00000     0.00000     0.00000    -0.00000     0.00000    -0.00000
+          37     0.00014     0.03396    -0.03510    -0.01750     0.01293    -0.00561
+          38    -0.03125    -0.17967     0.21584    -0.01816    -0.07353     0.02444
+          39    -0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
+          40     0.00014    -0.03396    -0.03510    -0.01750    -0.01293     0.00561
+          41    -0.03125     0.17967     0.21584    -0.01816     0.07353    -0.02444
+          42    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          43    -0.00641    -0.01998     0.02357     0.01332    -0.01811    -0.00650
+          44     0.02123    -0.00061    -0.00872    -0.01177     0.02547     0.00948
+          45     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
+          46    -0.00641     0.01998     0.02357     0.01332     0.01811     0.00650
+          47     0.02123     0.00061    -0.00872    -0.01177    -0.02547    -0.00948
+          48     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          49    -0.02288     0.05068    -0.04685     0.00222     0.00195    -0.00215
+          50     0.08858    -0.36160     0.35912     0.05793    -0.10371    -0.02693
+          51    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          52    -0.02288    -0.05068    -0.04685     0.00222    -0.00195     0.00215
+          53     0.08858     0.36160     0.35912     0.05793     0.10371     0.02693
+          54    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
+          55    -0.13521     0.42767    -0.40142    -0.08291     0.07996     0.01543
+          56     0.06598    -0.14591     0.12813     0.01580    -0.00179     0.00410
+          57    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
+          58    -0.13521    -0.42767    -0.40142    -0.08291    -0.07996    -0.01543
+          59     0.06598     0.14591     0.12813     0.01580     0.00179    -0.00410
+          60    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
 
                    49          50          51          52          53          54
  
  P.Frequency     1814.83     1815.80     3394.04     3394.77     3432.83     3432.83
  
-           1    -0.03129    -0.01449     0.00016     0.00015    -0.00037     0.00033
-           2     0.00993     0.02488     0.00002     0.00005    -0.00160     0.00159
-           3     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
-           4     0.03129    -0.01449     0.00016    -0.00015    -0.00037    -0.00033
-           5    -0.00993     0.02488     0.00002    -0.00005    -0.00160    -0.00159
-           6     0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
-           7     0.01075     0.00476     0.00077     0.00027     0.00151    -0.00199
-           8     0.01758     0.00541     0.00008    -0.00012     0.00056    -0.00075
-           9     0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
-          10    -0.01075     0.00476     0.00077    -0.00027     0.00151     0.00199
-          11    -0.01758     0.00541     0.00008     0.00012     0.00056     0.00075
-          12     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
-          13    -0.02264     0.00002    -0.00110     0.00096    -0.00037     0.00045
-          14    -0.02175    -0.01020     0.00077    -0.00050    -0.00018    -0.00057
+           1    -0.03129    -0.01449    -0.00016     0.00015     0.00037     0.00033
+           2     0.00993     0.02488    -0.00002     0.00005     0.00160     0.00159
+           3    -0.00000     0.00000    -0.00000     0.00000    -0.00000     0.00000
+           4     0.03129    -0.01449    -0.00016    -0.00015     0.00037    -0.00033
+           5    -0.00993     0.02488    -0.00002    -0.00005     0.00160    -0.00159
+           6     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
+           7     0.01075     0.00476    -0.00077     0.00027    -0.00151    -0.00199
+           8     0.01758     0.00541    -0.00008    -0.00012    -0.00056    -0.00075
+           9     0.00000     0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          10    -0.01075     0.00476    -0.00077    -0.00027    -0.00151     0.00199
+          11    -0.01758     0.00541    -0.00008     0.00012    -0.00056     0.00075
+          12     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          13    -0.02264     0.00002     0.00110     0.00096     0.00037     0.00045
+          14    -0.02175    -0.01020    -0.00077    -0.00050     0.00018    -0.00057
           15    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
-          16     0.02264     0.00002    -0.00110    -0.00096    -0.00037    -0.00045
-          17     0.02175    -0.01020     0.00077     0.00050    -0.00018     0.00057
-          18    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          19     0.02205     0.01127    -0.00877    -0.00189    -0.01762     0.02365
-          20    -0.00276    -0.00594    -0.00287    -0.00053    -0.00536     0.00774
-          21     0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          22    -0.02205     0.01127    -0.00877     0.00189    -0.01764    -0.02364
-          23     0.00276    -0.00594    -0.00287     0.00053    -0.00536    -0.00773
-          24     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          25     0.00664     0.02766     0.01020    -0.00702     0.00245    -0.00511
-          26     0.01604     0.01927    -0.00767     0.00510    -0.00178     0.00385
-          27    -0.00000    -0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          28    -0.00664     0.02766     0.01020     0.00702     0.00246     0.00511
-          29    -0.01604     0.01927    -0.00767    -0.00510    -0.00178    -0.00385
-          30    -0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
-          31    -0.07194     0.07136     0.01097    -0.01090     0.05776     0.05774
-          32     0.10892    -0.11364     0.00791    -0.00787     0.00950     0.00952
-          33    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
-          34     0.07194     0.07136     0.01097     0.01090     0.05772    -0.05779
-          35    -0.10892    -0.11364     0.00791     0.00787     0.00949    -0.00953
-          36    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          37    -0.03015     0.02931    -0.17462     0.17293    -0.63109    -0.63092
-          38    -0.14278     0.13895    -0.03967     0.03939    -0.14654    -0.14653
-          39     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
-          40     0.03015     0.02931    -0.17462    -0.17293    -0.63062     0.63139
-          41     0.14278     0.13895    -0.03967    -0.03939    -0.14643     0.14664
-          42     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
-          43     0.07693    -0.07771     0.02954    -0.02951    -0.01394    -0.01384
-          44    -0.09225     0.09392    -0.03603     0.03607     0.01031     0.01018
-          45    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          46    -0.07693    -0.07771     0.02954     0.02951    -0.01393     0.01385
-          47     0.09225     0.09392    -0.03603    -0.03607     0.01031    -0.01019
-          48    -0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
-          49     0.04826    -0.04843    -0.44964     0.45004     0.14525     0.14372
-          50     0.19162    -0.19576    -0.08010     0.08015     0.02806     0.02780
-          51     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
-          52    -0.04826    -0.04843    -0.44964    -0.45004     0.14515    -0.14382
-          53    -0.19162    -0.19576    -0.08010    -0.08015     0.02804    -0.02782
-          54     0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
-          55    -0.17114     0.17147     0.14250    -0.14273    -0.02991    -0.02941
-          56    -0.03741     0.03904     0.45481    -0.45522    -0.09571    -0.09426
-          57     0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
-          58     0.17114     0.17147     0.14250     0.14273    -0.02989     0.02944
-          59     0.03741     0.03904     0.45481     0.45522    -0.09564     0.09433
-          60     0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          16     0.02264     0.00002     0.00110    -0.00096     0.00037    -0.00045
+          17     0.02175    -0.01020    -0.00077     0.00050     0.00018     0.00057
+          18    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          19     0.02205     0.01127     0.00877    -0.00189     0.01763     0.02364
+          20    -0.00276    -0.00594     0.00287    -0.00053     0.00536     0.00773
+          21     0.00000    -0.00000     0.00000    -0.00000     0.00000     0.00000
+          22    -0.02205     0.01127     0.00877     0.00189     0.01763    -0.02364
+          23     0.00276    -0.00594     0.00287     0.00053     0.00536    -0.00773
+          24     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
+          25     0.00664     0.02766    -0.01020    -0.00702    -0.00245    -0.00511
+          26     0.01604     0.01927     0.00767     0.00510     0.00178     0.00385
+          27     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          28    -0.00664     0.02766    -0.01020     0.00702    -0.00245     0.00511
+          29    -0.01604     0.01927     0.00767    -0.00510     0.00178    -0.00385
+          30     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          31    -0.07194     0.07136    -0.01097    -0.01090    -0.05774     0.05777
+          32     0.10892    -0.11364    -0.00791    -0.00787    -0.00949     0.00952
+          33     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          34     0.07194     0.07136    -0.01097     0.01090    -0.05774    -0.05776
+          35    -0.10892    -0.11364    -0.00791     0.00787    -0.00949    -0.00952
+          36     0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
+          37    -0.03015     0.02931     0.17462     0.17293     0.63082    -0.63120
+          38    -0.14278     0.13895     0.03967     0.03939     0.14648    -0.14659
+          39    -0.00000     0.00000    -0.00000     0.00000     0.00000    -0.00000
+          40     0.03015     0.02931     0.17462    -0.17293     0.63090     0.63111
+          41     0.14278     0.13895     0.03967    -0.03939     0.14650     0.14657
+          42     0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
+          43     0.07693    -0.07771    -0.02954    -0.02951     0.01393    -0.01384
+          44    -0.09225     0.09392     0.03603     0.03607    -0.01031     0.01019
+          45     0.00000    -0.00000     0.00000     0.00000    -0.00000    -0.00000
+          46    -0.07693    -0.07771    -0.02954     0.02951     0.01393     0.01384
+          47     0.09225     0.09392     0.03603    -0.03607    -0.01031    -0.01019
+          48    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          49     0.04826    -0.04843     0.44964     0.45004    -0.14519     0.14378
+          50     0.19162    -0.19576     0.08010     0.08015    -0.02805     0.02782
+          51    -0.00000     0.00000     0.00000    -0.00000     0.00000     0.00000
+          52    -0.04826    -0.04843     0.44964    -0.45004    -0.14521    -0.14376
+          53    -0.19162    -0.19576     0.08010    -0.08015    -0.02805    -0.02781
+          54    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          55    -0.17114     0.17147    -0.14250    -0.14273     0.02990    -0.02943
+          56    -0.03741     0.03904    -0.45481    -0.45522     0.09567    -0.09430
+          57    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
+          58     0.17114     0.17147    -0.14250     0.14273     0.02990     0.02942
+          59     0.03741     0.03904    -0.45481     0.45522     0.09568     0.09429
+          60    -0.00000     0.00000    -0.00000    -0.00000     0.00000     0.00000
 
                    55          56          57          58          59          60
  
  P.Frequency     3447.88     3451.35     3471.32     3474.29     3546.60     3546.65
  
-           1    -0.00118     0.00257    -0.00372    -0.00145    -0.00015    -0.00016
-           2     0.00216    -0.00161     0.00002    -0.00203     0.00032     0.00032
-           3     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
-           4    -0.00118    -0.00257    -0.00372     0.00145    -0.00015     0.00016
-           5     0.00216     0.00161     0.00002     0.00203     0.00032    -0.00032
-           6    -0.00000    -0.00000     0.00000    -0.00000    -0.00000     0.00000
-           7     0.05177    -0.05188     0.02225    -0.02230     0.00003     0.00008
-           8     0.01792    -0.01832     0.01128    -0.01081    -0.00003     0.00007
-           9    -0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
-          10     0.05177     0.05188     0.02225     0.02230     0.00003    -0.00008
-          11     0.01792     0.01832     0.01128     0.01081    -0.00003    -0.00007
-          12     0.00000    -0.00000    -0.00000    -0.00000    -0.00000     0.00000
-          13    -0.01905     0.01826     0.04224    -0.04266    -0.00032     0.00039
-          14     0.01193    -0.01192    -0.03625     0.03639     0.00026    -0.00034
-          15    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          16    -0.01905    -0.01826     0.04224     0.04266    -0.00032    -0.00039
-          17     0.01193     0.01192    -0.03625    -0.03639     0.00026     0.00034
-          18     0.00000     0.00000     0.00000     0.00000     0.00000    -0.00000
-          19    -0.58121     0.58284    -0.24595     0.24125     0.00016    -0.00055
-          20    -0.21355     0.21457    -0.09209     0.08967    -0.00005    -0.00023
-          21     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          22    -0.58121    -0.58284    -0.24595    -0.24125     0.00016     0.00055
-          23    -0.21355    -0.21457    -0.09209    -0.08967    -0.00005     0.00023
-          24    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
-          25     0.20621    -0.20204    -0.47831     0.47992     0.00500    -0.00579
-          26    -0.16673     0.16441     0.39212    -0.39316    -0.00366     0.00433
-          27     0.00000    -0.00000     0.00000     0.00000     0.00000    -0.00000
-          28     0.20621     0.20204    -0.47831    -0.47992     0.00500     0.00579
-          29    -0.16673    -0.16441     0.39212     0.39316    -0.00366    -0.00433
-          30    -0.00000     0.00000    -0.00000     0.00000    -0.00000    -0.00000
-          31    -0.00192    -0.00209     0.00005    -0.00069    -0.00316     0.00316
-          32    -0.00028    -0.00041    -0.00015    -0.00003    -0.00067     0.00067
+           1    -0.00118     0.00257     0.00372    -0.00145     0.00015    -0.00016
+           2     0.00216    -0.00161    -0.00002    -0.00203    -0.00032     0.00032
+           3    -0.00000    -0.00000     0.00000    -0.00000     0.00000    -0.00000
+           4    -0.00118    -0.00257     0.00372     0.00145     0.00015     0.00016
+           5     0.00216     0.00161    -0.00002     0.00203    -0.00032    -0.00032
+           6     0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
+           7     0.05177    -0.05188    -0.02225    -0.02230    -0.00003     0.00008
+           8     0.01792    -0.01832    -0.01128    -0.01081     0.00003     0.00007
+           9    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
+          10     0.05177     0.05188    -0.02225     0.02230    -0.00003    -0.00008
+          11     0.01792     0.01832    -0.01128     0.01081     0.00003    -0.00007
+          12    -0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          13    -0.01905     0.01826    -0.04224    -0.04266     0.00032     0.00039
+          14     0.01193    -0.01192     0.03625     0.03639    -0.00026    -0.00034
+          15     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
+          16    -0.01905    -0.01826    -0.04224     0.04266     0.00032    -0.00039
+          17     0.01193     0.01192     0.03625    -0.03639    -0.00026     0.00034
+          18     0.00000     0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          19    -0.58121     0.58284     0.24595     0.24125    -0.00016    -0.00055
+          20    -0.21355     0.21457     0.09209     0.08967     0.00005    -0.00023
+          21     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          22    -0.58122    -0.58284     0.24595    -0.24125    -0.00016     0.00055
+          23    -0.21355    -0.21457     0.09209    -0.08967     0.00005     0.00023
+          24    -0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+          25     0.20621    -0.20204     0.47831     0.47992    -0.00500    -0.00579
+          26    -0.16673     0.16441    -0.39212    -0.39316     0.00366     0.00433
+          27     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          28     0.20621     0.20204     0.47831    -0.47992    -0.00500     0.00579
+          29    -0.16673    -0.16441    -0.39212     0.39316     0.00366    -0.00433
+          30     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          31    -0.00192    -0.00209    -0.00005    -0.00069     0.00316     0.00316
+          32    -0.00028    -0.00041     0.00015    -0.00003     0.00067     0.00067
           33     0.00000     0.00000     0.00000    -0.00000    -0.00000    -0.00000
-          34    -0.00192     0.00209     0.00005     0.00069    -0.00316    -0.00316
-          35    -0.00028     0.00041    -0.00015     0.00003    -0.00067    -0.00067
-          36    -0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
-          37     0.02039     0.02368     0.00257     0.00520     0.03652    -0.03648
-          38     0.00350     0.00486     0.00116    -0.00008     0.00653    -0.00653
-          39    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          40     0.02039    -0.02368     0.00257    -0.00520     0.03652     0.03648
-          41     0.00350    -0.00486     0.00116     0.00008     0.00653     0.00653
-          42     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
-          43     0.00006     0.00030    -0.00022     0.00039    -0.05034     0.05034
-          44     0.00053    -0.00071    -0.00095     0.00089    -0.04415     0.04414
-          45    -0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
-          46     0.00006    -0.00030    -0.00022    -0.00039    -0.05034    -0.05034
-          47     0.00053     0.00071    -0.00095    -0.00089    -0.04415    -0.04414
-          48     0.00000     0.00000     0.00000    -0.00000    -0.00000     0.00000
-          49     0.00360    -0.00515    -0.00291     0.00074     0.46698    -0.46713
-          50     0.00087    -0.00110    -0.00091     0.00053     0.07798    -0.07800
-          51     0.00000    -0.00000     0.00000     0.00000     0.00000     0.00000
-          52     0.00360     0.00515    -0.00291    -0.00074     0.46701     0.46710
-          53     0.00087     0.00110    -0.00091    -0.00053     0.07798     0.07800
-          54    -0.00000    -0.00000    -0.00000     0.00000     0.00000     0.00000
-          55    -0.00232     0.00193     0.00304    -0.00291     0.13352    -0.13348
-          56    -0.00822     0.00589     0.00990    -0.01015     0.44631    -0.44621
-          57     0.00000     0.00000    -0.00000     0.00000     0.00000     0.00000
-          58    -0.00232    -0.00193     0.00304     0.00291     0.13352     0.13347
-          59    -0.00822    -0.00589     0.00990     0.01015     0.44633     0.44619
-          60    -0.00000    -0.00000    -0.00000     0.00000     0.00000    -0.00000
+          34    -0.00192     0.00209    -0.00005     0.00069     0.00316    -0.00316
+          35    -0.00028     0.00041     0.00015     0.00003     0.00067    -0.00067
+          36     0.00000     0.00000    -0.00000    -0.00000     0.00000    -0.00000
+          37     0.02039     0.02368    -0.00257     0.00520    -0.03652    -0.03648
+          38     0.00350     0.00486    -0.00116    -0.00008    -0.00653    -0.00653
+          39    -0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          40     0.02039    -0.02368    -0.00257    -0.00520    -0.03652     0.03648
+          41     0.00350    -0.00486    -0.00116     0.00008    -0.00653     0.00653
+          42     0.00000    -0.00000    -0.00000     0.00000    -0.00000     0.00000
+          43     0.00006     0.00030     0.00022     0.00039     0.05034     0.05034
+          44     0.00053    -0.00071     0.00095     0.00089     0.04415     0.04414
+          45     0.00000    -0.00000    -0.00000    -0.00000     0.00000     0.00000
+          46     0.00006    -0.00030     0.00022    -0.00039     0.05034    -0.05034
+          47     0.00053     0.00071     0.00095    -0.00089     0.04415    -0.04414
+          48     0.00000    -0.00000    -0.00000    -0.00000    -0.00000    -0.00000
+          49     0.00360    -0.00515     0.00291     0.00074    -0.46701    -0.46711
+          50     0.00087    -0.00110     0.00091     0.00053    -0.07798    -0.07800
+          51     0.00000    -0.00000     0.00000     0.00000    -0.00000     0.00000
+          52     0.00360     0.00515     0.00291    -0.00074    -0.46699     0.46713
+          53     0.00087     0.00110     0.00091    -0.00053    -0.07798     0.07800
+          54     0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+          55    -0.00232     0.00193    -0.00304    -0.00291    -0.13352    -0.13347
+          56    -0.00822     0.00589    -0.00990    -0.01015    -0.44633    -0.44619
+          57     0.00000     0.00000     0.00000     0.00000    -0.00000    -0.00000
+          58    -0.00232    -0.00193    -0.00304     0.00291    -0.13352     0.13347
+          59    -0.00822    -0.00589    -0.00990     0.01015    -0.44631     0.44621
+          60     0.00000     0.00000     0.00000     0.00000    -0.00000     0.00000
 
 
 
@@ -2665,66 +3422,66 @@ Iterative solution of linear equations
  Normal Eigenvalue ||    Projected Derivative Dipole Moments (debye/angs)
   Mode   [cm**-1]  ||      [d/dqX]             [d/dqY]           [d/dqZ]
  ------ ---------- || ------------------ ------------------ -----------------
-    1       -0.000 ||      -0.000               0.000            -0.000
-    2       -0.000 ||       0.000              -0.000            -0.000
-    3       -0.000 ||       0.000               0.000            -0.000
-    4        0.000 ||       0.000              -0.000             0.000
-    5        0.000 ||       0.000              -0.000             0.000
-    6        0.000 ||       0.000               0.000            -0.000
-    7       49.010 ||      -0.000               0.000             0.027
-    8       81.563 ||      -0.000               0.000            -0.000
-    9      151.698 ||       0.000              -0.000            -0.091
+    1       -0.000 ||      -0.000              -0.000            -0.000
+    2        0.000 ||       0.000              -0.000             0.000
+    3        0.000 ||       0.000              -0.000            -0.000
+    4        0.000 ||      -0.000               0.000             0.000
+    5        0.000 ||       0.000               0.000            -0.000
+    6        0.000 ||       0.000              -0.000            -0.000
+    7       49.010 ||       0.000              -0.000             0.027
+    8       81.563 ||       0.000               0.000            -0.000
+    9      151.698 ||      -0.000              -0.000             0.091
    10      181.038 ||       0.031              -0.073             0.000
    11      265.733 ||       0.000              -0.000             0.000
-   12      300.969 ||       0.000              -0.000            -0.000
-   13      407.917 ||       0.000              -0.000            -0.000
-   14      424.393 ||       0.000              -0.000            -0.049
-   15      468.977 ||      -0.000               0.000             0.372
-   16      487.917 ||      -0.018               0.214             0.000
-   17      578.842 ||      -0.000               0.000             0.000
-   18      657.328 ||       0.000              -0.000            -0.000
+   12      300.969 ||      -0.000              -0.000            -0.000
+   13      407.917 ||       0.000              -0.000             0.000
+   14      424.393 ||      -0.000               0.000            -0.049
+   15      468.977 ||       0.000              -0.000             0.372
+   16      487.917 ||       0.018              -0.214             0.000
+   17      578.842 ||      -0.000              -0.000             0.000
+   18      657.328 ||       0.000              -0.000             0.000
    19      673.470 ||       0.000              -0.000             0.000
-   20      707.330 ||       0.000              -0.000            -0.105
+   20      707.330 ||       0.000               0.000            -0.105
    21      735.110 ||      -0.024               0.319            -0.000
-   22      810.677 ||      -0.000               0.000             0.000
-   23      862.518 ||      -0.000               0.000             0.000
-   24      895.309 ||      -0.000               0.000            -0.000
-   25      896.429 ||       0.000              -0.000             0.788
+   22      810.677 ||      -0.000              -0.000             0.000
+   23      862.518 ||      -0.000               0.000            -0.000
+   24      895.309 ||       0.000               0.000            -0.000
+   25      896.429 ||      -0.000               0.000             0.788
    26      980.901 ||      -0.000               0.000             0.000
-   27      980.975 ||      -0.000               0.000             0.930
-   28     1017.729 ||      -0.000               0.000            -0.000
-   29     1036.478 ||      -0.000               0.000            -0.013
-   30     1073.558 ||       0.014              -0.107            -0.000
-   31     1102.043 ||       0.034               0.456            -0.000
-   32     1107.662 ||       0.000              -0.000             0.000
-   33     1107.685 ||       0.000              -0.000            -0.558
-   34     1110.621 ||      -0.000              -0.000             0.000
-   35     1203.737 ||       0.090              -0.165             0.000
+   27      980.975 ||       0.000              -0.000             0.930
+   28     1017.729 ||      -0.000               0.000             0.000
+   29     1036.478 ||      -0.000               0.000             0.013
+   30     1073.558 ||       0.014              -0.107             0.000
+   31     1102.043 ||      -0.034              -0.456             0.000
+   32     1107.662 ||      -0.000              -0.000             0.000
+   33     1107.685 ||       0.000               0.000             0.558
+   34     1110.621 ||      -0.000               0.000            -0.000
+   35     1203.737 ||      -0.090               0.165             0.000
    36     1260.965 ||       0.000               0.000             0.000
    37     1284.270 ||       0.024               0.025            -0.000
-   38     1296.189 ||       0.000               0.000             0.000
+   38     1296.189 ||       0.000               0.000            -0.000
    39     1350.007 ||      -0.050              -0.460            -0.000
    40     1398.542 ||       0.000               0.000            -0.000
    41     1422.113 ||      -0.086               0.440            -0.000
-   42     1427.487 ||       0.000              -0.000             0.000
-   43     1514.545 ||      -0.648              -0.167             0.000
+   42     1427.487 ||      -0.000               0.000             0.000
+   43     1514.545 ||      -0.648              -0.167            -0.000
    44     1565.407 ||       0.000              -0.000            -0.000
-   45     1575.243 ||       0.082               0.084             0.000
-   46     1639.653 ||      -0.039               0.601             0.000
-   47     1690.932 ||      -0.000              -0.000             0.000
-   48     1738.513 ||      -0.000              -0.000            -0.000
-   49     1814.826 ||      -0.000              -0.000             0.000
+   45     1575.243 ||      -0.082              -0.084             0.000
+   46     1639.653 ||      -0.039               0.601            -0.000
+   47     1690.932 ||       0.000              -0.000            -0.000
+   48     1738.513 ||       0.000              -0.000             0.000
+   49     1814.826 ||      -0.000              -0.000            -0.000
    50     1815.798 ||       0.188               0.009            -0.000
    51     3394.043 ||      -0.362               1.486            -0.000
-   52     3394.772 ||       0.000              -0.000            -0.000
-   53     3432.831 ||      -0.068               0.287             0.000
-   54     3432.835 ||       0.000              -0.000             0.000
+   52     3394.772 ||      -0.000               0.000            -0.000
+   53     3432.831 ||       0.068              -0.287             0.000
+   54     3432.835 ||      -0.000               0.000             0.000
    55     3447.881 ||      -0.173              -0.028             0.000
-   56     3451.354 ||      -0.000               0.000             0.000
-   57     3471.324 ||      -0.347               0.112             0.000
-   58     3474.287 ||       0.000              -0.000            -0.000
-   59     3546.602 ||       0.012              -0.020            -0.000
-   60     3546.649 ||      -0.000               0.000             0.000
+   56     3451.354 ||       0.000               0.000            -0.000
+   57     3471.324 ||       0.347              -0.112             0.000
+   58     3474.287 ||      -0.000               0.000             0.000
+   59     3546.602 ||       0.012              -0.020             0.000
+   60     3546.649 ||       0.000              -0.000             0.000
  ----------------------------------------------------------------------------
 
 
@@ -2736,8 +3493,8 @@ Iterative solution of linear equations
   Mode   [cm**-1]  || [atomic units] [(debye/angs)**2] [(KM/mol)] [arbitrary]
  ------ ---------- || -------------- ----------------- ---------- -----------
     1       -0.000 ||    0.000000           0.000         0.000       0.000
-    2       -0.000 ||    0.000000           0.000         0.000       0.000
-    3       -0.000 ||    0.000000           0.000         0.000       0.000
+    2        0.000 ||    0.000000           0.000         0.000       0.000
+    3        0.000 ||    0.000000           0.000         0.000       0.000
     4        0.000 ||    0.000000           0.000         0.000       0.000
     5        0.000 ||    0.000000           0.000         0.000       0.000
     6        0.000 ||    0.000000           0.000         0.000       0.000
@@ -2789,7 +3546,7 @@ Iterative solution of linear equations
    52     3394.772 ||    0.000000           0.000         0.000       0.000
    53     3432.831 ||    0.003773           0.087         3.678       8.376
    54     3432.835 ||    0.000000           0.000         0.000       0.000
-   55     3447.881 ||    0.001330           0.031         1.297       2.952
+   55     3447.881 ||    0.001330           0.031         1.297       2.953
    56     3451.354 ||    0.000000           0.000         0.000       0.000
    57     3471.324 ||    0.005760           0.133         5.615      12.786
    58     3474.287 ||    0.000000           0.000         0.000       0.000
@@ -2801,13 +3558,13 @@ Iterative solution of linear equations
 
  vib:animation  F
 
- Task  times  cpu:      212.5s     wall:      223.5s
- 
- 
+ Task  times  cpu:      287.4s     wall:      287.9s
+
+
                                 NWChem Input Module
                                 -------------------
- 
- 
+
+
  Summary of allocated global arrays
 -----------------------------------
   No active global arrays
@@ -2818,40 +3575,64 @@ Iterative solution of linear equations
                          ------------------------------
 
        create   destroy   get      put      acc     scatter   gather  read&inc
-calls: 6378     6378     2.98e+06 6.22e+04 2.58e+06 1262        0     1622     
-number of processes/call 1.21e+12 5.10e+13 8.50e+10 0.00e+00 0.00e+00
-bytes total:             3.87e+08 4.85e+07 3.49e+08 0.00e+00 0.00e+00 1.30e+04
-bytes remote:            2.61e+08 1.83e+07 2.57e+08 -3.00e+03 0.00e+00 0.00e+00
-Max memory consumed for GA by this process: 4761304 bytes
- 
+calls: 6381     6381     1.36e+07 2.42e+05 1.03e+07 1262        0     6912     
+number of processes/call 6.25e+10 2.70e+13 4.09e+10 0.00e+00 0.00e+00
+bytes total:             1.41e+09 1.69e+08 1.25e+09 7.00e+03 0.00e+00 5.53e+04
+bytes remote:            0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00 0.00e+00
+Max memory consumed for GA by this process: 19036800 bytes
+
 MA_summarize_allocated_blocks: starting scan ...
-MA_summarize_allocated_blocks: scan completed: 0 heap blocks, 0 stack blocks
+heap block 'gridpts', handle 103, address 0x5b84ef4ec418:
+	type of elements:		double precision
+	number of elements:		53628253
+	address of client space:	0x5b84ef4ec480
+	index for client space:		13061661
+	total number of bytes:		429026136
+MA_summarize_allocated_blocks: scan completed: 1 heap block, 0 stack blocks
 MA usage statistics:
 
 	allocation statistics:
 					      heap	     stack
 					      ----	     -----
-	current number of blocks	         0	         0
-	maximum number of blocks	        25	        54
-	current total bytes		         0	         0
-	maximum total bytes		   6909864	  67349688
-	maximum total K-bytes		      6910	     67350
-	maximum total M-bytes		         7	        68
- 
- 
+	current number of blocks	         1	         0
+	maximum number of blocks	        26	        54
+	current total bytes		 429026136	         0
+	maximum total bytes		 456188312	  67349688
+	maximum total K-bytes		    456189	     67350
+	maximum total M-bytes		       457	        68
+
+
                                      CITATION
                                      --------
                 Please cite the following reference when publishing
                            results obtained with NWChem:
- 
-                 M. Valiev, E.J. Bylaska, N. Govind, K. Kowalski,
-              T.P. Straatsma, H.J.J. van Dam, D. Wang, J. Nieplocha,
-                        E. Apra, T.L. Windus, W.A. de Jong
-                 "NWChem: a comprehensive and scalable open-source
-                  solution for large scale molecular simulations"
-                      Comput. Phys. Commun. 181, 1477 (2010)
-                           doi:10.1016/j.cpc.2010.04.018
- 
+
+          E. Aprà, E. J. Bylaska, W. A. de Jong, N. Govind, K. Kowalski,
+       T. P. Straatsma, M. Valiev, H. J. J. van Dam, Y. Alexeev, J. Anchell,
+       V. Anisimov, F. W. Aquino, R. Atta-Fynn, J. Autschbach, N. P. Bauman,
+     J. C. Becca, D. E. Bernholdt, K. Bhaskaran-Nair, S. Bogatko, P. Borowski,
+        J. Boschen, J. Brabec, A. Bruner, E. Cauët, Y. Chen, G. N. Chuev,
+      C. J. Cramer, J. Daily, M. J. O. Deegan, T. H. Dunning Jr., M. Dupuis,
+   K. G. Dyall, G. I. Fann, S. A. Fischer, A. Fonari, H. Früchtl, L. Gagliardi,
+      J. Garza, N. Gawande, S. Ghosh, K. Glaesemann, A. W. Götz, J. Hammond,
+       V. Helms, E. D. Hermes, K. Hirao, S. Hirata, M. Jacquelin, L. Jensen,
+   B. G. Johnson, H. Jónsson, R. A. Kendall, M. Klemm, R. Kobayashi, V. Konkov,
+      S. Krishnamoorthy, M. Krishnan, Z. Lin, R. D. Lins, R. J. Littlefield,
+      A. J. Logsdail, K. Lopata, W. Ma, A. V. Marenich, J. Martin del Campo,
+   D. Mejia-Rodriguez, J. E. Moore, J. M. Mullin, T. Nakajima, D. R. Nascimento,
+    J. A. Nichols, P. J. Nichols, J. Nieplocha, A. Otero-de-la-Roza, B. Palmer,
+    A. Panyala, T. Pirojsirikul, B. Peng, R. Peverati, J. Pittner, L. Pollack,
+   R. M. Richard, P. Sadayappan, G. C. Schatz, W. A. Shelton, D. W. Silverstein,
+   D. M. A. Smith, T. A. Soares, D. Song, M. Swart, H. L. Taylor, G. S. Thomas,
+            V. Tipparaju, D. G. Truhlar, K. Tsemekhman, T. Van Voorhis,
+     Á. Vázquez-Mayagoitia, P. Verma, O. Villa, A. Vishnu, K. D. Vogiatzis,
+        D. Wang, J. H. Weare, M. J. Williamson, T. L. Windus, K. Woliński,
+        A. T. Wong, Q. Wu, C. Yang, Q. Yu, M. Zacharias, Z. Zhang, Y. Zhao,
+                                and R. J. Harrison
+                        "NWChem: Past, present, and future
+                         J. Chem. Phys. 152, 184102 (2020)
+                               doi:10.1063/5.0004997
+
                                       AUTHORS
                                       -------
      E. Apra, E. J. Bylaska, N. Govind, K. Kowalski, M. Valiev, W. A. de Jong,
@@ -2874,4 +3655,4 @@ MA usage statistics:
       T. Nakajima, S. Niu, L. Pollack, M. Rosing, K. Glaesemann, G. Sandrone,
       M. Stave, H. Taylor, G. Thomas, J. H. van Lenthe, A. T. Wong, Z. Zhang.
 
- Total times  cpu:      212.5s     wall:      223.6s
+ Total times  cpu:      287.4s     wall:      288.0s


### PR DESCRIPTION
The old test outputs were missing SCF energies, which are necessary for computing all thermochemistry properties.