### PR TITLE
ADF: set unknown core MO energies to NaN

### DIFF
--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -580,7 +580,7 @@ class ADF(logfileparser.Logfile):
 
             # handle case where MO information up to a certain orbital are missing
             while int(info[0]) - 1 != len(self.moenergies[0]):
-                self.moenergies[0].append(99999)
+                self.moenergies[0].append(numpy.nan)
                 self.mosyms[0].append("A")
 
             homoA = None

--- a/test/regression.py
+++ b/test/regression.py
@@ -2882,7 +2882,7 @@ class ADFSPTest_nosyms_valence(ADFSPTest_nosyms):
     def testlengthmoenergies(self, data: "ccData") -> None:
         """Only valence orbital energies were printed here."""
         assert len(data.moenergies[0]) == 45
-        assert data.moenergies[0][0] == 99999.0
+        assert numpy.isnan(data.moenergies[0][0])
 
 
 class ADFSPTest_nosyms_valence_noscfvalues(ADFSPTest_nosyms_valence):


### PR DESCRIPTION
It doesn't make sense for set an unknown to a really large number when there is a better way of representing a numeric unknown.