### PR TITLE
Make all parsed thermochemistry consistently in atomic units

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# Psi3/Psi4: pyflakes and spacing
+fb35435f66eeb8b4825f7022cc2ab315e5379483
 ## https://github.com/cclib/cclib/pull/1307
 # remove trailing whitespace
 37740d43064bc13445b19ff2d3c5f1154f202896

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -812,10 +812,7 @@ class ADF(logfileparser.Logfile):
             line = next(inputfile)
             assert "Entropy" in line
             self.set_attribute(
-                "entropy",
-                utils.convertor(
-                    float(line.split()[6]) * self.temperature / 1000, "kcal/mol", "hartree"
-                ),
+                "entropy", utils.convertor(float(line.split()[6]) / 1000, "kcal/mol", "hartree")
             )
             line = next(inputfile)
             assert "Internal Energy" in line

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -1346,10 +1346,7 @@ class DALTON(logfileparser.Logfile):
         # atomcharges
         # atomspins
         # coreelectrons
-        # enthalpy
-        # entropy
         # etrotats
-        # freeenergy
         # grads
         # hessian
         # mocoeffs
@@ -1359,11 +1356,4 @@ class DALTON(logfileparser.Logfile):
         # scanenergies
         # scannames
         # scanparm
-        # temperature
         # vibanharms
-
-        # N/A:
-        # fonames
-        # fooverlaps
-        # fragnames
-        # frags

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1636,17 +1636,14 @@ class GAMESS(logfileparser.Logfile):
             line = next(inputfile)  # TOTAL
             thermoValues = line.split()
 
-            if hasattr(self, "scfenergies"):
-                electronicEnergy = utils.convertor(self.scfenergies[-1], "eV", "hartree")
-            else:
-                electronicEnergy = 0  # GAMESS  prints thermochemistry at the end, so it should have a value for this already
+            electronic_energy = utils.convertor(self.scfenergies[0], "eV", "hartree")
             self.set_attribute(
                 "enthalpy",
-                electronicEnergy + utils.convertor(float(thermoValues[2]), "kcal/mol", "hartree"),
+                electronic_energy + utils.convertor(float(thermoValues[2]), "kcal/mol", "hartree"),
             )
             self.set_attribute(
                 "freeenergy",
-                electronicEnergy + utils.convertor(float(thermoValues[3]), "kcal/mol", "hartree"),
+                electronic_energy + utils.convertor(float(thermoValues[3]), "kcal/mol", "hartree"),
             )
             self.set_attribute(
                 "entropy", utils.convertor(float(thermoValues[6]) / 1000.0, "kcal/mol", "hartree")

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -740,17 +740,18 @@ class Jaguar(logfileparser.Logfile):
                 # For such an old version it looks like only finite difference
                 # via gradient is available, so assume the first SCF energy is
                 # the stationary point.
+                electronic_energy = utils.convertor(self.scfenergies[0], "eV", "hartree")
                 self.set_attribute(
                     "enthalpy",
                     utils.convertor(float(tokens[3]), "kcal/mol", "hartree")
                     + self.zpve
-                    + self.scfenergies[0],
+                    + electronic_energy,
                 )
                 self.set_attribute(
                     "freeenergy",
                     utils.convertor(float(tokens[4]), "kcal/mol", "hartree")
                     + self.zpve
-                    + self.scfenergies[0],
+                    + electronic_energy,
                 )
 
         # Parse excited state output (for CIS calculations).

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1746,9 +1746,11 @@ cannot be determined. Rerun without `$molecule read`."""
 
                 line = next(inputfile)
                 assert "Total Enthalpy" in line
-                if not hasattr(self, "enthalpy"):
-                    enthalpy = float(line.split()[2])
-                    self.enthalpy = utils.convertor(enthalpy, "kcal/mol", "hartree")
+                self.set_attribute(
+                    "enthalpy",
+                    utils.convertor(float(line.split()[2]), "kcal/mol", "hartree")
+                    + utils.convertor(self.scfenergies[-1], "eV", "hartree"),
+                )
                 line = next(inputfile)
                 assert "Total Entropy" in line
                 if not hasattr(self, "entropy"):

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1753,12 +1753,9 @@ cannot be determined. Rerun without `$molecule read`."""
                 )
                 line = next(inputfile)
                 assert "Total Entropy" in line
