### PR TITLE
small change to ccread return and kwarg handling

### DIFF
--- a/.github/workflows/test_and_package.yml
+++ b/.github/workflows/test_and_package.yml
@@ -130,4 +130,4 @@ jobs:
         run: |
           cd ~
           python -c 'import cclib; print(cclib.__version__)'
-          python -c 'from cclib.io import ccread; data = ccread("https://raw.githubusercontent.com/amandadumi/cclib/master/data/Gaussian/basicGaussian16/dvb_sp.out"); print(data._parsed_data[0].scfenergies)'
+          python -c 'from cclib.io import ccread; data = ccread("https://raw.githubusercontent.com/amandadumi/cclib/master/data/Gaussian/basicGaussian16/dvb_sp.out"); print(data[0].scfenergies)'

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -135,7 +135,7 @@ def ccread(
     if not isinstance(source, list):
         source = [source]
 
-    a = ccDriver(source,**kwargs)
+    a = ccDriver(source, **kwargs)
     a.process_combinator()
     return a._ccCollection._parsed_data
 

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -135,9 +135,9 @@ def ccread(
     if not isinstance(source, list):
         source = [source]
 
-    a = ccDriver(source)
+    a = ccDriver(source,**kwargs)
     a.process_combinator()
-    return a._ccCollection
+    return a._ccCollection._parsed_data
 
 
 def ccopen(


### PR DESCRIPTION
Fixing small things about ccread to accept a defined tree and return the tree root.

`collection = ccread(file)`

before
`collection.parsed_data[0]` was ccdata object
now:
`collection[0]` is the ccdata object