-                if not hasattr(self, "entropy"):
-                    entropy = float(line.split()[2]) / 1000
-                    # This is the *temperature dependent* entropy.
-                    self.entropy = utils.convertor(entropy, "kcal/mol", "hartree")
-                if not hasattr(self, "freeenergy"):
-                    self.freeenergy = self.enthalpy - self.entropy * self.temperature
+                self.set_attribute(
+                    "entropy", utils.convertor(float(line.split()[2]) / 1000, "kcal/mol", "hartree")
+                )
 
         # Extract total elapsed (wall) and CPU job times
         if line[:16] == " Total job time:":

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -126,6 +126,7 @@ def convertor(value: float, fromunits: str, tounits: str) -> float:
         "ebohr3_to_Debye.ang2": lambda x: x * 0.7117614302,
         "ebohr4_to_Debye.ang3": lambda x: x * 0.3766479268,
         "ebohr5_to_Debye.ang4": lambda x: x * 0.1993134985,
+        # FIXME I'm not sure this is correct.
         "hartree/bohr2_to_mDyne/angstrom": lambda x: x * 8.23872350 / 0.5291772109,
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ select = []
 lines-after-imports = 2
 section-order = ["future", "standard-library", "first-party", "third-party", "local-folder"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "test/test*.py" = [
     "PLR2004", # magic value comparison
     "S101",    # use of assert detected

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -218,6 +218,9 @@ class ADFIRTest(GenericIRTest):
 
     # ???
     zpve_thresh = 1.0e-2
+    entropy = 0.00013953096105839138
+
+    entropy_places = 4
 
 
 class FireflyIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -20,6 +20,7 @@ class GenericIRTest:
 
     # Unit tests may give these values for the largest force constant and reduced mass, respectively.
     max_force_constant = 10.0
+    force_constant_thresh = 0.1
     max_reduced_mass = 6.9
 
     # reference zero-point correction from Gaussian 16 dvb_ir.out
@@ -95,7 +96,7 @@ class GenericIRTest:
     )
     def testvibfconsts(self, data) -> None:
         """Is the maximum force constant 10. +/- 0.1 mDyn/angstrom?"""
-        assert abs(max(data.vibfconsts) - self.max_force_constant) < 0.1
+        assert abs(max(data.vibfconsts) - self.max_force_constant) < self.force_constant_thresh
 
     @skipForParser("ADF", "ADF cannot print reduced masses")
     @skipForParser("DALTON", "DALTON cannot print reduced masses")

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -76,9 +76,14 @@ class GenericIRTest:
         """Does the highest frequency value match?"""
         assert abs(max(data.vibfreqs) - self.highest_freq) < self.highest_freq_thresh
 
-    @skipForParser("Psi4", "Psi cannot print IR intensities")
     @skipForLogfile("FChk/basicGaussian09", "not printed in older versions than 16")
     @skipForLogfile("FChk/basicQChem5.4", "not printed")
+    @skipForLogfile(
+        "Psi4/basicPsi4-1.2.1/dvb_ir_rhf.out", "not implemented in versions older than 1.7"
+    )
+    @skipForLogfile(
+        "Psi4/basicPsi4-1.3.1/dvb_ir_rhf.out", "not implemented in versions older than 1.7"
+    )
     def testirintens(self, data) -> None:
         """Is the maximum IR intensity 100 +/- 10 km/mol?"""
         assert abs(max(data.vibirs) - self.max_IR_intensity) < 10
@@ -95,9 +100,6 @@ class GenericIRTest:
     @skipForParser("xTB", "xTB does not print force constants")
     @skipForLogfile("FChk/basicGaussian09", "not printed in older versions than 16")
     @skipForLogfile("FChk/basicQChem5.4", "not printed")
-    @skipForLogfile(
-        "Psi4/Psi4-1.0", "Data file contains vibrational info with cartesian coordinates"
-    )
     def testvibfconsts(self, data) -> None:
         """Is the maximum force constant 10. +/- 0.1 mDyn/angstrom?"""
         assert abs(max(data.vibfconsts) - self.max_force_constant) < self.force_constant_thresh
@@ -111,7 +113,6 @@ class GenericIRTest:
     @skipForLogfile("FChk/basicGaussian09", "not printed in older versions than 16")
     @skipForLogfile("FChk/basicQChem5.4", "not printed")
     @skipForLogfile("GAMESS/PCGAMESS", "Data file does not contain reduced masses")
-    @skipForLogfile("Psi4/Psi4-1.0", "Data file does not contain reduced masses")
     def testvibrmasses(self, data) -> None:
         """Is the maximum reduced mass 6.9 +/- 0.1 daltons?"""
         assert abs(max(data.vibrmasses) - self.max_reduced_mass) < 0.1
@@ -145,7 +146,6 @@ class GenericIRTest:
     @skipForParser("DALTON", "not implemented yet")
     @skipForParser("FChk", "not printed")
     @skipForParser("Molpro", "not implemented yet")
-    @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
     def testtemperature(self, data) -> None:
         """Is the temperature 298.15 K?"""
@@ -166,7 +166,6 @@ class GenericIRTest:
     @skipForParser("Jaguar", "not implemented yet")
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
-    @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
     def testentropy(self, data) -> None:
         """Is the entropy reasonable"""
@@ -177,7 +176,6 @@ class GenericIRTest:
     @skipForParser("FChk", "not printed")
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
-    @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
     def testenthalpy(self, data) -> None:
         """Is the enthalpy reasonable"""
@@ -189,7 +187,6 @@ class GenericIRTest:
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("NWChem", "not printed directly")
-    @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
     def testfreeenergy(self, data) -> None:
         """Is the freeenergy reasonable"""
@@ -201,7 +198,6 @@ class GenericIRTest:
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("NWChem", "not printed directly")
-    @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
     def testfreeenergyconsistency(self, data) -> None:
         """Does G = H - TS hold"""

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -186,7 +186,6 @@ class GenericIRTest:
     @skipForParser("FChk", "not printed")
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
-    @skipForParser("NWChem", "not printed directly")
     @skipForParser("Turbomole", "not implemented yet")
     def testfreeenergy(self, data) -> None:
         """Is the freeenergy reasonable"""
@@ -197,7 +196,6 @@ class GenericIRTest:
     @skipForParser("FChk", "not printed")
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
-    @skipForParser("NWChem", "not printed directly")
     @skipForParser("Turbomole", "not implemented yet")
     def testfreeenergyconsistency(self, data) -> None:
         """Does G = H - TS hold"""

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -30,9 +30,14 @@ class GenericIRTest:
     freeenergy = -382.164915
 
     zpve_thresh = 1.0e-3
+    # TODO refactor from places to thresh
     enthalpy_places = 3
     entropy_places = 6
     freeenergy_places = 3
+
+    # Molecular mass of DVB in mD.
+    molecularmass = 130078.25
+    molecularmass_thresh = 0.25
 
     @pytest.fixture
     def numvib(self, data) -> int:
@@ -213,14 +218,29 @@ class GenericIRTest:
             == 0
         )
 
+    @skipForParser("FChk", "not printed")
+    @skipForParser("GAMESSUK", "not implemented yet")
+    @skipForParser("Jaguar", "not implemented yet")
+    @skipForParser("Molcas", "not implemented yet")
+    @skipForParser("Molpro", "not implemented yet")
+    @skipForParser("GAMESSUK", "not implemented yet")
+    @skipForParser("Turbomole", "not implemented yet")
+    @skipForParser("xTB", "not implemented yet")
+    def testatommasses(self, data) -> None:
+        """Do the atom masses sum up to the molecular mass?"""
+        mm = 1000 * sum(data.atommasses)
+        assert (
+            abs(mm - self.molecularmass) < self.molecularmass_thresh
+        ), f"Molecule mass: {mm:f} not {self.molecularmass:f} +- {self.molecularmass_thresh:f} mD"
+
 
 class ADFIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
-    # ???
-    zpve_thresh = 1.0e-2
+    zpve = 0.1759
     entropy = 0.00013953096105839138
 
+    zpve_thresh = 1.1e-3
     entropy_places = 4
 
 
@@ -228,8 +248,12 @@ class FireflyIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
     max_IR_intensity = 135
-    # ???
+
     zpve = 0.1935
+    enthalpy = -379.5751787863937
+    freeenergy = -379.61838132136285
+
+    entropy_places = 5
 
 
 class GaussianIRTest(GenericIRTest):
@@ -273,37 +297,27 @@ class NWChemIRTest(GenericIRTest):
         return 3 * len(data.atomnos)
 
 
-class QChemIRTest(GenericIRTest):
-    """Customized vibrational frequency unittest"""
-
-    enthalpy = 0.1871270552135131
-    entropy = 0.00014667348271900577
-    freeenergy = 0.14339635634084155
-
-    # Molecular mass of DVB in mD.
-    molecularmass = 130078.25
-
-    @skipForParser("FChk", "not printed")
-    def testatommasses(self, data) -> None:
-        """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
-        mm = 1000 * sum(data.atommasses)
-        assert abs(mm - 130078.25) < 0.1, f"Molecule mass: {mm:f} not 130078 +- 0.1mD"
-
-
 class GamessIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
-    # Molecular mass of DVB in mD.
-    molecularmass = 130078.25
-
-    enthalpy = -381.86372805188300
     entropy = 0.00014875961938
+    enthalpy = -381.86372805188300
     freeenergy = -381.90808120060200
 
-    def testatommasses(self, data) -> None:
-        """Do the atom masses sum up to the molecular mass (130078.25+-0.1mD)?"""
-        mm = 1000 * sum(data.atommasses)
-        assert abs(mm - 130078.25) < 0.1, f"Molecule mass: {mm:f} not 130078 +- 0.1mD"
+
+class OrcaIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    # ORCA 5.0
+    entropy = 0.00014384698977024988
+    enthalpy = -381.86823907
+    freeenergy = -381.91112705
+
+    enthalpy_places = 2
+    entropy_places = 5
+    freeenergy_places = 2
+
+    molecularmass = 130190
 
 
 class Psi4HFIRTest(GenericIRTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -95,7 +95,6 @@ class GenericIRTest:
     @skipForParser("xTB", "xTB does not print force constants")
     @skipForLogfile("FChk/basicGaussian09", "not printed in older versions than 16")
     @skipForLogfile("FChk/basicQChem5.4", "not printed")
-    @skipForLogfile("Jaguar/Jaguar4.2", "Data file does not contain force constants")
     @skipForLogfile(
         "Psi4/Psi4-1.0", "Data file contains vibrational info with cartesian coordinates"
     )
@@ -145,7 +144,6 @@ class GenericIRTest:
 
     @skipForParser("DALTON", "not implemented yet")
     @skipForParser("FChk", "not printed")
-    @skipForParser("Jaguar", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("Psi4", "not implemented yet")
     @skipForParser("Turbomole", "not implemented yet")
@@ -177,7 +175,6 @@ class GenericIRTest:
     @skipForParser("ADF", "not implemented yet")
     @skipForParser("DALTON", "not implemented yet")
     @skipForParser("FChk", "not printed")
-    @skipForParser("Jaguar", "not implemented yet")
     @skipForParser("GAMESSUK", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("Psi4", "not implemented yet")
@@ -190,7 +187,6 @@ class GenericIRTest:
     @skipForParser("DALTON", "not implemented yet")
     @skipForParser("FChk", "not printed")
     @skipForParser("GAMESSUK", "not implemented yet")
-    @skipForParser("Jaguar", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("NWChem", "not printed directly")
     @skipForParser("Psi4", "not implemented yet")
@@ -203,7 +199,6 @@ class GenericIRTest:
     @skipForParser("DALTON", "not implemented yet")
     @skipForParser("FChk", "not printed")
     @skipForParser("GAMESSUK", "not implemented yet")
-    @skipForParser("Jaguar", "not implemented yet")
     @skipForParser("Molpro", "not implemented yet")
     @skipForParser("NWChem", "not printed directly")
     @skipForParser("Psi4", "not implemented yet")
@@ -271,6 +266,8 @@ class JaguarIRTest(GenericIRTest):
     # Jagur outputs vibrational info with cartesian coordinates
     max_force_constant = 3.7
     max_reduced_mass = 2.3
+
+    freeenergy_places = 2
 
     def testvibsyms(self, data, numvib) -> None:
         """Is the length of vibsyms correct?"""

--- a/test/regression.py
+++ b/test/regression.py
@@ -3025,6 +3025,12 @@ class GaussianPolarTest(ReferencePolarTest):
 # Jaguar #
 
 
+class JaguarIRTest_v42(JaguarIRTest):
+    @pytest.mark.skip("Data file does not contain force constants")
+    def testvibfconsts(self, data: "ccData") -> None:
+        pass
+
+
 class JaguarSPTest_noatomcharges(JaguarSPTest):
     """Atomic partial charges were not printed in old Jaguar unit tests."""
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -2967,6 +2967,11 @@ class GAMESSUSSPunTest_charge0(GenericSPunTest):
         """HOMOs were incorrect due to charge being wrong."""
 
 
+class GamessIRTest_old(GamessIRTest):
+    entropy_places = 5
+    freeenergy_places = 2
+
+
 class GAMESSUSIRTest_ts(GenericIRimgTest):
     @pytest.mark.skip("This is a transition state with different intensities")
     def testirintens(self, data: "ccData") -> None:

--- a/test/regression.py
+++ b/test/regression.py
@@ -125,9 +125,9 @@ from .data.testvib import (
     GenericRamanTest,
     JaguarIRTest,
     OrcaRamanTest,
+    Psi4HFIRTest,
+    QChemRamanTest,
 )
-from .data.testvib import Psi4HFIRTest as Psi4IRTest
-from .data.testvib import QChemIRTest, QChemRamanTest
 
 # The following regression test functions were manually written, because they
 # contain custom checks that were determined on a per-file basis. Care needs to be taken
@@ -3370,3 +3370,18 @@ class PsiHFSPTest_noatommasses(PsiHFSPTest):
     @pytest.mark.skip("atommasses were not printed in this file.")
     def testatommasses(self, data: "ccData") -> None:
         """These values are not present in this output file."""
+
+
+class Psi4HFIRTest_v1(Psi4HFIRTest):
+    max_force_constant = 7.981
+
+    enthalpy_places = 2
+    freeenergy_places = 2
+
+    @pytest.mark.skip("not implemented in versions older than 1.7")
+    def testirintens(self, data: "ccData") -> None:
+        pass
+
+    @pytest.mark.skip("not implemented in versions older than 1.2")
+    def testvibrmasses(self, data: "ccData") -> None:
+        pass

--- a/test/regression.py
+++ b/test/regression.py
@@ -124,6 +124,7 @@ from .data.testvib import (
     GenericIRTest,
     GenericRamanTest,
     JaguarIRTest,
+    OrcaIRTest,
     OrcaRamanTest,
     Psi4HFIRTest,
     QChemRamanTest,
@@ -3241,49 +3242,23 @@ class OrcaTDDFTTest_pre1085(OrcaTDDFTTest_pre5):
         assert abs(max(data.etoscs) - 0.94) < 0.2
 
 
-class OrcaIRTest(GenericIRTest):
+class OrcaIRTest_pre4(OrcaIRTest):
     """Customized vibrational frequency unittest"""
 
     # ORCA has a bug in the intensities for version < 4.0
     max_IR_intensity = 215
     zpve = 0.1921
 
+    entropy = 0.00012080325339594164
+    enthalpy = -381.85224835
+    freeenergy = -381.88826585
+
     enthalpy_places = 3
     entropy_places = 6
     freeenergy_places = 3
 
-    def testtemperature(self, data) -> None:
-        """Is the temperature 298.15 K?"""
-        assert round(abs(298.15 - data.temperature), 7) == 0
 
-    def testpressure(self, data) -> None:
-        """Is the pressure 1 atm?"""
-        assert round(abs(1 - data.pressure), 7) == 0
-
-    def testenthalpy(self, data) -> None:
-        """Is the enthalpy reasonable"""
-        assert round(abs(-381.85224835 - data.enthalpy), self.enthalpy_places) == 0
-
-    def testentropy(self, data) -> None:
-        """Is the entropy reasonable"""
-        assert round(abs(0.00012080325339594164 - data.entropy), self.entropy_places) == 0
-
-    def testfreeenergy(self, data) -> None:
-        """Is the freeenergy reasonable"""
-        assert round(abs(-381.88826585 - data.freeenergy), self.freeenergy_places) == 0
-
-    def testfreeenergyconsistency(self, data) -> None:
-        """Does G = H - TS hold"""
-        assert (
-            round(
-                abs(data.enthalpy - data.temperature * data.entropy - data.freeenergy),
-                self.freeenergy_places,
-            )
-            == 0
-        )
-
-
-class OrcaIRTest_old(OrcaIRTest):
+class OrcaIRTest_old(OrcaIRTest_pre4):
     """The frequency part of this calculation didn't finish, but went ahead and
     printed incomplete and incorrect results anyway.
     """

--- a/test/testdata
+++ b/test/testdata
@@ -444,7 +444,7 @@ vib       DALTON      GenericIRTest         basicDALTON-2013      dvb_ir.out
 vib       DALTON      GenericIRTest         basicDALTON-2015      dvb_ir.out
 vib       FChk        GaussianIRTest        basicGaussian09       dvb_ir.fchk
 vib       FChk        GaussianIRTest        basicGaussian16       dvb_ir.fchk
-vib       FChk        QChemIRTest           basicQChem5.4         dvb_ir.fchk
+vib       FChk        GenericIRTest         basicQChem5.4         dvb_ir.fchk
 vib       GAMESSUK    GenericIRTest         basicGAMESS-UK7.0     dvb_ir.out
 vib       GAMESSUK    GenericIRTest         basicGAMESS-UK8.0     dvb_ir.out
 vib       GAMESS      FireflyIRTest         basicFirefly8.0       dvb_ir.out
@@ -459,15 +459,15 @@ vib       Molcas      MolcasIRTest          basicOpenMolcas18.0   dvb_ir.out
 vib       Molpro      GenericIRTest         basicMolpro2006       dvb_ir.out            dvb_ir.log
 vib       Molpro      GenericIRTest         basicMolpro2012       dvb_ir.out            dvb_ir.log
 vib       NWChem      NWChemIRTest          basicNWChem7.0        dvb_ir.out
-vib       ORCA        GenericIRTest         basicORCA4.1          dvb_ir.out
-vib       ORCA        GenericIRTest         basicORCA4.2          dvb_ir.out
-vib       ORCA        GenericIRTest         basicORCA5.0          dvb_ir.out
+vib       ORCA        OrcaIRTest            basicORCA4.1          dvb_ir.out
+vib       ORCA        OrcaIRTest            basicORCA4.2          dvb_ir.out
+vib       ORCA        OrcaIRTest            basicORCA5.0          dvb_ir.out
 vib       Psi4        Psi4HFIRTest          basicPsi4-1.2.1       dvb_ir_rhf.out
 vib       Psi4        Psi4HFIRTest          basicPsi4-1.3.1       dvb_ir_rhf.out
 vib       Psi4        Psi4HFIRTest          basicPsi4-1.7         dvb_ir_rhf.out
 vib       Psi4        Psi4KSIRTest          basicPsi4-1.7         dvb_ir_rks.out
-vib       QChem       QChemIRTest           basicQChem5.1         dvb_ir.out
-vib       QChem       QChemIRTest           basicQChem5.4         dvb_ir.out
+vib       QChem       GenericIRTest         basicQChem5.1         dvb_ir.out
+vib       QChem       GenericIRTest         basicQChem5.4         dvb_ir.out
 vib       Turbomole   TurbomoleIRTest       basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out
 vib       XTB         XTBIRTest             basicXTB6.6.1/dvb_ir  dvb_ir.out
 

--- a/test/testdata
+++ b/test/testdata
@@ -469,7 +469,7 @@ vib       Psi4        Psi4KSIRTest          basicPsi4-1.7         dvb_ir_rks.out
 vib       QChem       QChemIRTest           basicQChem5.1         dvb_ir.out
 vib       QChem       QChemIRTest           basicQChem5.4         dvb_ir.out
 vib       Turbomole   TurbomoleIRTest       basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out
-vib       XTB         XTBIRTest         basicXTB6.6.1/dvb_ir  dvb_ir.out
+vib       XTB         XTBIRTest             basicXTB6.6.1/dvb_ir  dvb_ir.out
 
 vib       GAMESS      GenericIRimgTest      basicGAMESS-US2017    nh3_ts_ir.out
 vib       GAMESS      GenericIRimgTest      basicGAMESS-US2018    nh3_ts_ir.out


### PR DESCRIPTION
First major part of #89

Enthalpy and free energy should have units of hartree/particle.  Entropy is currently temperature-dependent: it has units of hartree/particle/kelvin.  This is what Gaussian was already presenting.  Probably most people want these as kcal/mol and cal/mol/K, but it is easiest to internally be in a.u., even when a conversion is required.

Previous supporting PRs:
- https://github.com/cclib/cclib/pull/1412
- https://github.com/cclib/cclib/pull/1413
- https://github.com/cclib/cclib/pull/1415
- https://github.com/cclib/cclib/pull/1416