### PR TITLE
Apply pyupgrade and fix ruff lints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,14 +125,17 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
-      - id: fix-encoding-pragma
-        args: [--remove]
       - id: no-commit-to-branch
         args: [--branch, main, --branch, master]
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
     rev: "v1.7.1.15"
     hooks:
       - id: actionlint
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.16.0
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
     rev: "5.13.2"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,9 +143,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.1
     hooks:
+      - id: ruff-format
       - id: ruff
         args: [--fix]
-      - id: ruff-format
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: "v1.3.0"
   #   hooks:

--- a/cclib/__init__.py
+++ b/cclib/__init__.py
@@ -17,6 +17,7 @@ To this end, cclib provides a number of bridges to help transfer data to other l
 as well as example methods that take parsed data as input.
 """
 
+# ruff: noqa: F401
 from cclib._version import __version__
 
 # isort: off

--- a/cclib/bridge/__init__.py
+++ b/cclib/bridge/__init__.py
@@ -5,6 +5,7 @@
 
 """Facilities for moving parsed data to other cheminformatic libraries."""
 
+# ruff: noqa: F401
 from cclib.parser.utils import find_package
 
 if find_package("Bio"):

--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -18,7 +18,7 @@ if _found_openbabel:
     # The `try` block is for OB >= 3.0, and `except` is for 2.4.x and older.
     try:
         from openbabel import openbabel as ob
-    except:
+    except:  # noqa: E722
         import openbabel as ob
 
 

--- a/cclib/bridge/cclib2psi4.py
+++ b/cclib/bridge/cclib2psi4.py
@@ -21,7 +21,7 @@ def _check_psi4(found_psi4: bool) -> None:
 
 def makepsi4(
     atomcoords: np.ndarray, atomnos: np.ndarray, charge: int = 0, mult: int = 1
-) -> "psi4.core.Molecule":
+) -> "Molecule":
     """Create a Psi4 Molecule."""
     _check_psi4(_found_psi4)
     return Molecule.from_arrays(

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -55,7 +55,7 @@ def makepyscf(data, charge=0, mult=1):
                 curr_e_prim = j[1]
                 new_list = [l_sym2num[f"{curr_l}"]]
                 new_list += curr_e_prim
-                if not f"{pt.element[uatoms[idx]]}" in basis:
+                if f"{pt.element[uatoms[idx]]}" not in basis:
                     basis[f"{pt.element[uatoms[idx]]}"] = [new_list]
                 else:
                     basis[f"{pt.element[uatoms[idx]]}"].append(new_list)

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -29,7 +29,6 @@ def _check_pyscf(found_pyscf):
 def makepyscf(data, charge=0, mult=1):
     """Create a Pyscf Molecule."""
     _check_pyscf(_found_pyscf)
-    inputattrs = data.__dict__
     required_attrs = {"atomcoords", "atomnos"}
     missing = [x for x in required_attrs if not hasattr(data, x)]
     if missing:

--- a/cclib/io/__init__.py
+++ b/cclib/io/__init__.py
@@ -5,6 +5,7 @@
 
 """Contains all writers for standard chemical representations."""
 
+# ruff: noqa: F401
 # This allows users to type:
 #   from cclib.io import ccframe
 #   from cclib.io import ccopen

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -282,10 +282,10 @@ def fallback(source):
             # From OB 3.0 onward, Pybel is contained inside the OB module.
             try:
                 import openbabel.pybel as pb
-            except:
+            except:  # noqa: E722
                 try:
                     import pybel as pb
-                except:
+                except:  # noqa: E722
                     return
             if ext in pb.informats:
                 return cclib2openbabel.readfile(source, ext)

--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -180,7 +180,7 @@ def ccread(
         log = ccopen(source, *args, **kwargs)
         logger = logging.getLogger("cclib")
         if log:
-            logger.info("Identified logfile to be in {} format".format(type(log).__name__))
+            logger.info("Identified logfile to be in %s format", type(log).__name__)
 
             return log.parse()
         else:

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -24,7 +24,7 @@ if _has_openbabel:
         import openbabel.pybel as pb
         from openbabel import openbabel as ob
     # Open Babel 2.4.x and below
-    except:
+    except:  # noqa: E722
         import openbabel as ob
 
         # There's no guarantee pybel is also available...

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -157,7 +157,7 @@ class Writer(ABC):
         if not self.indices:
             self.indices = set()
         elif not isinstance(self.indices, Iterable):
-            self.indices = set([self.indices])
+            self.indices = {self.indices}
         # This is the most likely place to get the number of
         # geometries from.
         if hasattr(self.ccdata, "atomcoords"):

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -183,17 +183,17 @@ class MOLDEN(filewriter.Writer):
         for i in range(len(mooccs)):
             for j in range(len(mooccs[i])):
                 restricted_spin_idx = i % len(mocoeffs)
-                lines.append(" Sym= {}".format(mosyms[restricted_spin_idx][j]))
+                lines.append(f" Sym= {mosyms[restricted_spin_idx][j]}")
                 moenergy = moenergies[restricted_spin_idx][j]
-                lines.append(" Ene= {:10.4f}".format(moenergy))
-                lines.append(" Spin= {}".format(spin))
-                lines.append(" Occup= {:10.6f}".format(mooccs[i][j]))
+                lines.append(f" Ene= {moenergy:10.4f}")
+                lines.append(f" Spin= {spin}")
+                lines.append(f" Occup= {mooccs[i][j]:10.6f}")
                 # Rearrange mocoeffs according to Molden's lexicographical order.
                 mocoeffs[restricted_spin_idx][j] = self._rearrange_mocoeffs(
                     mocoeffs[restricted_spin_idx][j]
                 )
                 for k, mocoeff in enumerate(mocoeffs[restricted_spin_idx][j]):
-                    lines.append("{:4d}  {:10.6f}".format(k + 1, mocoeff))
+                    lines.append(f"{k + 1:4d}  {mocoeff:10.6f}")
             spin = "Beta"
         return lines
 

--- a/cclib/io/moldenwriter.py
+++ b/cclib/io/moldenwriter.py
@@ -52,7 +52,7 @@ class MOLDEN(filewriter.Writer):
             elements = [self.ghost if e is None else e for e in elements]
         elif None in elements:
             raise ValueError(
-                f"It seems that there is at least one ghost atom in these elements. Please use the ghost flag to specify a label for the ghost atoms."
+                "It seems that there is at least one ghost atom in these elements. Please use the ghost flag to specify a label for the ghost atoms."
             )
         atomcoords = self.ccdata.atomcoords[index]
         atomnos = self.ccdata.atomnos

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -501,7 +501,7 @@ class WFXWriter(filewriter.Writer):
             try:
                 section_data = section_module()
                 wfx_lines.extend(_section(section_name, section_data))
-            except:
+            except:  # noqa: E722
                 if section_required:
                     raise filewriter.MissingAttributeError(
                         f"Unable to write required wfx section: {section_name}"

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -172,7 +172,10 @@ class WFXWriter(filewriter.Writer):
         """Section: Nuclear Cartesian Coordinates.
         Nuclear coordinates in Bohr."""
         coord_template = WFX_FIELD_FMT * 3
-        to_bohr = lambda x: utils.convertor(x, "Angstrom", "bohr")
+
+        def to_bohr(x: float) -> float:
+            return utils.convertor(x, "Angstrom", "bohr")
+
         nuc_coords = [
             coord_template % tuple(to_bohr(coord)) for coord in self.ccdata.atomcoords[-1]
         ]

--- a/cclib/method/__init__.py
+++ b/cclib/method/__init__.py
@@ -5,6 +5,7 @@
 
 """Example analyses and calculations based on data parsed by cclib."""
 
+# ruff: noqa: F401
 from cclib.method.bader import Bader
 from cclib.method.bickelhaupt import Bickelhaupt
 from cclib.method.cda import CDA

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -7,9 +7,11 @@
 
 import logging
 import sys
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from cclib.progress import Progress
+if TYPE_CHECKING:
+    from cclib.parser.data import ccData
+    from cclib.progress import Progress
 
 
 class MissingAttributeError(Exception):
@@ -40,8 +42,8 @@ class Method:
 
     def __init__(
         self,
-        data: "cclib.parser.data.ccData",
-        progress: Optional[Progress] = None,
+        data: "ccData",
+        progress: Optional["Progress"] = None,
         loglevel: int = logging.INFO,
         logname: str = "Log",
     ) -> None:

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -99,7 +99,7 @@ class CDA(FragmentAnalysis):
                             * fooverlaps[k][n]
                         )
 
-                for l in range(offset, offset + homob + 1):
+                for l in range(offset, offset + homob + 1):  # noqa: E741
                     for m in range(homoa + 1, offset):
                         bdonations[spin][i] += (
                             2

--- a/cclib/method/cda.py
+++ b/cclib/method/cda.py
@@ -61,7 +61,6 @@ class CDA(FragmentAnalysis):
         step = 0
         for spin in range(len(self.mocoeffs)):
             size = len(self.mocoeffs[spin])
-            homo = self.data.homos[spin]
 
             if len(fragments[0].homos) == 2:
                 homoa = fragments[0].homos[spin]

--- a/cclib/method/cspa.py
+++ b/cclib/method/cspa.py
@@ -62,7 +62,6 @@ class CSPA(Population):
                 submocoeffs = self.data.mocoeffs[spin][i]
                 scale = numpy.inner(submocoeffs, submocoeffs)
                 tempcoeffs = numpy.multiply(submocoeffs, submocoeffs)
-                tempvec = tempcoeffs / scale
                 self.aoresults[spin][i] = numpy.divide(tempcoeffs, scale).astype("d")
 
                 step += 1

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -102,7 +102,8 @@ class DDEC6(Stockholder):
         # Notify user about the total charge in the density grid
         integrated_density = self.charge_density.integrate()
         self.logger.info(
-            f"Total charge density in the grid is {integrated_density}. If this does not match what is expected, using a finer grid may help."
+            "Total charge density in the grid is %f. If this does not match what is expected, using a finer grid may help.",
+            integrated_density,
         )
 
         # * STEP 1 *
@@ -186,7 +187,7 @@ class DDEC6(Stockholder):
         steps = 5
         self._update_kappa = False
         while steps < 7:
-            self.logger.info(f"Optimizing grid weights. (Step {steps}/7)")
+            self.logger.info(f"Optimizing grid weights. (Step %d/7)", steps)
             self.N_A.append(self._calculate_w_and_u())
 
             # Determine whether kappa needs to be updated or not based on Figure S4.2

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -284,9 +284,9 @@ class DDEC6(Stockholder):
         stockholder_bigW = numpy.sum(stockholder_w, axis=0)
         localized_bigW = numpy.sum(localized_w, axis=0)
 
-        reference_charges = numpy.zeros((self.data.natom))
-        localizedcharges = numpy.zeros((self.data.natom))
-        stockholdercharges = numpy.zeros((self.data.natom))
+        reference_charges = numpy.zeros(self.data.natom)
+        localizedcharges = numpy.zeros(self.data.natom)
+        stockholdercharges = numpy.zeros(self.data.natom)
 
         for atomi in range(self.data.natom):
             # Equation 52 and 51 in doi: 10.1039/c6ra04656h

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -187,7 +187,7 @@ class DDEC6(Stockholder):
         steps = 5
         self._update_kappa = False
         while steps < 7:
-            self.logger.info(f"Optimizing grid weights. (Step %d/7)", steps)
+            self.logger.info("Optimizing grid weights. (Step %d/7)", steps)
             self.N_A.append(self._calculate_w_and_u())
 
             # Determine whether kappa needs to be updated or not based on Figure S4.2

--- a/cclib/method/electrons.py
+++ b/cclib/method/electrons.py
@@ -9,8 +9,6 @@ import logging
 
 from cclib.method.calculationmethod import Method
 
-import numpy
-
 
 class Electrons(Method):
     """A container for methods pertaining to electrons."""

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -6,7 +6,6 @@
 """Fragment analysis based on parsed ADF data."""
 
 import logging
-import random
 
 import numpy
 

--- a/cclib/method/fragments.py
+++ b/cclib/method/fragments.py
@@ -7,11 +7,11 @@
 
 import logging
 
+from cclib.method.calculationmethod import Method
+
 import numpy
 
 numpy.inv = numpy.linalg.inv
-
-from cclib.method.calculationmethod import Method
 
 
 class FragmentAnalysis(Method):

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -5,18 +5,9 @@
 
 """Calculation of Hirshfeld charges based on data parsed by cclib."""
 
-import copy
 import logging
-import math
-import os
-import random
-import sys
-from typing import List
 
-from cclib.method.calculationmethod import Method
 from cclib.method.stockholder import Stockholder
-from cclib.method.volume import electrondensity_spin
-from cclib.parser.utils import find_package
 
 import numpy
 

--- a/cclib/method/hirshfeld.py
+++ b/cclib/method/hirshfeld.py
@@ -113,7 +113,7 @@ class Hirshfeld(Stockholder):
         # radial distance from center of atom chi.
         stockholder_bigW = numpy.sum(stockholder_w, axis=0)
 
-        self.fragcharges = numpy.zeros((self.data.natom))
+        self.fragcharges = numpy.zeros(self.data.natom)
         self.logger.info("Creating fragcharges: array[1]")
 
         for atomi in range(self.data.natom):

--- a/cclib/method/moments.py
+++ b/cclib/method/moments.py
@@ -5,7 +5,6 @@
 
 """Calculation of electric multipole moments based on data parsed by cclib."""
 
-import sys
 from collections.abc import Iterable
 
 from cclib.method.calculationmethod import Method

--- a/cclib/method/nuclear.py
+++ b/cclib/method/nuclear.py
@@ -81,7 +81,10 @@ class Nuclear(Method):
         counts = {el: elements.count(el) for el in set(elements)}
 
         formula = ""
-        elcount = lambda el, c: f"{el}{int(c)}" if c > 1 else el
+
+        def elcount(el: str, c: int) -> str:
+            return f"{el}{int(c)}" if c > 1 else el
+
         if "C" in elements:
             formula += elcount("C", counts["C"])
             counts.pop("C")

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -62,7 +62,6 @@ class OPA(Population):
         nstep = func(nfrag - 1)
         unrestricted = len(self.data.mocoeffs) == 2
         alpha = len(self.data.mocoeffs[0])
-        nbasis = self.data.nbasis
 
         self.logger.info("Creating attribute results: array[4]")
         results = [numpy.zeros([nfrag, nfrag, alpha], "d")]
@@ -80,10 +79,8 @@ class OPA(Population):
         if self.progress:
             self.progress.initialize(nstep)
 
-        size = len(self.data.mocoeffs[0])
         step = 0
 
-        preresults = []
         for spin in range(len(self.data.mocoeffs)):
             two = numpy.array([2.0] * len(self.data.mocoeffs[spin]), "d")
 

--- a/cclib/method/opa.py
+++ b/cclib/method/opa.py
@@ -5,9 +5,6 @@
 
 """Calculation of overlap population analysis based on cclib data."""
 
-import random
-
-from cclib.method.calculationmethod import Method
 from cclib.method.population import Population
 
 import numpy

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -81,7 +81,6 @@ class Population(Method):
                     indices[index].append(i)
 
         natoms = len(indices)
-        nmocoeffs = len(self.aoresults[0])
 
         # Build results numpy array[3].
         alpha = len(self.aoresults[0])

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -6,12 +6,15 @@
 """Population analyses based on cclib data."""
 
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from cclib.method.calculationmethod import Method, MissingAttributeError
 from cclib.progress import Progress
 
 import numpy
+
+if TYPE_CHECKING:
+    from cclib.parser.data import ccData
 
 
 class Population(Method):
@@ -25,7 +28,7 @@ class Population(Method):
 
     def __init__(
         self,
-        data: "cclib.parser.data.ccData",
+        data: "ccData",
         progress: Optional[Progress] = None,
         loglevel: int = logging.INFO,
         logname: str = "Log",

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -12,7 +12,7 @@ from cclib.parser.utils import convertor, find_package
 
 import numpy
 
-""" In the dictionary sym2powerlist below, each element is a list that contain the combinations of
+r""" In the dictionary sym2powerlist below, each element is a list that contain the combinations of
     powers that are applied to x, y, and z in the equation for the gaussian primitives --
     \psi (x, y, z) = x^a * y^b * z^c * exp(-\lambda * r^2)
 """
@@ -149,7 +149,7 @@ def _check_pyvtk(found_pyvtk):
         raise ImportError("You must install `pyvtk` to use this function.")
 
 
-class Volume(object):
+class Volume:
     """Represent a volume in space.
 
     Required parameters:

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -135,8 +135,8 @@ if _found_pyquante2:
 
 _found_pyvtk = find_package("pyvtk")
 if _found_pyvtk:
-    from pyvtk import *
-    from pyvtk.DataSetAttr import *
+    from pyvtk import *  # noqa: F403
+    from pyvtk.DataSetAttr import *  # noqa: F403
 
 
 def _check_pyquante():
@@ -195,10 +195,10 @@ class Volume:
             numpy.arange(self.data.shape[1]),
             numpy.arange(self.data.shape[0]),
         )
-        v = VtkData(
-            RectilinearGrid(*ranges),
+        v = VtkData(  # noqa: F405
+            RectilinearGrid(*ranges),  # noqa: F405
             "Test",
-            PointData(Scalars(self.data.ravel(), "from cclib", "default")),
+            PointData(Scalars(self.data.ravel(), "from cclib", "default")),  # noqa: F405
         )
         v.tofile(filename)
 

--- a/cclib/method/volume.py
+++ b/cclib/method/volume.py
@@ -416,7 +416,7 @@ def read_from_cube(filepath):
         # First two lines are comments
         # Lines 3-6 specify the grid in Cartesian coordinates
         # Line 3 -- [Number of atoms] [Origin x] [Origin y] [Origin z]
-        natom = (int)(lines[2].split()[0])
+        natom = int(lines[2].split()[0])  # noqa: F841
         originx, originy, originz = numpy.asanyarray(lines[2].split()[1:], dtype=float)
 
         # Line 4, 5, 6 -- [Number of Grid Points] [Spacing x] [Spacing y], [Spacing z]

--- a/cclib/parser/__init__.py
+++ b/cclib/parser/__init__.py
@@ -5,7 +5,7 @@
 
 """Contains parsers for all supported programs"""
 
-
+# ruff: noqa: F401
 # These import statements are added for the convenience of users...
 # Rather than having to type:
 #         from cclib.parser.gaussianparser import Gaussian

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -453,7 +453,7 @@ class ADF(logfileparser.Logfile):
 
             self.skip_lines(inputfile, ["e", "b"])
 
-            energies_old = next(inputfile)
+            energies_old = next(inputfile)  # noqa: F841
             energies_new = next(inputfile)
             self.append_attribute("scfenergies", float(energies_new.split()[-1]))
 
@@ -497,7 +497,7 @@ class ADF(logfileparser.Logfile):
         # cart. step max                      0.03331296     0.01000000    F
         # cart. step rms                      0.00844037     0.00666667    F
         if line[:31] == "Geometry Convergence after Step":
-            stepno = int(line.split()[4])
+            stepno = int(line.split()[4])  # noqa: F841
 
             # This is to make geometry optimization always have the optdone attribute,
             # even if it is to be empty for unconverged runs.
@@ -514,8 +514,8 @@ class ADF(logfileparser.Logfile):
             energy_change = next(inputfile)
             constrained_gradient_max = next(inputfile)
             constrained_gradient_rms = next(inputfile)
-            gradient_max = next(inputfile)
-            gradient_rms = next(inputfile)
+            gradient_max = next(inputfile)  # noqa: F841
+            gradient_rms = next(inputfile)  # noqa: F841
             cart_step_max = next(inputfile)
             cart_step_rms = next(inputfile)
 
@@ -565,8 +565,6 @@ class ADF(logfileparser.Logfile):
             while int(info[0]) - 1 != len(self.moenergies[0]):
                 self.moenergies[0].append(numpy.nan)
                 self.mosyms[0].append("A")
-
-            homoA = None
 
             while len(line) > 10:
                 info = line.split()
@@ -728,7 +726,7 @@ class ADF(logfileparser.Logfile):
 
             freqs = next(inputfile)
             while freqs.strip() != "":
-                minus = next(inputfile)
+                self.skip_line(inputfile, "d")
                 p = [[], [], []]
                 for i in range(len(self.atomnos)):
                     broken = list(map(float, next(inputfile).split()[1:]))
@@ -814,18 +812,14 @@ class ADF(logfileparser.Logfile):
                 [] for frag in self.frags
             ]  # parse atombasis in the case of trivial SFOs
 
-            self.skip_line(inputfile, "blank")
-
-            note = next(inputfile)
-            symoffset = 0
-
-            self.skip_line(inputfile, "blank")
+            self.skip_lines(inputfile, ["blank", "note", "blank"])
             line = next(inputfile)
             if len(line) > 2:  # fix for ADF2006.01 as it has another note
                 self.skip_line(inputfile, "blank")
                 line = next(inputfile)
             self.skip_line(inputfile, "blank")
 
+            symoffset = 0
             self.nosymreps = []
             while len(self.fonames) < self.nbasis:
                 symline = next(inputfile)
@@ -1074,13 +1068,11 @@ class ADF(logfileparser.Logfile):
 
             # Note that here, and later, the number of blank lines can vary between
             # version of ADF (extra lines are seen in 2013.01 unit tests, for example).
-            self.skip_line(inputfile, "blank")
-            excitation_occupied = next(inputfile)
+            self.skip_lines(inputfile, ["blank", "Excitation  Occupied to virtual  Contribution"])
             header = next(inputfile)
             while not header.strip():
                 header = next(inputfile)
-            header2 = next(inputfile)
-            x_y_z = next(inputfile)
+            self.skip_lines(inputfile, ["tdm section header", "x y z"])
             line = next(inputfile)
             while not line.strip():
                 line = next(inputfile)

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -48,7 +48,7 @@ class ADF(logfileparser.Logfile):
             temp = f'{ans[0]}"'
             ans = temp
 
-        l = len(ans)
+        l = len(ans)  # noqa: E741
         if (
             l > 1 and ans[0] == ans[1]
         ):  # Python only tests the second condition if the first is true

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -558,8 +558,8 @@ class ADF(logfileparser.Logfile):
             line = next(inputfile)
             info = line.split()
 
-            if not info[0] == "1":
-                self.logger.warning(f"MO info up to #{info[0]} is missing")
+            if info[0] != "1":
+                self.logger.warning("MO info up to #%s is missing", info[0])
 
             # handle case where MO information up to a certain orbital are missing
             while int(info[0]) - 1 != len(self.moenergies[0]):

--- a/cclib/parser/adfparser.py
+++ b/cclib/parser/adfparser.py
@@ -113,7 +113,7 @@ class ADF(logfileparser.Logfile):
             while True:
                 self.updateprogress(inputfile, "Unsupported Information", self.fupdate)
                 line = next(inputfile) if line.strip() == "(INPUT FILE)" else None
-                if line and not line[:6] in ("Create", "create"):
+                if line and line[:6] not in ("Create", "create"):
                     break
                 line = next(inputfile)
 
@@ -844,7 +844,7 @@ class ADF(logfileparser.Logfile):
                     info = line.split()
 
                     # index0 index1 occ2 energy3/4 fragname5 coeff6 orbnum7 orbname8 fragname9
-                    if not sym in list(self.start_indeces.keys()):
+                    if sym not in list(self.start_indeces.keys()):
                         # have we already set the start index for this symmetry?
                         self.start_indeces[sym] = int(info[1])
 
@@ -1002,7 +1002,7 @@ class ADF(logfileparser.Logfile):
                     # The table can end with a blank line or "1".
                     row = 0
                     line = next(inputfile)
-                    while not line.strip() in ["", "1"]:
+                    while line.strip() not in ["", "1"]:
                         info = line.split()
 
                         if int(info[0]) < self.start_indeces[sym]:

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -495,7 +495,7 @@ class DALTON(logfileparser.Logfile):
                     orbital = cols[2]
                     prims = [int(i) - 1 for i in cols[3:]]
 
-                shell = orbital[0]
+                shell = orbital[0]  # noqa: F841
                 subshell = orbital[1].upper()
 
                 iatom = basisatoms[ibasis]
@@ -760,7 +760,7 @@ class DALTON(logfileparser.Logfile):
             # the number of electrons for open-shell calculations.
             while "Number of electrons" not in line:
                 line = next(inputfile)
-            nelectrons = int(line.split()[-1])
+            nelectrons = int(line.split()[-1])  # noqa: F841
 
             line = next(inputfile)
             occupations = [int(o) for o in line.split()[3:]]

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -981,7 +981,7 @@ class DALTON(logfileparser.Logfile):
             # If we're missing something above, throw away the partial geovalues since
             # we don't want artificial NaNs getting into cclib. Instead, fix the dictionary
             # to make things work.
-            if not numpy.nan in values:
+            if numpy.nan not in values:
                 if not hasattr(self, "geovalues"):
                     self.geovalues = []
                 self.geovalues.append(values)
@@ -1001,7 +1001,7 @@ class DALTON(logfileparser.Logfile):
             line = next(inputfile)
             line = next(inputfile)
             line = next(inputfile)
-            if not "zero by symmetry" in line:
+            if "zero by symmetry" not in line:
                 line = next(inputfile)
 
                 line = next(inputfile)

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -213,9 +213,9 @@ class DALTON(logfileparser.Logfile):
                 line = next(inputfile)
 
             # Split lines into columsn and dd any missing symmetry labels, if needed.
-            lines = [l.split() for l in lines]
-            if any([len(l) == 3 for l in lines]):
-                for il, l in enumerate(lines):
+            lines = [l.split() for l in lines]  # noqa: E741
+            if any([len(l) == 3 for l in lines]):  # noqa: E741
+                for il, l in enumerate(lines):  # noqa: E741
                     if len(l) == 2:
                         lines[il] = [l[0], "_1", l[1]]
 

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -304,7 +304,7 @@ class ccData:
                       means they are not specified in self._attrlist
         """
 
-        if type(attributes) is not dict:
+        if not isinstance(attributes, dict):
             raise TypeError("attributes must be in a dictionary")
 
         valid = [a for a in attributes if a in self._attrlist]

--- a/cclib/parser/data.py
+++ b/cclib/parser/data.py
@@ -227,15 +227,15 @@ class ccData:
         attrlist = [k for k in self._attrlist if hasattr(self, k)]
         for k in attrlist:
             v = self._attributes[k].type
-            if v == numpy.ndarray:
+            if v is numpy.ndarray:
                 setattr(self, k, getattr(self, k).tolist())
-            elif v == list and k in self._listsofarrays:
+            elif v is list and k in self._listsofarrays:
                 setattr(self, k, [x.tolist() for x in getattr(self, k)])
-            elif v == dict and k in self._dictsofarrays:
+            elif v is dict and k in self._dictsofarrays:
                 items = getattr(self, k).items()
                 pairs = [(key, val.tolist()) for key, val in items]
                 setattr(self, k, dict(pairs))
-            elif v == dict and k in self._dictsofdicts:
+            elif v is dict and k in self._dictsofdicts:
                 items = getattr(self, k).items()
                 pairs = [
                     (key, {subkey: subval.tolist()})
@@ -253,15 +253,15 @@ class ccData:
             precision = "d"
             if k in self._intarrays:
                 precision = "i"
-            if v == numpy.ndarray:
+            if v is numpy.ndarray:
                 setattr(self, k, numpy.array(getattr(self, k), precision))
-            elif v == list and k in self._listsofarrays:
+            elif v is list and k in self._listsofarrays:
                 setattr(self, k, [numpy.array(x, precision) for x in getattr(self, k)])
-            elif v == dict and k in self._dictsofarrays:
+            elif v is dict and k in self._dictsofarrays:
                 items = getattr(self, k).items()
                 pairs = [(key, numpy.array(val, precision)) for key, val in items]
                 setattr(self, k, dict(pairs))
-            elif v == dict and k in self._dictsofdicts:
+            elif v is dict and k in self._dictsofdicts:
                 items = getattr(self, k).items()
                 pairs = [
                     (
@@ -328,7 +328,7 @@ class ccData:
         self.arrayify()
         for attr in [a for a in self._attrlist if hasattr(self, a)]:
             val = getattr(self, attr)
-            if type(val) == self._attributes[attr].type:
+            if type(val) is self._attributes[attr].type:
                 continue
 
             try:

--- a/cclib/parser/fchkparser.py
+++ b/cclib/parser/fchkparser.py
@@ -404,9 +404,9 @@ class FChk(logfileparser.Logfile):
             elif self.program == "QChem":
                 unknown_jobtype = self.jobtype not in ("sp", "freq", "force", "fopt")
             else:
-                self.logger.info(f"Unknown originating program for fchk file: {self.program}")
+                self.logger.info("Unknown originating program for fchk file: %s", self.program)
             if unknown_jobtype:
-                self.logger.info(f"Unknown job type for fchk file: {self.jobtype}")
+                self.logger.info("Unknown job type for fchk file: %s", self.jobtype)
         else:
             self.logger.info("Couldn't determine originating program for fchk file")
 

--- a/cclib/parser/gamessdatparser.py
+++ b/cclib/parser/gamessdatparser.py
@@ -7,8 +7,7 @@
 
 import re
 
-from cclib.parser import logfileparser, utils
-from cclib.parser.utils import PeriodicTable
+from cclib.parser import logfileparser
 
 import numpy
 

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -786,7 +786,7 @@ class GAMESS(logfileparser.Logfile):
             # Need to get to the modes line, which is often preceeded by
             # a list of atomic weights and some possible warnings.
             # Pass the warnings to the logger if they are there.
-            while not "MODES" in line:
+            while "MODES" not in line:
                 self.updateprogress(inputfile, "Frequency Information")
 
                 line = next(inputfile)
@@ -838,7 +838,7 @@ class GAMESS(logfileparser.Logfile):
             while not line.strip() or not re.search(" {26,}1", line) is not None:
                 line = next(inputfile)
 
-            while not "SAYVETZ" in line:
+            while "SAYVETZ" not in line:
                 self.updateprogress(inputfile, "Frequency Information")
 
                 # Note: there may be imaginary frequencies like this (which we make negative):

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1083,7 +1083,7 @@ class GAMESS(logfileparser.Logfile):
                 # Eigenvalues for these orbitals (in hartrees).
                 try:
                     self.moenergies[0].extend([float(x) for x in line.split()])
-                except:
+                except:  # noqa: E722
                     self.logger.warning("MO section found but could not be parsed!")
                     break
 

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1465,7 +1465,7 @@ class GAMESS(logfileparser.Logfile):
                         "Overwriting previous multipole moments with new values; "
                         "This could be from post-HF properties or geometry optimization"
                     )
-                    self.moments = [reference, dipole]
+                    self.set_attribute("moments", [reference, dipole])
 
         # Static polarizability from a harmonic frequency calculation
         # with $CPHF/POLAR=.TRUE.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -809,9 +809,10 @@ class GAMESS(logfileparser.Logfile):
                     self.set_attribute("atommasses", atommasses)
 
                 if "THIS IS NOT A STATIONARY POINT" in line:
-                    msg = "\n   This is not a stationary point on the molecular PES"
-                    msg += "\n   The vibrational analysis is not valid!!!"
-                    self.logger.warning(msg)
+                    self.logger.warning(
+                        "\n   This is not a stationary point on the molecular PES"
+                        "\n   The vibrational analysis is not valid!!!"
+                    )
                 if "* * * WARNING, MODE" in line:
                     line1 = line.strip()
                     line2 = next(inputfile).strip()
@@ -1460,8 +1461,8 @@ class GAMESS(logfileparser.Logfile):
                 try:
                     assert self.moments[1] == dipole
                 except AssertionError:
-                    self.logger.warning("Overwriting previous multipole moments with new values")
                     self.logger.warning(
+                        "Overwriting previous multipole moments with new values; "
                         "This could be from post-HF properties or geometry optimization"
                     )
                     self.moments = [reference, dipole]

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -193,7 +193,7 @@ class GAMESS(logfileparser.Logfile):
         # Symmetry: ordering of irreducible representations
         if line.strip() == "DIMENSIONS OF THE SYMMETRY SUBSPACES ARE":
             line = next(inputfile)
-            symlabels = [self.normalisesym(label) for label in line.split()[::3]]
+            symlabels = [self.normalisesym(label) for label in line.split()[::3]]  # noqa: F841
 
         # We are looking for this line:
         #           PARAMETERS CONTROLLING GEOMETRY SEARCH ARE
@@ -389,7 +389,7 @@ class GAMESS(logfileparser.Logfile):
             if "OPTICALLY" in line:
                 pass
             else:
-                statenumber = int(line.split()[-1])
+                statenumber = int(line.split()[-1])  # noqa: F841
                 self.skip_lines(
                     inputfile,
                     [
@@ -882,7 +882,7 @@ class GAMESS(logfileparser.Logfile):
                         self.vibramans = []
                     ramanIntensity = line.strip().split()
                     self.vibramans.extend(list(map(float, ramanIntensity[2:])))
-                    depolar = next(inputfile)
+                    depolar = next(inputfile)  # noqa: F841
                     line = next(inputfile)
 
                 # This line seems always to be blank.
@@ -1062,7 +1062,7 @@ class GAMESS(logfileparser.Logfile):
 
                 # This is for regression CdtetraM1B3LYP.
                 if "ALPHA SET" in numbers:
-                    blank = next(inputfile)
+                    self.skip_line(inputfile, "b")
                     numbers = next(inputfile)
 
                 # If not all coefficients are printed, the logfile will go right to
@@ -1107,7 +1107,6 @@ class GAMESS(logfileparser.Logfile):
 
                     # Fill atombasis and aonames only first time around
                     if readatombasis and base == 0:
-                        aonames = []
                         start = line[:17].strip()
                         m = p.search(start)
 
@@ -1175,10 +1174,10 @@ class GAMESS(logfileparser.Logfile):
 
             # Covers label with both dashes and stars (like regression CdtetraM1B3LYP).
             if "BETA SET" in line:
-                self.mocoeffs.append(numpy.zeros((self.nmo, self.nbasis), "d"))
-                self.moenergies.append([])
-                self.mosyms.append([])
-                blank = next(inputfile)
+                self.append_attribute("mocoeffs", numpy.zeros((self.nmo, self.nbasis), "d"))
+                self.append_attribute("moenergies", [])
+                self.append_attribute("mosyms", [])
+                self.skip_line(inputfile, "b")
                 line = next(inputfile)
 
                 # Sometimes EIGENVECTORS is missing, so rely on dashes to signal it.
@@ -1357,15 +1356,15 @@ class GAMESS(logfileparser.Logfile):
 
             header = next(inputfile)
             while header.split()[0] == "PARAMETERS":
-                name = header[17:25]
+                element_symbol_dash_ecp = header[17:25]  # noqa: F841
                 atomnum = int(header[34:40])
-                # The pseudopotnetial is given explicitely
+                # The pseudopotential is given explicitly
                 if header[40:50] == "WITH ZCORE":
                     zcore = int(header[50:55])
-                    lmax = int(header[63:67])
+                    lmax = int(header[63:67])  # noqa: F841
                     self.coreelectrons[atomnum - 1] = zcore
-                # The pseudopotnetial is copied from another atom
-                if header[40:55] == "ARE THE SAME AS":
+                # The pseudopotential is copied from another atom
+                elif header[40:55] == "ARE THE SAME AS":
                     atomcopy = int(header[60:])
                     self.coreelectrons[atomnum - 1] = self.coreelectrons[atomcopy - 1]
                 line = next(inputfile)
@@ -1396,7 +1395,7 @@ class GAMESS(logfileparser.Logfile):
             # so let's get a flag out of that circumstance.
             doubles_printed = line.strip() == ""
             if doubles_printed:
-                title = next(inputfile)
+                self.skip_line(inputfile, "TOTAL MULLIKEN AND LOWDIN ATOMIC POPULATIONS")
                 header = next(inputfile)
                 line = next(inputfile)
 
@@ -1430,7 +1429,7 @@ class GAMESS(logfileparser.Logfile):
 
             # The old PC-GAMESS prints memory assignment information here.
             if "MEMORY ASSIGNMENT" in line:
-                memory_assignment = next(inputfile)
+                self.skip_line(inputfile, "IELM IEMW IDENSA IDENSB LAST")
                 line = next(inputfile)
 
             # If something else ever comes up, we should get a signal from this assert.

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -494,7 +494,7 @@ class GAMESS(logfileparser.Logfile):
                     else:
                         i_occ_vir = [0, 1]
                         i_coeff = 2
-                    fromMO, toMO = [int(cols[i]) - 1 for i in i_occ_vir]
+                    fromMO, toMO = (int(cols[i]) - 1 for i in i_occ_vir)
                     coeff = float(cols[i_coeff])
                     CIScontribs.append([(fromMO, 0), (toMO, 0), coeff])
                     line = next(inputfile)

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -383,7 +383,7 @@ class GAMESSUK(logfileparser.Logfile):
                     line = next(inputfile)
                 except StopIteration:
                     self.logger.warning(
-                        f"File terminated before end of last SCF! Last tester: {line.split()[5]}"
+                        "File terminated before end of last SCF! Last tester: %s", line.split()[5]
                     )
                     break
             self.scfvalues.append(scfvalues)

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -273,8 +273,7 @@ class GAMESSUK(logfileparser.Logfile):
                 self.vibfreqs = []
                 self.vibirs = []
 
-            units = next(inputfile)
-            xyz = next(inputfile)
+            self.skip_lines(inputfile, ["debyes debyes**2 km/mole", "x y z"])
             equals = next(inputfile)
             line = next(inputfile)
             while line != equals:
@@ -418,14 +417,12 @@ class GAMESSUK(logfileparser.Logfile):
             while line.find("contraction coefficients") < 0:
                 line = next(inputfile)
             equals = next(inputfile)
-            blank = next(inputfile)
-            atomname = next(inputfile)
+            self.skip_lines(inputfile, ["b", "atomsym"])
             basisregexp = re.compile(r"\d*(\D+)")  # Get everything after any digits
             shellcounter = 1
             while line != equals:
                 gbasis = []  # Stores basis sets on one atom
-                blank = next(inputfile)
-                blank = next(inputfile)
+                self.skip_lines(inputfile, ["b", "b"])
                 line = next(inputfile)
                 shellno = int(line.split()[0])
                 shellgap = shellno - shellcounter
@@ -523,7 +520,7 @@ class GAMESSUK(logfileparser.Logfile):
         if line.strip() == "Number of orbitals belonging to irreps of this group":
             self.skip_line(inputfile, "d")
             line = next(inputfile)
-            irreps = [self.normalisesym(irrep) for irrep in line.split()[::2]]
+            irreps = [self.normalisesym(irrep) for irrep in line.split()[::2]]  # noqa: F841
 
         if line[50:62] == "eigenvectors":
             # Mocoeffs...can get evalues from here too
@@ -531,7 +528,7 @@ class GAMESSUK(logfileparser.Logfile):
             if not hasattr(self, "mocoeffs"):
                 self.aonames = []
                 aonames = []
-            minus = next(inputfile)
+            self.skip_line(inputfile, "e")
 
             mocoeffs = numpy.zeros((self.nmo, self.nbasis), "d")
             readatombasis = False

--- a/cclib/parser/gamessukparser.py
+++ b/cclib/parser/gamessukparser.py
@@ -688,7 +688,7 @@ class GAMESSUK(logfileparser.Logfile):
             if not hasattr(self, "atomcharges"):
                 self.atomcharges = {}
 
-            while not "total gross population on atoms" in line:
+            while "total gross population on atoms" not in line:
                 line = next(inputfile)
 
             self.skip_line(inputfile, "blank")

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -885,7 +885,7 @@ class Gaussian(logfileparser.Logfile):
                 self.scftargets = []
             # The following can happen with ONIOM which are mixed SCF
             # and semi-empirical
-            if type(self.scftargets) == type(numpy.array([])):
+            if isinstance(self.scftargets, numpy.ndarray):
                 self.scftargets = []
 
             scftargets = []

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1088,7 +1088,7 @@ class Gaussian(logfileparser.Logfile):
                 self.logger.debug(line)
                 parts = line.split()
                 if "NO" in parts[-1]:
-                    allconverged = False
+                    allconverged = False  # noqa: F841
                 try:
                     value = utils.float(parts[2])
                 except ValueError:
@@ -1913,7 +1913,7 @@ class Gaussian(logfileparser.Logfile):
                     self.logger.warning("Molecular coefficients header found but no coefficients.")
                     break
 
-                symmetries = next(inputfile)
+                symmetries = next(inputfile)  # noqa: F841
                 eigenvalues = next(inputfile)
                 for i in range(self.nbasis):
                     line = next(inputfile)
@@ -1965,7 +1965,7 @@ class Gaussian(logfileparser.Logfile):
             atombasis = []
             for base in range(0, self.nmo, 5):
                 self.updateprogress(inputfile, updateprogress_title, self.fupdate)
-                colmNames = next(inputfile)
+                self.skip_line(inputfile, "column numbers")
                 eigenvalues = next(inputfile)
                 occnos.extend(map(float, eigenvalues.split()[2:]))
                 for i in range(self.nbasis):
@@ -2274,9 +2274,9 @@ class Gaussian(logfileparser.Logfile):
                 line1 = next(inputfile)
                 line2 = next(inputfile)
                 if line1.split()[0] == "Natural" and line2.split()[2] == "Charge":
-                    dashes = next(inputfile)
+                    self.skip_line(inputfile, "d")
                     charges = []
-                    for i in range(self.natom):
+                    for _ in range(self.natom):
                         nline = next(inputfile)
                         charges.append(float(nline.split()[2]))
                     self.atomcharges["natural"] = charges

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -223,7 +223,7 @@ class Gaussian(logfileparser.Logfile):
                     f"{self.YEAR_SUFFIXES_TO_YEARS[year_suffix]}+{revision}"
                 )
                 self.metadata["platform"] = groupdict["platform"]
-            run_date = next(inputfile).strip()
+            run_date = next(inputfile).strip()  # noqa: F841
 
         if line.strip().startswith("Link1:  Proceeding to internal job step number"):
             self.new_internal_job()

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -336,7 +336,7 @@ class Gaussian(logfileparser.Logfile):
             # Also, in older versions there is bo blank line (G98 regressions),
             # so we need to watch out for leaving the link.
             natom = 0
-            while line.split() and not "Variables" in line and not "Leave Link" in line:
+            while line.split() and "Variables" not in line and "Leave Link" not in line:
                 natom += 1
                 line = next(inputfile)
             self.set_attribute("natom", natom)
@@ -352,7 +352,7 @@ class Gaussian(logfileparser.Logfile):
             self.updateprogress(inputfile, "Charge and Multiplicity", self.fupdate)
 
             if line.split()[-1] == "supermolecule" or (
-                not "fragment" in line and not "model system" in line
+                "fragment" not in line and "model system" not in line
             ):
                 regex = r".*=(.*)Mul.*=\s*-?(\d+).*"
                 match = re.match(regex, line)
@@ -674,7 +674,7 @@ class Gaussian(logfileparser.Logfile):
 
             atomcoords = []
             line = next(inputfile)
-            while not "MW cartesian" in line:
+            while "MW cartesian" not in line:
                 broken = line.split()
                 atomcoords.append(list(map(utils.float, (broken[3], broken[5], broken[7]))))
                 #    self.inputatoms.append(int(broken[1]))
@@ -769,7 +769,7 @@ class Gaussian(logfileparser.Logfile):
         # Eventually we want to make this more general, or even better parse the output for
         # all fragment, but that will happen in a newer version of cclib.
         if line[1:16] == "Fragment guess:" and getattr(self, "nfragments", 0) > 1:
-            if not "full" in line:
+            if "full" not in line:
                 raise StopParsing()
 
         # Another hack for regression Gaussian03/ortho_prod_freq.log, which is an ONIOM job.
@@ -2259,9 +2259,9 @@ class Gaussian(logfileparser.Logfile):
                         # "mulliken atomic charges:" and " atomic charges:"
                         if prop == "atomic":
                             if (
-                                not "mulliken" in line.lower()
-                                and not "lowdin" in line.lower()
-                                and not "apt" in line.lower()
+                                "mulliken" not in line.lower()
+                                and "lowdin" not in line.lower()
+                                and "apt" not in line.lower()
                             ):
                                 extract_charges_spins(line, prop)
                         else:
@@ -2495,9 +2495,9 @@ class Gaussian(logfileparser.Logfile):
         # Extract total elapsed (wall) and CPU job times
         if line[:14] == " Elapsed time:" or line[:14] == " Job cpu time:":
             # create empty list for the times to be stored in
-            if line[:14] == " Elapsed time:" and not "wall_time" in self.metadata:
+            if line[:14] == " Elapsed time:" and "wall_time" not in self.metadata:
                 self.metadata["wall_time"] = []
-            if line[:14] == " Job cpu time:" and not "cpu_time" in self.metadata:
+            if line[:14] == " Job cpu time:" and "cpu_time" not in self.metadata:
                 self.metadata["cpu_time"] = []
             # the line format is " Elapsed time:       0 days  0 hours  0 minutes 47.5 seconds." at the end of each job ran.
             # the line format is " Job cpu time:       0 days  0 hours  8 minutes 45.7 seconds." at the end of each job ran.

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -579,7 +579,9 @@ class Gaussian(logfileparser.Logfile):
                         numpy.testing.assert_equal(self.moments[4], hexadecapole)
                     except AssertionError:
                         self.logger.warning(
-                            f"Attribute hexadecapole changed value ({self.moments[4]} -> {hexadecapole})"
+                            "Attribute hexadecapole changed value (%s -> %s)",
+                            self.moments[4],
+                            hexadecapole,
                         )
                     self.append_attribute("moments", hexadecapole)
 
@@ -1091,7 +1093,8 @@ class Gaussian(logfileparser.Logfile):
                     value = utils.float(parts[2])
                 except ValueError:
                     self.logger.error(
-                        f"Problem parsing the value for geometry optimisation: {parts[2]} is not a number."
+                        "Problem parsing the value for geometry optimisation: %s is not a number.",
+                        parts[2],
                     )
                 else:
                     newlist[i] = value
@@ -1802,7 +1805,9 @@ class Gaussian(logfileparser.Logfile):
                     assert nbasis == self.nbasis
                 except AssertionError:
                     self.logger.warning(
-                        f"Number of basis functions (nbasis) has changed from {int(self.nbasis)} to {int(nbasis)}"
+                        "Number of basis functions (nbasis) has changed from %s to %s",
+                        self.nbasis,
+                        nbasis,
                     )
             self.nbasis = nbasis
 

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1924,7 +1924,7 @@ class Gaussian(logfileparser.Logfile):
                         parts = line[:start_of_basis_fn_name].split()
                         if len(parts) > 1:  # New atom
                             if i > 0:
-                                self.atombasis.append(atombasis)
+                                self.atombasis.append(atombasis)  # noqa: F821
                             atombasis = []
                             atomname = f"{parts[2]}{parts[1]}"
                         orbital = line[start_of_basis_fn_name:20].strip()
@@ -1976,7 +1976,7 @@ class Gaussian(logfileparser.Logfile):
                         # New atom.
                         if len(parts) > 1:
                             if i > 0:
-                                atombasis.append(basisonatom)
+                                atombasis.append(basisonatom)  # noqa: F821
                             basisonatom = []
                             atomname = f"{parts[2]}{parts[1]}"
                         orbital = line[11:20].strip()
@@ -2398,7 +2398,7 @@ class Gaussian(logfileparser.Logfile):
                             line[83:95],
                         ]
                     ]
-                except:
+                except:  # noqa: E722
                     # G16A03 and older
                     # Sample:
                     #       Exact polarizability:  68.238  -6.777 143.018   0.000   0.000  11.343
@@ -2518,7 +2518,7 @@ class Gaussian(logfileparser.Logfile):
                     seconds=float(split_line[n + 6]),
                 )
                 self.metadata[key].append(time)
-            except:
+            except:  # noqa: E722
                 pass
 
         # Extract Rotational Constants

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1598,7 +1598,7 @@ class Gaussian(logfileparser.Logfile):
             self.append_attribute("etoscs", utils.float(line.split("f=")[-1].split()[0]))
             # Fix Gaussian's weird capitalisation.
             mult, symm = groups[0].strip().split("-")
-            self.append_attribute("etsyms", "{}-{}".format(mult, self.normalisesym(symm)))
+            self.append_attribute("etsyms", f"{mult}-{self.normalisesym(symm)}")
 
             line = next(inputfile)
 

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -105,7 +105,7 @@ class Jaguar(logfileparser.Logfile):
             fn_per_atom = []
             while line.strip():
                 if len(line.split()) > 3:
-                    aname = line.split()[0]
+                    aname = line.split()[0]  # noqa: F841
                     fn = int(line.split()[1])
                     prim = int(line.split()[2])
                     L = line.split()[3]
@@ -207,8 +207,7 @@ class Jaguar(logfileparser.Logfile):
             p = re.compile(r"(\D+)\d+")  # One/more letters followed by a number
             atomcoords = []
             atomnos = []
-            angstrom = next(inputfile)
-            title = next(inputfile)
+            self.skip_lines(inputfile, ["angstroms", "header"])
             line = next(inputfile)
             while line.strip():
                 temp = line.split()
@@ -260,7 +259,7 @@ class Jaguar(logfileparser.Logfile):
             line = next(inputfile)
             boccs = int(line.split()[-1])
             line = next(inputfile)
-            bvirt = int(line.split()[-1])
+            bvirt = int(line.split()[-1])  # noqa: F841
 
             self.set_attribute("nmo", aoccs + avirts)
             self.set_attribute("homos", numpy.array([aoccs - 1, boccs - 1], "i"))
@@ -539,7 +538,7 @@ class Jaguar(logfileparser.Logfile):
 
             gopt_step = int(line.split()[-1])
 
-            energy = next(inputfile)
+            energy = next(inputfile)  # noqa: F841
             blank = next(inputfile)
 
             # A quick hack for messages that show up right after the energy

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -295,7 +295,7 @@ class Jaguar(logfileparser.Logfile):
                     line = next(inputfile)
                 except StopIteration:
                     self.logger.warning(
-                        f"File terminated before end of last SCF! Last error: {maxdiiserr}"
+                        "File terminated before end of last SCF! Last error: %f", maxdiiserr
                     )
                     break
             self.scfvalues.append(values)

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -239,13 +239,13 @@ class Jaguar(logfileparser.Logfile):
             occs = int(line.split()[-1])
             line = next(inputfile)
             virts = int(line.split()[-1])
-            self.nmo = occs + virts
-            self.homos = numpy.array([occs - 1], "i")
 
-            self.unrestrictedflag = False
+            self.set_attribute("nmo", occs + virts)
+            self.set_attribute("homos", numpy.array([occs - 1], "i"))
+            self.set_attribute("unrestrictedflag", False)
 
         if line[1:28] == "number of occupied orbitals":
-            self.homos = numpy.array([float(line.strip().split()[-1]) - 1], "i")
+            self.set_attribute("homos", numpy.array([float(line.strip().split()[-1]) - 1], "i"))
 
         if line[2:27] == "number of basis functions":
             nbasis = int(line.strip().split()[-1])
@@ -262,14 +262,13 @@ class Jaguar(logfileparser.Logfile):
             line = next(inputfile)
             bvirt = int(line.split()[-1])
 
-            self.nmo = aoccs + avirts
-            self.homos = numpy.array([aoccs - 1, boccs - 1], "i")
-            self.unrestrictedflag = True
+            self.set_attribute("nmo", aoccs + avirts)
+            self.set_attribute("homos", numpy.array([aoccs - 1, boccs - 1], "i"))
+            self.set_attribute("unrestrictedflag", True)
 
         if line[0:4] == "etot":
             # Get SCF convergence information
             if not hasattr(self, "scfvalues"):
-                self.scfvalues = []
                 self.scftargets = [[5e-5, 5e-6]]
             values = []
             while line[0:4] == "etot":
@@ -298,7 +297,7 @@ class Jaguar(logfileparser.Logfile):
                         "File terminated before end of last SCF! Last error: %f", maxdiiserr
                     )
                     break
-            self.scfvalues.append(values)
+            self.append_attribute("scfvalues", values)
 
         # MO energies and symmetries.
         # Jaguar 7.0: provides energies and symmetries for both

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -121,7 +121,7 @@ class Jaguar(logfileparser.Logfile):
                         self.gbasis.append([])
 
                     # Remember that fn is repeated when functions are contracted.
-                    if not fn - 1 in atombasis[-1]:
+                    if fn - 1 not in atombasis[-1]:
                         atombasis[-1].append(fn - 1)
 
                     # Here we use fn only to know when a new contraction is encountered,
@@ -129,7 +129,7 @@ class Jaguar(logfileparser.Logfile):
                     # What's more, since we only wish to save the parameters for each subshell
                     # once, we don't even need to consider lines for orbitals other than
                     # those for X*, making things a bit easier.
-                    if not fn in fn_per_atom:
+                    if fn not in fn_per_atom:
                         fn_per_atom.append(fn)
                         label = {"S": "S", "X": "P", "XX": "D", "XXX": "F"}[L]
                         self.gbasis[-1].append((label, []))
@@ -141,7 +141,7 @@ class Jaguar(logfileparser.Logfile):
                     L = line.split()[1]
 
                     # Some AO indices are only printed in these lines, for L > 0.
-                    if not fn - 1 in atombasis[-1]:
+                    if fn - 1 not in atombasis[-1]:
                         atombasis[-1].append(fn - 1)
 
                 line = next(inputfile)
@@ -618,7 +618,7 @@ class Jaguar(logfileparser.Logfile):
             # which could be caught. This is not true in newer version (including 8.3),
             # but in general it would be better to bound this loop more strictly.
             freqs = next(inputfile)
-            while freqs.strip() and not "imaginary frequencies" in freqs:
+            while freqs.strip() and "imaginary frequencies" not in freqs:
                 # Number of modes (columns printed in this block).
                 nmodes = len(freqs.split()) - 1
 

--- a/cclib/parser/jaguarparser.py
+++ b/cclib/parser/jaguarparser.py
@@ -43,7 +43,7 @@ class Jaguar(logfileparser.Logfile):
         self.geoopt = False
 
     def after_parsing(self):
-        super(Jaguar, self).after_parsing()
+        super().after_parsing()
 
         # This is to make sure we always have optdone after geometry optimizations,
         # even if it is to be empty for unconverged runs. We have yet to test this

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -107,9 +107,9 @@ class Logfile(ABC):
             # Call logger.info() only if the attribute is new.
             if not hasattr(self, name):
                 if type(value) in [numpy.ndarray, list]:
-                    self.logger.info(f"Creating attribute {name}[]")
+                    self.logger.info("Creating attribute %s[]", name)
                 else:
-                    self.logger.info(f"Creating attribute {name}: {str(value)}")
+                    self.logger.info("Creating attribute %s: %s", name, value)
 
         # Set the attribute.
         object.__setattr__(self, name, value)
@@ -165,7 +165,7 @@ class Logfile(ABC):
 
                 # Not all input files support last_line.
                 if hasattr(self.inputfile, "last_line"):
-                    self.logger.error(f"Last line read: {self.inputfile.last_line}")
+                    self.logger.error("Last line read: %s", self.inputfile.last_line)
                 raise
 
         # Maybe the sub-class has something to do after parsing.
@@ -282,7 +282,7 @@ class Logfile(ABC):
                 numpy.testing.assert_equal(getattr(self, name), value)
             except AssertionError:
                 self.logger.warning(
-                    f"Attribute {name} changed value ({getattr(self, name)} -> {value})"
+                    "Attribute %s changed value (%s -> %s)", name, getattr(self, name), value
                 )
 
         setattr(self, name, value)
@@ -370,10 +370,9 @@ class Logfile(ABC):
                         inspect.currentframe()
                     )[1]
                     parser = fname.split("/")[-1]
-                    msg = (
-                        f"In {parser}, line {int(lno)}, line not blank as expected: {line.strip()}"
+                    self.logger.warning(
+                        "In %s, line %d, line not blank as expected: %s", parser, lno, line.strip()
                     )
-                    self.logger.warning(msg)
 
             # All cases of heterogeneous lines can be dealt with by the same code.
             for character, keys in expected_characters.items():
@@ -385,8 +384,13 @@ class Logfile(ABC):
                             inspect.currentframe()
                         )[1]
                         parser = fname.split("/")[-1]
-                        msg = f"In {parser}, line {int(lno)}, line not all {keys[0]} as expected: {line.strip()}"
-                        self.logger.warning(msg)
+                        self.logger.warning(
+                            "In %s, line %d, line not all %s as expected: %s",
+                            parser,
+                            lno,
+                            keys[0],
+                            line.strip(),
+                        )
                         continue
 
             # Save the skipped line, and we will return the whole list.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -160,7 +160,7 @@ class Logfile(ABC):
             except StopIteration:
                 self.logger.error("Unexpectedly encountered end of logfile.")
                 break
-            except Exception as e:
+            except Exception:
                 self.logger.error("Encountered error when parsing.")
 
                 # Not all input files support last_line.
@@ -202,7 +202,7 @@ class Logfile(ABC):
         # Delete all temporary attributes (including cclib attributes).
         # All attributes should have been moved to a data object, which will be returned.
         for attr in list(self.__dict__.keys()):
-            if not attr in _nodelete:
+            if attr not in _nodelete:
                 self.__delattr__(attr)
 
         # Perform final checks on values of attributes.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -259,7 +259,7 @@ class Logfile(ABC):
 
     def hasattrs(self, names: Iterable[str]) -> bool:
         """Does this logfile have all the given attributes?"""
-        return all((hasattr(self, name) for name in names))
+        return all(hasattr(self, name) for name in names)
 
     def set_attribute(self, name: str, value: Any, check_change: bool = True) -> None:
         """Set an attribute and perform an optional check when it already exists.

--- a/cclib/parser/logfileparser.py
+++ b/cclib/parser/logfileparser.py
@@ -407,4 +407,5 @@ class Logfile(ABC):
             if line.strip() != "":
                 return line
 
-    skip_line = lambda self, inputfile, expected: self.skip_lines(inputfile, [expected])
+    def skip_line(self, inputfile: "FileWrapper", expected: str) -> List[str]:
+        return self.skip_lines(inputfile, [expected])

--- a/cclib/parser/logfilewrapper.py
+++ b/cclib/parser/logfilewrapper.py
@@ -152,9 +152,7 @@ class FileWrapper(FileWrapperBase):
 
             except (ValueError, URLError) as error:
                 # Maybe no need to raise a different exception?
-                raise ValueError(
-                    "Encountered an error processing the URL '{}'".format(source)
-                ) from error
+                raise ValueError(f"Encountered an error processing the URL '{source}'") from error
 
         elif hasattr(source, "read") or hasattr(source, "readline"):
             # This file is a file.

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -986,7 +986,7 @@ class Molcas(logfileparser.Logfile):
                     try:
                         basis_element = line.split()[3].split(".")[0]
                         basis_element = basis_element[0] + basis_element[1:].lower()
-                    except:
+                    except:  # noqa: E722
                         self.logger.warning("Basis set label is missing!")
                         basis_element = ""
                 if "valence basis set:" in line.lower():

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -641,7 +641,10 @@ class Molcas(logfileparser.Logfile):
                 self.atomcoords.append(atomcoords)
             else:
                 self.logger.warning(
-                    f"Parsed coordinates not consistent with previous, skipping. This could be due to symmetry being turned on during the job. Length was {len(self.atomcoords[-1])}, now found {len(atomcoords)}. New coordinates: {str(atomcoords)}"
+                    "Parsed coordinates not consistent with previous, skipping. This could be due to symmetry being turned on during the job. Length was %d, now found %d. New coordinates: %s",
+                    len(self.atomcoords[-1]),
+                    len(atomcoords),
+                    atomcoords,
                 )
 
         #  **********************************************************************************************************************
@@ -694,7 +697,9 @@ class Molcas(logfileparser.Logfile):
                 self.atomcoords.append(atomcoords)
             else:
                 self.logger.error(
-                    f"Number of atoms ({len(atomcoords)}) in parsed atom coordinates is smaller than previously ({int(self.natom)}), possibly due to symmetry. Ignoring these coordinates."
+                    "Number of atoms (%d) in parsed atom coordinates is smaller than previously (%d), possibly due to symmetry. Ignoring these coordinates.",
+                    len(atomcoords),
+                    int(self.natom),
                 )
 
         ## Parsing Molecular Gradients attributes in this section.

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -327,8 +327,7 @@ class Molcas(logfileparser.Logfile):
                 match = re.match(iteration_regex, line.strip())
                 if match:
                     groups = match.groups()
-                    cols = [g.strip() for g in match.groups()]
-                    cols = [c.replace("*", "") for c in cols]
+                    cols = [g.strip().replace("*", "") for g in groups]
 
                     energy = float(cols[4])
                     density = float(cols[5])
@@ -933,7 +932,6 @@ class Molcas(logfileparser.Logfile):
 
                     exponents = []
                     coefficients = []
-                    func_array = []
                     while line.split():
                         exponents.append(utils.float(line.split()[1]))
                         coefficients.append([utils.float(i) for i in line.split()[2:]])

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -149,7 +149,7 @@ class Molpro(logfileparser.Logfile):
 
         # Besides a double blank line, stop when the next orbitals are encountered for unrestricted jobs
         # or if there are stars on the line which always signifies the end of the block.
-        while line.strip() and (not "ORBITALS" in line) and (not set(line.strip()) == {"*"}):
+        while line.strip() and ("ORBITALS" not in line) and (not set(line.strip()) == {"*"}):
             # The function names are normally printed just once, but if symmetry is used then each irrep
             # has its own mocoeff block with a preceding list of names.
             is_aonames = line[:25].strip() == ""
@@ -660,7 +660,7 @@ class Molpro(logfileparser.Logfile):
             # Newer version of Molpro (at least for 2012) print and additional column
             # with the timing information for each step. Otherwise, the history looks the same.
             headers = next(inputfile).split()
-            if not len(headers) in (10, 11):
+            if len(headers) not in (10, 11):
                 return
 
             # Although criteria can be changed, the printed format should not change.

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -204,7 +204,7 @@ class Molpro(logfileparser.Logfile):
                     try:
                         c = float(p)
                     except ValueError as detail:
-                        self.logger.warning(f"setting coeff element to zero: {detail}")
+                        self.logger.warning("setting coeff element to zero: %s", detail)
                         c = 0.0
                     coeff.append(c)
                 coeffs.extend(coeff)
@@ -483,7 +483,7 @@ class Molpro(logfileparser.Logfile):
                     line = next(inputfile)
                 except StopIteration:
                     self.logger.warning(
-                        f"File terminated before end of last SCF! Last gradient: {grad}"
+                        "File terminated before end of last SCF! Last gradient: %f", grad
                     )
                     break
             self.scfvalues.append(numpy.array(scfvalues))

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -343,7 +343,7 @@ class Molpro(logfileparser.Logfile):
                 # or indentation size. However, we will rely on explicit slices since not all components
                 # are always available. In fact, components not being there has some meaning (see below).
                 line_nr = line[1:6].strip()
-                line_sym = line[7:9].strip()
+                line_sym = line[7:9].strip()  # noqa: F841
                 line_nuc = line[11:15].strip()
                 line_type = line[16:22].strip()
                 line_exp = line[25:38].strip()

--- a/cclib/parser/molproparser.py
+++ b/cclib/parser/molproparser.py
@@ -360,19 +360,19 @@ class Molpro(logfileparser.Logfile):
                     # update the dict if something unexpected comes up.
                     funcbasis = None
                     for fb, names in self.atomic_orbital_names.items():
-                        if functype in names:
+                        if functype in names:  # noqa: F821
                             funcbasis = fb
                     assert funcbasis
 
                     # There is a separate basis function for each column of contraction coefficients. Since all
                     # atomic orbitals for a subshell will have the same parameters, we can simply check if
                     # the function tuple is already in gbasis[i] before adding it.
-                    for i in range(len(coefficients[0])):
+                    for i in range(len(coefficients[0])):  # noqa: F821
                         func = (funcbasis, [])
-                        for j in range(len(exponents)):
-                            func[1].append((exponents[j], coefficients[j][i]))
-                        if func not in gbasis[funcatom - 1]:
-                            gbasis[funcatom - 1].append(func)
+                        for j in range(len(exponents)):  # noqa: F821
+                            func[1].append((exponents[j], coefficients[j][i]))  # noqa: F821
+                        if func not in gbasis[funcatom - 1]:  # noqa: F821
+                            gbasis[funcatom - 1].append(func)  # noqa: F821
 
                 # If it is a new type, set up the variables for the next shell(s). An exception is symmetry functions,
                 # which we want to copy from the previous function and don't have a new number on the line. For them,
@@ -807,7 +807,7 @@ class Molpro(logfileparser.Logfile):
             while line.strip():
                 try:
                     list(map(float, line.strip().split()[2:]))
-                except:
+                except:  # noqa: E722
                     line = next(inputfile)
                 line.strip().split()[1:]
                 hess.extend([list(map(float, line.strip().split()[1:]))])
@@ -826,7 +826,7 @@ class Molpro(logfileparser.Logfile):
                     break
                 if k >= lig:
                     k = len(tmp[-1])
-            for l in tmp:
+            for l in tmp:  # noqa: E741
                 hessian += l
 
             self.set_attribute("hessian", hessian)

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -115,7 +115,7 @@ class MOPAC(logfileparser.Logfile):
             self.inputcoords = []
             self.inputatoms = []
 
-            blankline = next(inputfile)
+            self.skip_line(inputfile, "b")
 
             atomcoords = []
             line = next(inputfile)
@@ -168,9 +168,8 @@ class MOPAC(logfileparser.Logfile):
         # note that the last occurence of this in the thermochemistry section has reduced precision,
         # so we will want to use the 2nd to last instance
         if line[0:40] == "          ROTATIONAL CONSTANTS IN CM(-1)":
-            blankline = next(inputfile)
-            rotinfo = next(inputfile)
-            broken = rotinfo.split()
+            self.skip_line(inputfile, "b")
+            broken = next(inputfile).split()
             # leave the rotational constants in Hz
             a = float(broken[2])
             b = float(broken[5])

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -14,7 +14,7 @@
 import math
 import re
 
-from cclib.parser import data, logfileparser, utils
+from cclib.parser import logfileparser, utils
 
 import numpy
 

--- a/cclib/parser/mopacparser.py
+++ b/cclib/parser/mopacparser.py
@@ -170,14 +170,12 @@ class MOPAC(logfileparser.Logfile):
         if line[0:40] == "          ROTATIONAL CONSTANTS IN CM(-1)":
             blankline = next(inputfile)
             rotinfo = next(inputfile)
-            if not hasattr(self, "rotconsts"):
-                self.rotconsts = []
             broken = rotinfo.split()
             # leave the rotational constants in Hz
             a = float(broken[2])
             b = float(broken[5])
             c = float(broken[8])
-            self.rotconsts.append([a, b, c])
+            self.append_attribute("rotconsts", [a, b, c])
 
         # Start of the IR/Raman frequency section.
         # Example:

--- a/cclib/parser/nboparser.py
+++ b/cclib/parser/nboparser.py
@@ -144,8 +144,8 @@ class NBO(logfileparser.Logfile):
                 natural_charge = float(population_analysis[2])
                 core = float(population_analysis[3])
                 valence = float(population_analysis[4])
-                rydberg = float(population_analysis[5])
-                total = float(population_analysis[6])
+                rydberg = float(population_analysis[5])  # noqa: F841
+                total = float(population_analysis[6])  # noqa: F841
 
                 # TODO append to attibutes
                 charges.append(natural_charge)
@@ -169,22 +169,22 @@ class NBO(logfileparser.Logfile):
             line = next(inputfile)
             line = next(inputfile)
 
-            core = float(line.split()[1])
+            core = float(line.split()[1])  # noqa: F841
             # TODO append to attibutes
 
             line = next(inputfile)
 
-            valence = float(line.split()[1])
+            valence = float(line.split()[1])  # noqa: F841
             # TODO append to attibutes
 
             line = next(inputfile)
 
-            natural_minimal_basis = float(line.split()[3])
+            natural_minimal_basis = float(line.split()[3])  # noqa: F841
             # TODO append to attibutes
 
             line = next(inputfile)
 
-            natural_rydberg_basis = float(line.split()[3])
+            natural_rydberg_basis = float(line.split()[3])  # noqa: F841
             # TODO append to attibutes
 
         #     Atom No         Natural Electron Configuration
@@ -200,7 +200,7 @@ class NBO(logfileparser.Logfile):
             while len(line.strip()):
                 configuration_line = line.split()
                 atom = configuration_line[0]
-                configuration = "".join(configuration_line[2:])
+                configuration = "".join(configuration_line[2:])  # noqa: F841
 
                 # TODO append to attibutes
 
@@ -222,17 +222,17 @@ class NBO(logfileparser.Logfile):
 
             nbo_analysis = line.split()
 
-            cycle = int(nbo_analysis[0])
-            max_ctr = int(nbo_analysis[1])
-            occ_thresh = float(nbo_analysis[2])
-            occ_lewis = float(nbo_analysis[3])
-            occ_non_lewis = float(nbo_analysis[4])
-            lewis_cr = float(nbo_analysis[5])
-            lewis_bd = int(nbo_analysis[6])
-            lewis_nc = int(nbo_analysis[7])
-            lewis_lp = int(nbo_analysis[8])
-            low_occ = int(nbo_analysis[9])
-            high_occ = int(nbo_analysis[10])
+            cycle = int(nbo_analysis[0])  # noqa: F841
+            max_ctr = int(nbo_analysis[1])  # noqa: F841
+            occ_thresh = float(nbo_analysis[2])  # noqa: F841
+            occ_lewis = float(nbo_analysis[3])  # noqa: F841
+            occ_non_lewis = float(nbo_analysis[4])  # noqa: F841
+            lewis_cr = float(nbo_analysis[5])  # noqa: F841
+            lewis_bd = int(nbo_analysis[6])  # noqa: F841
+            lewis_nc = int(nbo_analysis[7])  # noqa: F841
+            lewis_lp = int(nbo_analysis[8])  # noqa: F841
+            low_occ = int(nbo_analysis[9])  # noqa: F841
+            high_occ = int(nbo_analysis[10])  # noqa: F841
 
             # TODO append to attibutes
 

--- a/cclib/parser/nboparser.py
+++ b/cclib/parser/nboparser.py
@@ -5,12 +5,7 @@
 
 """Parser for NBO output files"""
 
-import re
-
-from cclib.parser import logfileparser, utils
-from cclib.parser.utils import PeriodicTable
-
-import numpy
+from cclib.parser import logfileparser
 
 
 class NBO(logfileparser.Logfile):

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -402,7 +402,7 @@ class NWChem(logfileparser.Logfile):
             if hasattr(self, "linesearch") and self.linesearch:
                 return
 
-            while not "Final" in line:
+            while "Final" not in line:
                 # Only the norm of the orbital gradient is used to test convergence.
                 if line[:22] == " Convergence threshold":
                     target = float(line.split()[-1])
@@ -1272,7 +1272,7 @@ class NWChem(logfileparser.Logfile):
             line = next(inputfile)
             if "Spin forbidden" not in line:
                 # find Dipole Oscillator Strength
-                while not ("Dipole Oscillator Strength" in line):
+                while "Dipole Oscillator Strength" not in line:
                     line = next(inputfile)
                 etoscs = utils.float(line.split()[-1])
                 # in case of magnetic contribution replace, replace Dipole Oscillator Strength with Total Oscillator Strength

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -31,7 +31,9 @@ class NWChem(logfileparser.Logfile):
         """NWChem does not require normalizing symmetry labels."""
         return label
 
-    name2element = lambda self, lbl: "".join(itertools.takewhile(str.isalpha, str(lbl)))
+    @staticmethod
+    def name2element(lbl: str) -> str:
+        return "".join(itertools.takewhile(str.isalpha, str(lbl)))
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -1323,7 +1323,7 @@ class NWChem(logfileparser.Logfile):
 
     def after_parsing(self):
         """NWChem-specific routines for after parsing a file."""
-        super(NWChem, self).after_parsing()
+        super().after_parsing()
 
         # Expand self.shells into a proper aonames attribute.
         #

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -429,7 +429,8 @@ class NWChem(logfileparser.Logfile):
                         # Is this the end of the file for some reason?
                         except StopIteration:
                             self.logger.warning(
-                                f"File terminated before end of last SCF! Last gradient norm: {gnorm}"
+                                "File terminated before end of last SCF! Last gradient norm: %f",
+                                gnorm,
                             )
                             break
                     if not hasattr(self, "scfvalues"):
@@ -490,7 +491,7 @@ class NWChem(logfileparser.Logfile):
                 # Is this the end of the file for some reason?
                 except StopIteration:
                     self.logger.warning(
-                        f"File terminated before end of last SCF! Last error: {diis}"
+                        "File terminated before end of last SCF! Last error: %f", diis
                     )
                     break
 
@@ -623,7 +624,7 @@ class NWChem(logfileparser.Logfile):
                     sym = sym[0].upper() + sym[1:]
                     if self.mosyms[0][index]:
                         if self.mosyms[0][index] != sym:
-                            self.logger.warning(f"Symmetry of MO {int(index + 1)} has changed")
+                            self.logger.warning("Symmetry of MO %d has changed", index + 1)
                     self.mosyms[0][index] = sym
                 line = next(inputfile)
 
@@ -1393,8 +1394,7 @@ class NWChem(logfileparser.Logfile):
                 shell_text = self.shells[element]
             except KeyError:
                 del self.aonames
-                msg = "Cannot determine aonames for at least one atom."
-                self.logger.warning(msg)
+                self.logger.warning("Cannot determine aonames for at least one atom.")
                 break
 
             prefix = f"{element}{int(i + 1)}_"  # (e.g. C1_)

--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -535,7 +535,7 @@ class NWChem(logfileparser.Logfile):
             self.skip_line(inputfile, "dashes")
             self.linesearch = False
         if line[0] == "@" and line.split()[1] == "Step":
-            at_and_dashes = next(inputfile)
+            self.skip_line(inputfile, "at and dashes")
             line = next(inputfile)
             tokens = line.split()
             assert int(tokens[1]) == self.geostep == 0
@@ -834,7 +834,11 @@ class NWChem(logfileparser.Logfile):
         # by default, but they are printed by this modules later on. They are also print
         # for Hartree-Fock runs, though, so in that case make sure they are consistent.
         if line.strip() == "Mulliken population analysis":
-            self.skip_lines(inputfile, ["d", "b", "total_overlap_population", "b"])
+            skipped_lines = self.skip_lines(inputfile, ["d", "b", "total_overlap_population"])
+            if "overlap population" in skipped_lines[2]:
+                self.skip_line(inputfile, "b")
+            elif "shell population" in skipped_lines[2]:
+                self.skip_line(inputfile, "d")
 
             overlaps = []
             line = next(inputfile)

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2594,16 +2594,28 @@ Dispersion correction           -0.016199959
         # start, stop - indices for slicing lines and grabbing values
         # should_stop: when to stop parsing
         if chargestype == "mulliken":
-            should_stop = lambda x: x.startswith("Sum of atomic charges")
+
+            def should_stop(x: str) -> bool:
+                return x.startswith("Sum of atomic charges")
+
             start, stop = 8, 20
         elif chargestype == "lowdin":
-            should_stop = lambda x: not bool(x.strip())
+
+            def should_stop(x: str) -> bool:
+                return not bool(x.strip())
+
             start, stop = 8, 20
         elif chargestype == "chelpg":
-            should_stop = lambda x: x.startswith("---")
+
+            def should_stop(x: str) -> bool:
+                return x.startswith("---")
+
             start, stop = 11, 26
         elif chargestype == "hirshfeld":
-            should_stop = lambda x: not bool(x.strip())
+
+            def should_stop(x: str) -> bool:
+                return not bool(x.strip())
+
             start, stop = 9, 18
             self.skip_lines(
                 inputfile,

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2655,10 +2655,7 @@ Dispersion correction           -0.016199959
         assert line[2] == "Delta-E"
         assert line[3] == "Max-DP"
 
-        if not hasattr(self, "scfvalues"):
-            self.scfvalues = []
-
-        self.scfvalues.append([])
+        self.append_attribute("scfvalues", [])
 
         # Try to keep track of the converger (NR, DIIS, SOSCF, etc.).
         diis_active = True

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -1322,9 +1322,9 @@ Dispersion correction           -0.016199959
                     -----------------------------------------------------------------------------
                        1 5184116.7      1.9   0.040578220   0.00258  -0.05076  -0.00000  -0.00000"""
                     try:
-                        state, energy, wavelength, intensity, t2, tx, ty, tz = [
+                        state, energy, wavelength, intensity, t2, tx, ty, tz = (
                             utils.float(x) for x in line.split()
-                        ]
+                        )
                     except ValueError as e:
                         # Must be spin forbidden and thus no intensity
                         energy = utils.float(line.split()[1])
@@ -1359,7 +1359,7 @@ Dispersion correction           -0.016199959
                         d2_contrib,
                         m2_contrib,
                         q2_contrib,
-                    ) = [utils.float(x) for x in line.split()]
+                    ) = (utils.float(x) for x in line.split())
                     energy = utils.convertor(energy, "wavenumber", "hartree")
                     return energy, intensity
 
@@ -1448,9 +1448,9 @@ Dispersion correction           -0.016199959
                     -------------------------------------------------------------------------------
                      0  1       0.0      0.0   0.000000000   0.00000   0.00000   0.00000   0.00000
                      0  2 5184116.4      1.9   0.020288451   0.00258   0.05076   0.00003   0.00000"""
-                    state, state2, energy, wavelength, intensity, t2, tx, ty, tz = [
+                    state, state2, energy, wavelength, intensity, t2, tx, ty, tz = (
                         utils.float(x) for x in line.split()
-                    ]
+                    )
                     energy = utils.convertor(energy, "wavenumber", "hartree")
                     return energy, intensity
 
@@ -1483,7 +1483,7 @@ Dispersion correction           -0.016199959
                         d2_contrib,
                         m2_contrib,
                         q2_contrib,
-                    ) = [utils.float(x) for x in line.split()]
+                    ) = (utils.float(x) for x in line.split())
                     energy = utils.convertor(energy, "wavenumber", "hartree")
                     return energy, intensity
 
@@ -1635,7 +1635,7 @@ Dispersion correction           -0.016199959
                     etrotat, mx, my, mz = 0.0, 0.0, 0.0, 0.0
                     etenergy_wavenumber = utils.float(tokens[-4])
                 else:
-                    etrotat, mx, my, mz = [utils.float(t) for t in tokens[-4:]]
+                    etrotat, mx, my, mz = (utils.float(t) for t in tokens[-4:])
                     etenergy_wavenumber = utils.float(tokens[-6])
                 etenergies.append(utils.convertor(etenergy_wavenumber, "wavenumber", "hartree"))
                 etrotats.append(etrotat)

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -627,9 +627,7 @@ Dispersion correction           -0.016199959
         # RMS Displacement         TolRMSD  ....  2.0000e-03 bohr
         #
         if line[25:50] == "Geometry Optimization Run":
-            stars = next(inputfile)
-            blank = next(inputfile)
-
+            self.skip_lines(inputfile, ["s", "b"])
             line = next(inputfile)
             while line[0:23] != "Convergence Tolerances:":
                 line = next(inputfile)
@@ -742,7 +740,7 @@ Dispersion correction           -0.016199959
             self.skip_lines(inputfile, ["d", "b"])
             line = next(inputfile)
             assert line[:4] == "E(0)"
-            scfenergy = float(line.split()[-1])
+            scfenergy = float(line.split()[-1])  # noqa: F841
             line = next(inputfile)
             assert line[:7] == "E(CORR)"
             while "E(TOT)" not in line:
@@ -813,9 +811,7 @@ Dispersion correction           -0.016199959
         #          -----------------------------------------------------------------
         #
         if line[33:53] == "Geometry convergence":
-            headers = next(inputfile)
-            dashes = next(inputfile)
-
+            self.skip_lines(inputfile, ["header", "d"])
             names = []
             values = []
             targets = []
@@ -932,8 +928,7 @@ Dispersion correction           -0.016199959
 
             # handle beta orbitals for UHF
             if line[17:35] == "SPIN DOWN ORBITALS":
-                text = next(inputfile)
-
+                self.skip_line(inputfile, "text")
                 self.mooccnos.append([])
                 self.moenergies.append([])
                 self.mosyms.append([])
@@ -1036,8 +1031,7 @@ Dispersion correction           -0.016199959
                 for i in range(0, self.nbasis, 6):
                     self.updateprogress(inputfile, "Coefficients")
 
-                    self.skip_lines(inputfile, ["numbers", "energies", "occs"])
-                    dashes = next(inputfile)
+                    self.skip_lines(inputfile, ["numbers", "energies", "occs", "d"])
 
                     for j in range(self.nbasis):
                         line = next(inputfile)
@@ -1147,7 +1141,7 @@ Dispersion correction           -0.016199959
             self.skip_lines(inputfile, ["dashes", "blank"])
             self.set_attribute("temperature", float(next(inputfile).split()[2]))
             self.set_attribute("pressure", float(next(inputfile).split()[2]))
-            total_mass = float(next(inputfile).split()[3])
+            total_mass = float(next(inputfile).split()[3])  # noqa: F841
 
             # Vibrations, rotations, and translations
             line = next(inputfile)
@@ -1155,16 +1149,16 @@ Dispersion correction           -0.016199959
                 line = next(inputfile)
             self.electronic_energy = float(line.split()[3])
             self.set_attribute("zpve", float(next(inputfile).split()[4]))
-            thermal_vibrational_correction = float(next(inputfile).split()[4])
-            thermal_rotional_correction = float(next(inputfile).split()[4])
+            thermal_vibrational_correction = float(next(inputfile).split()[4])  # noqa: F841
+            thermal_rotional_correction = float(next(inputfile).split()[4])  # noqa: F841
             thermal_translational_correction = float(next(inputfile).split()[4])
             self.skip_lines(inputfile, ["dashes"])
-            total_thermal_energy = float(next(inputfile).split()[3])
+            total_thermal_energy = float(next(inputfile).split()[3])  # noqa: F841
 
             # Enthalpy
             while line[:17] != "Total free energy":
                 line = next(inputfile)
-            thermal_enthalpy_correction = float(next(inputfile).split()[4])
+            thermal_enthalpy_correction = float(next(inputfile).split()[4])  # noqa: F841
             next(inputfile)
 
             # For a single atom, ORCA provides the total free energy or inner energy
@@ -1179,8 +1173,8 @@ Dispersion correction           -0.016199959
             while line[:18] != "Electronic entropy":
                 line = next(inputfile)
             electronic_entropy = float(line.split()[3])
-            vibrational_entropy = float(next(inputfile).split()[3])
-            rotational_entropy = float(next(inputfile).split()[3])
+            vibrational_entropy = float(next(inputfile).split()[3])  # noqa: F841
+            rotational_entropy = float(next(inputfile).split()[3])  # noqa: F841
             translational_entropy = float(next(inputfile).split()[3])
             self.skip_lines(inputfile, ["dashes"])
 
@@ -2249,8 +2243,8 @@ Dispersion correction           -0.016199959
             # Symmetry section is only printed if symmetry is used.
             if vals[0] == "Symmetry":
                 assert vals[-1] == "ON"
-                point_group = next(inputfile).split()[-1]
-                used_point_group = next(inputfile).split()[-1]
+                point_group = next(inputfile).split()[-1]  # noqa: F841
+                used_point_group = next(inputfile).split()[-1]  # noqa: F841
                 num_irreps = int(next(inputfile).split()[-1])
                 num_active = 0
                 # Parse the irreps.
@@ -2278,10 +2272,10 @@ Dispersion correction           -0.016199959
             # Number of active orbitals           ...    4
             # Total number of electrons           ...    4
             # Total number of orbitals            ...   20
-            num_el = int(next(inputfile).split()[-1])
+            num_el = int(next(inputfile).split()[-1])  # noqa: F841
             num_orbs = int(next(inputfile).split()[-1])
-            total_el = int(next(inputfile).split()[-1])
-            total_orbs = int(next(inputfile).split()[-1])
+            total_el = int(next(inputfile).split()[-1])  # noqa: F841
+            total_orbs = int(next(inputfile).split()[-1])  # noqa: F841
 
             line = utils.skip_until_no_match(
                 inputfile, r"^\s*$|^Total number aux.*$|^Determined.*$"
@@ -2327,18 +2321,18 @@ Dispersion correction           -0.016199959
                 vals = next(inputfile).split()
                 # The irrep will only be printed if using symmetry.
                 if vals[0] == "Irrep":
-                    irrep_idx = int(vals[-2])
+                    irrep_idx = int(vals[-2])  # noqa: F841
                     irrep = vals[-1].strip("()")
                     vals = next(inputfile).split()
-                num_confs = int(vals[-1])
-                num_csfs = int(next(inputfile).split()[-1])
+                num_confs = int(vals[-1])  # noqa: F841
+                num_csfs = int(next(inputfile).split()[-1])  # noqa: F841
                 num_roots = int(next(inputfile).split()[-1])
                 # Parse the roots.
                 for r, line in zip(range(num_roots), inputfile):
                     reg = r"=(\d+) WEIGHT=\s*(\d\.\d+)"
                     groups = re.search(reg, line).groups()
                     root = int(groups[0])
-                    weight = float(groups[1])
+                    weight = float(groups[1])  # noqa: F841
                     assert r == root
 
             # Skip additional setup printing and CASSCF iterations.
@@ -2352,7 +2346,7 @@ Dispersion correction           -0.016199959
             #
             # Final CASSCF energy       : -14.597120777 Eh    -397.2078 eV
             self.skip_lines(inputfile, ["d", "b"])
-            casscf_energy = float(next(inputfile).split()[4])
+            casscf_energy = float(next(inputfile).split()[4])  # noqa: F841
 
             # This is only printed for first and last step of geometry optimization.
             # ----------------
@@ -2394,7 +2388,7 @@ Dispersion correction           -0.016199959
                 # The irrep will only be printed if using symmetry.
                 if groups[2] is not None:
                     irrep = groups[2].split("=")[1].strip()
-                nroots = int(groups[3].split("=")[1])
+                nroots = int(groups[3].split("=")[1])  # noqa: F841
 
                 self.skip_lines(inputfile, ["d", "b"])
 
@@ -2408,15 +2402,15 @@ Dispersion correction           -0.016199959
                         energy = float(groups[1])
                         # Excitation energies are only printed for excited state roots.
                         if groups[2] is not None:
-                            excitation_energy_ev = float(groups[2].split()[0])
-                            excitation_energy_cm = float(groups[3])
+                            excitation_energy_ev = float(groups[2].split()[0])  # noqa: F841
+                            excitation_energy_cm = float(groups[3])  # noqa: F841
                     else:
                         # Parse the occupations section.
                         reg = r"(\d+\.\d+) \[\s*(\d+)\]: (\d+)"
                         groups = re.search(reg, line).groups()
                         coeff = float(groups[0])
-                        number = float(groups[1])
-                        occupations = list(map(int, groups[2]))
+                        number = float(groups[1])  # noqa: F841
+                        occupations = list(map(int, groups[2]))  # noqa: F841
 
                     line = next(inputfile).strip()
 
@@ -2475,19 +2469,19 @@ Dispersion correction           -0.016199959
             #                                   -14.444151727
             #
             # Core energy                  :    -13.604678408 Eh     -370.2021 eV
-            one_el_energy = float(next(inputfile).split()[4])
-            two_el_energy = float(next(inputfile).split()[4])
-            nuclear_repulsion_energy = float(next(inputfile).split()[4])
+            one_el_energy = float(next(inputfile).split()[4])  # noqa: F841
+            two_el_energy = float(next(inputfile).split()[4])  # noqa: F841
+            nuclear_repulsion_energy = float(next(inputfile).split()[4])  # noqa: F841
             self.skip_line(inputfile, "dashes")
             energy = float(next(inputfile).strip())
             self.skip_line(inputfile, "blank")
-            kinetic_energy = float(next(inputfile).split()[3])
-            potential_energy = float(next(inputfile).split()[3])
-            virial_ratio = float(next(inputfile).split()[3])
+            kinetic_energy = float(next(inputfile).split()[3])  # noqa: F841
+            potential_energy = float(next(inputfile).split()[3])  # noqa: F841
+            virial_ratio = float(next(inputfile).split()[3])  # noqa: F841
             self.skip_line(inputfile, "dashes")
             energy = float(next(inputfile).strip())
             self.skip_line(inputfile, "blank")
-            core_energy = float(next(inputfile).split()[3])
+            core_energy = float(next(inputfile).split()[3])  # noqa: F841
 
         if "Program running with" in line and "parallel MPI-processes" in line:
             # ************************************************************
@@ -2678,7 +2672,6 @@ Dispersion correction           -0.016199959
             elif "SOSCF" in line:
                 diis_active = False
             elif line[0].isdigit():
-                shim = 0
                 try:
                     energy = float(line[1])
                     deltaE = float(line[2])
@@ -2701,7 +2694,7 @@ Dispersion correction           -0.016199959
                         )
                         decimal1, integer2 = decimal1_integer2[:10], decimal1_integer2[10:]
                         decimal2, integer3 = decimal2_integer3[:12], decimal2_integer3[12:]
-                        energy = float(integer1 + "." + decimal1)
+                        energy = float(integer1 + "." + decimal1)  # noqa: F841
                         deltaE = float(integer2 + "." + decimal2)
                         maxDP = float(integer3 + "." + decimal3)
                         rmsDP = float(line[2 + int(not diis_active)])
@@ -2778,7 +2771,7 @@ Dispersion correction           -0.016199959
                 break
             info = line.split()
             if len(info) > 1 and info[1] == "ITERATION":
-                dashes = next(inputfile)
+                self.skip_line(inputfile, "d")
                 energy_line = next(inputfile).split()
                 energy = float(energy_line[3])
                 deltaE_line = next(inputfile).split()

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -2059,8 +2059,10 @@ Dispersion correction           -0.016199959
         if line[:11] == "IR SPECTRUM":
             package_version = self.metadata.get("package_version", None)
             if package_version is None:
-                self.logger.warning("package_version has not been set, assuming 5.x.x")
                 package_version = "5.x.x"
+                self.logger.warning(
+                    "package_version has not been set, assuming %s", package_version
+                )
             major_version = int(package_version[0])
             if major_version <= 4:
                 self.skip_lines(inputfile, ["d", "b", "header", "d"])

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -253,7 +253,7 @@ class ORCA(logfileparser.Logfile):
                                     float(angle),
                                     float(dihedral),
                                 ]
-                            except:
+                            except:  # noqa: E722
                                 return [
                                     atom,
                                     int(a1),

--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -527,7 +527,7 @@ class ORCA(logfileparser.Logfile):
             if not hasattr(self, "scftargets"):
                 self.scftargets = []
 
-            while not "Total Energy       :" in line:
+            while "Total Energy       :" not in line:
                 line = next(inputfile)
             self.append_attribute("scfenergies", utils.float(line.split()[3]))
             if self.is_DFT:
@@ -1325,7 +1325,7 @@ Dispersion correction           -0.016199959
                         state, energy, wavelength, intensity, t2, tx, ty, tz = (
                             utils.float(x) for x in line.split()
                         )
-                    except ValueError as e:
+                    except ValueError:
                         # Must be spin forbidden and thus no intensity
                         energy = utils.float(line.split()[1])
                         intensity = 0
@@ -2787,7 +2787,7 @@ Dispersion correction           -0.016199959
         # The SCF convergence targets are always printed in this next section
         # but which targets are available depends on the SCF method in use,
         # among other things.
-        while not "Last Energy change" in line:
+        while "Last Energy change" not in line:
             line = next(inputfile)
 
         deltaE_value = float(line.split()[4])

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -567,11 +567,11 @@ class Psi4(logfileparser.Logfile):
             line = next(inputfile)
             assert line.strip() == "Final Occupation by Irrep:"
             line = next(inputfile)
-            irreps = line.split()
+            irreps = line.split()  # noqa: F841
             line = next(inputfile)
             tokens = line.split()
             assert tokens[0] == "DOCC"
-            docc = sum([int(x.replace(",", "")) for x in tokens[2:-1]])
+            docc = sum([int(x.replace(",", "")) for x in tokens[2:-1]])  # noqa: F841
             line = next(inputfile)
             if line.strip():
                 tokens = line.split()
@@ -652,15 +652,15 @@ class Psi4(logfileparser.Logfile):
                 while line.strip():
                     chomp = line.split()
                     m = len(chomp)
-                    iao = int(chomp[0])
+                    iao = int(chomp[0])  # noqa: F841
                     coeffs = [float(c) for c in chomp[m - n :]]
                     for i, c in enumerate(coeffs):
                         mocoeffs[indices[i] - 1].append(c)
                     line = next(inputfile)
 
-                energies = next(inputfile)
-                symmetries = next(inputfile)
-                occupancies = next(inputfile)
+                energies = next(inputfile)  # noqa: F841
+                symmetries = next(inputfile)  # noqa: F841
+                occupancies = next(inputfile)  # noqa: F841
 
                 self.skip_lines(inputfile, ["b", "b"])
                 indices = next(inputfile)
@@ -1040,10 +1040,10 @@ class Psi4(logfileparser.Logfile):
                 while line.strip():
                     chomp = line.split()
                     # Do nothing with this for now.
-                    atomsym = chomp[0]
+                    atomsym = chomp[0]  # noqa: F841
                     atomcoords = [float(x) for x in chomp[1:4]]
                     # Do nothing with this for now.
-                    atommass = float(chomp[4])
+                    atommass = float(chomp[4])  # noqa: F841
                     normal_mode_disps.append(atomcoords)
                     line = next(inputfile)
                 self.append_attribute("vibdisps", normal_mode_disps)

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -173,9 +173,13 @@ class Psi4(logfileparser.Logfile):
             units = tokens[2][:-2]
             assert units in ("Angstrom", "Bohr")
             if units == "Bohr":
-                convert_coords = lambda x: utils.convertor(x, "bohr", "Angstrom")
+
+                def convert_coords(x: numpy.ndarray) -> numpy.ndarray:
+                    return utils.convertor(x, "bohr", "Angstrom")
             else:
-                convert_coords = lambda x: x
+
+                def convert_coords(x: numpy.ndarray) -> numpy.ndarray:
+                    return x
 
             assert tokens[3] == "charge"
             charge = int(tokens[5].strip(","))
@@ -338,7 +342,8 @@ class Psi4(logfileparser.Logfile):
                 last_same = ngbasis - self.atomnos[:ngbasis][::-1].index(missing_atomno) - 1
                 return gbasis[last_same]
 
-            dfact = lambda n: (n <= 0) or n * dfact(n - 2)
+            def dfact(n: int) -> int:
+                return n <= 0 or n * dfact(n - 2)
 
             # Early beta versions of Psi4 normalize basis function
             # coefficients when printing.
@@ -353,7 +358,9 @@ class Psi4(logfileparser.Logfile):
                     else:
                         return norm_s
             else:
-                get_normalization_factor = lambda exp, lx, ly, lz: 1
+
+                def get_normalization_factor(exp: float, lx: int, ly: int, lz: int) -> float:
+                    return 1.0
 
             self.skip_lines(inputfile, ["b", "basisname"])
 

--- a/cclib/parser/psi4parser.py
+++ b/cclib/parser/psi4parser.py
@@ -52,7 +52,7 @@ class Psi4(logfileparser.Logfile):
         self.ccsd_t_trigger = "* CCSD(T) total energy"
 
     def after_parsing(self):
-        super(Psi4, self).after_parsing()
+        super().after_parsing()
 
         # Newer versions of Psi4 don't explicitly print the number of atoms.
         if not hasattr(self, "natom"):
@@ -80,7 +80,7 @@ class Psi4(logfileparser.Logfile):
             ["Irrep num and total size", "b", "123", "b"],
         ),
     }
-    GRADIENT_HEADERS = set([gradient_type.header for gradient_type in GRADIENT_TYPES.values()])
+    GRADIENT_HEADERS = {gradient_type.header for gradient_type in GRADIENT_TYPES.values()}
 
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -945,7 +945,7 @@ cannot be determined. Rerun without `$molecule read`."""
                     # Is this the end of the file for some reason?
                     except StopIteration:
                         self.logger.warning(
-                            f"File terminated before end of last SCF! Last error: {error}"
+                            "File terminated before end of last SCF! Last error: %f", error
                         )
                         break
 

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1752,5 +1752,5 @@ cannot be determined. Rerun without `$molecule read`."""
                 cpu_td = datetime.timedelta(seconds=float(a[-1].split("s")[0]))
                 self.metadata["wall_time"].append(wall_td)
                 self.metadata["cpu_time"].append(cpu_td)
-            except:
+            except:  # noqa: E722
                 pass

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -364,7 +364,7 @@ cannot be determined. Rerun without `$molecule read`."""
 
         # The end of the block is either a blank line or only dashes.
         while (
-            not self.re_dashes_and_spaces.search(line) and not "Warning : Irrep of orbital" in line
+            not self.re_dashes_and_spaces.search(line) and "Warning : Irrep of orbital" not in line
         ):
             if "Occupied" in line or "Virtual" in line:
                 # A nice trick to find where the HOMO is.
@@ -922,7 +922,7 @@ cannot be determined. Rerun without `$molecule read`."""
 
                 # We should have the header between dashes now,
                 # but sometimes there are lines before the first dashes.
-                while not "Cycle       Energy" in line:
+                while "Cycle       Energy" not in line:
                     line = next(inputfile)
                 self.skip_line(inputfile, "d")
 
@@ -1732,9 +1732,9 @@ cannot be determined. Rerun without `$molecule read`."""
         if line[:16] == " Total job time:":
             self.metadata["success"] = True
             # create empty list for the times to be stored in
-            if not "wall_time" in self.metadata:
+            if "wall_time" not in self.metadata:
                 self.metadata["wall_time"] = []
-            if not "cpu_time" in self.metadata:
+            if "cpu_time" not in self.metadata:
                 self.metadata["cpu_time"] = []
             # the line format is " Total job time:  120.37s(wall), 2251.02s(cpu)" at the end of each job ran.
             # first split the line by white space

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -124,7 +124,7 @@ class QChem(logfileparser.Logfile):
         ]
 
     def after_parsing(self):
-        super(QChem, self).after_parsing()
+        super().after_parsing()
 
         # If parsing a fragment job, each of the geometries appended to
         # `atomcoords` may be of different lengths, which will prevent
@@ -597,7 +597,7 @@ cannot be determined. Rerun without `$molecule read`."""
                         if line.split()[0].lower() == "read":
                             pass
                         else:
-                            charge, mult = [int(x) for x in line.split()]
+                            charge, mult = (int(x) for x in line.split())
                             self.user_input["molecule"]["charge"] = charge
                             self.user_input["molecule"]["mult"] = mult
 

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -786,9 +786,13 @@ cannot be determined. Rerun without `$molecule read`."""
             # Extract the atomic numbers and coordinates of the atoms.
             if "Standard Nuclear Orientation" in line:
                 if "Angstroms" in line:
-                    convertor = lambda x: x
+
+                    def convertor(x: float) -> float:
+                        return x
                 elif "Bohr" in line:
-                    convertor = lambda x: utils.convertor(x, "bohr", "Angstrom")
+
+                    def convertor(x: float) -> float:
+                        return utils.convertor(x, "bohr", "Angstrom")
                 else:
                     raise ValueError(f"Unknown units in coordinate header: {line}")
                 self.skip_lines(inputfile, ["cols", "dashes"])

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -372,7 +372,7 @@ class Turbomole(logfileparser.Logfile):
                 # Check we won't loose information converting to int.
                 if total_charge != total_charge_int:
                     self.logger.warning(
-                        f"Converting non integer total charge '{total_charge}' to integer"
+                        "Converting non integer total charge '%f' to integer", total_charge
                     )
 
                 # Set regardless.

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -1533,9 +1533,9 @@ class OldTurbomole(logfileparser.Logfile):
                 list.append(int(f) - 1)
         return list
 
-    def normalisesym(self, label):
+    def normalisesym(self, symlabel: str) -> str:
         """Normalise the symmetries used by Turbomole."""
-        return ans
+        return symlabel
 
     def before_parsing(self):
         self.geoopt = False  # Is this a GeoOpt? Needed for SCF targets/values.

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -26,7 +26,6 @@ class AtomBasis:
         self.parse_basis(inputfile)
 
     def parse_basis(self, inputfile):
-        i = 0
         line = next(inputfile)
 
         while line[0] != "*":
@@ -1567,7 +1566,7 @@ class OldTurbomole(logfileparser.Logfile):
             self.nmo = nmo
         if line[3:9] == "nshell":
             temp = line.split("=")
-            homos = int(temp[1])
+            homos = int(temp[1])  # noqa: F841
 
         if line[0:6] == "$basis":
             print("Found basis")
@@ -1838,7 +1837,7 @@ class OldTurbomole(logfileparser.Logfile):
                 while title[0] != "$":
                     temp = title.split()
 
-                    orb_symm = temp[1]
+                    orb_symm = temp[1]  # noqa: F841
 
                     try:
                         energy = float(temp[2][11:].replace("D", "E"))

--- a/cclib/parser/turbomoleparser.py
+++ b/cclib/parser/turbomoleparser.py
@@ -2,19 +2,18 @@
 #
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
-from datetime import timedelta
-
-import scipy.constants
 
 """Parser for Turbomole output files."""
 
 import re
 import typing
+from datetime import timedelta
 from pathlib import Path
 
 from cclib.parser import data, logfileparser, utils
 
 import numpy
+import scipy.constants
 
 
 class AtomBasis:

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -8,7 +8,7 @@
 import re
 from itertools import accumulate
 from math import sqrt
-from typing import Iterable, List, Sequence, TypeVar
+from typing import List, Sequence
 
 import numpy
 import periodictable

--- a/cclib/progress/__init__.py
+++ b/cclib/progress/__init__.py
@@ -3,6 +3,7 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
+# ruff: noqa: F401
 import sys
 
 from cclib.progress.textprogress import TextProgress

--- a/cclib/scripts/__init__.py
+++ b/cclib/scripts/__init__.py
@@ -3,4 +3,5 @@
 # This file is part of cclib (http://cclib.github.io) and is distributed under
 # the terms of the BSD 3-Clause License.
 
+# ruff: noqa: F401
 from . import ccframe, ccget, ccwrite, cda

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -15,9 +15,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-import sys
-
 
 # this adds the styling ccs to increase the content max width
 # previously there was a large blank space on the right side of the screen

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -261,6 +261,6 @@ context = {
 }
 
 if "html_context" in globals():
-    html_context.update(context)
+    html_context.update(context)  # noqa: F821
 else:
     html_context = context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,13 @@ sections = ["FUTURE", "STDLIB", "FIRSTPARTY", "THIRDPARTY", "LOCALFOLDER"]
 [tool.ruff]
 line-length = 100
 src = ["cclib"]
+target-version = "py37"
 
 [tool.ruff.format]
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-select = []
+
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,6 +5,7 @@
 
 """Unit tests and parser data tests for cclib."""
 
+# ruff: noqa: F401
 from test import test_data
 
-from .data import *
+from .data import *  # noqa: F403

--- a/test/bridge/testopenbabel.py
+++ b/test/bridge/testopenbabel.py
@@ -26,6 +26,7 @@ class OpenbabelTest:
         obmol = cclib2openbabel.makeopenbabel(atomcoords=atomcoords, atomnos=atomnos)
         obconversion = openbabel.OBConversion()
         formatok = obconversion.SetOutFormat("inchi")
+        assert formatok
         assert obconversion.WriteString(obmol).strip() == "InChI=1S/H2O/h1H2"
 
     def test_makeopenbabel_and_makecclib(self) -> None:

--- a/test/data/testMP.py
+++ b/test/data/testMP.py
@@ -57,7 +57,7 @@ class GaussianMP2Test(GenericMP2Test):
         """Are natural orbital coefficients the right size?"""
         assert data.nocoeffs.shape == (data.nmo, data.nbasis)
 
-    def testnocoeffs(self, data) -> None:
+    def testnooccnos(self, data) -> None:
         """Are natural orbital occupation numbers the right size?"""
         assert data.nooccnos.shape == (data.nmo,)
 

--- a/test/data/testNMR.py
+++ b/test/data/testNMR.py
@@ -14,7 +14,7 @@ class GenericNMRTest:
 
     def testkeys(self, data) -> None:
         """Check dictionary keys are ints."""
-        key_types = set([type(key) for key in data.nmrtensors.keys()])
+        key_types = {type(key) for key in data.nmrtensors.keys()}
         assert len(key_types) == 1 and int in key_types
 
     def testsize(self, data) -> None:
@@ -41,12 +41,10 @@ class GenericNMRCouplingTest:
     def testkeys(self, data) -> None:
         """Check dictionary keys are ints."""
         assert all(
-            set(
-                [
-                    all((type(key[0]) == int, type(key[1]) == int))
-                    for key in data.nmrcouplingtensors.keys()
-                ]
-            )
+            {
+                all((type(key[0]) == int, type(key[1]) == int))
+                for key in data.nmrcouplingtensors.keys()
+            }
         )
 
         assert all(

--- a/test/data/testNMR.py
+++ b/test/data/testNMR.py
@@ -28,9 +28,8 @@ class GenericNMRTest:
         tensor = data.nmrtensors[0]
         total = 0.0
         for t_type in ("diamagnetic", "paramagnetic"):
-            total += sum(numpy.linalg.eigvals(tensor[t_type])) / len(
-                numpy.linalg.eigvals(tensor[t_type])
-            )
+            eigvals = numpy.linalg.eigvals(tensor[t_type])
+            total += numpy.mean(eigvals)
 
         assert total == pytest.approx(tensor["isotropic"], abs=3)
 
@@ -74,8 +73,7 @@ class GenericNMRCouplingTest:
             "spin-dipolar",
             "spin-dipolar-fermi",
         ):
-            total += sum(numpy.linalg.eigvals(tensor[t_type])) / len(
-                numpy.linalg.eigvals(tensor[t_type])
-            )
+            eigvals = numpy.linalg.eigvals(tensor[t_type])
+            total += numpy.mean(eigvals)
 
         assert total == pytest.approx(tensor["isotropic"], abs=3)

--- a/test/data/testNMR.py
+++ b/test/data/testNMR.py
@@ -42,14 +42,14 @@ class GenericNMRCouplingTest:
         """Check dictionary keys are ints."""
         assert all(
             {
-                all((type(key[0]) == int, type(key[1]) == int))
+                all((isinstance(key[0], int), isinstance(key[1], int)))
                 for key in data.nmrcouplingtensors.keys()
             }
         )
 
         assert all(
             [
-                all((type(isotopekey[0]) == int, type(isotopekey[1]) == int))
+                all((isinstance(isotopekey[0], int), isinstance(isotopekey[1], int)))
                 for isotopes in data.nmrcouplingtensors.values()
                 for isotopekey in isotopes.keys()
             ]

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -42,7 +42,7 @@ class DDEC6Test:
             vol = volume.Volume((-4, -4, -4), (4, 4, 4), (0.2, 0.2, 0.2))
             delattr(self.data, missing_attribute)
             with pytest.raises(MissingAttributeError):
-                trial = DDEC6(self.data, vol, os.path.dirname(os.path.realpath(__file__)))
+                trial = DDEC6(self.data, vol, os.path.dirname(os.path.realpath(__file__)))  # noqa: F841
 
     def test_proatom_read(self) -> None:
         """Are proatom densities imported correctly?"""
@@ -59,7 +59,7 @@ class DDEC6Test:
             2.66407612e-01,
             2.66407322e-01,
         ]  # Hydrogen first five densities
-        refH_r = [
+        refH_r = [  # noqa: F841
             1.17745807e-07,
             4.05209491e-06,
             3.21078677e-05,
@@ -73,7 +73,7 @@ class DDEC6Test:
             2.98258487e02,
             2.98258290e02,
         ]  # Oxygen first five densities
-        refO_r = [
+        refO_r = [  # noqa: F841
             5.70916728e-09,
             1.97130512e-07,
             1.56506399e-06,

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -35,7 +35,7 @@ class HirshfeldTest:
             self.parse()
             delattr(self.data, missing_attribute)
             with pytest.raises(MissingAttributeError):
-                trialBader = Hirshfeld(
+                trialBader = Hirshfeld(  # noqa: F841
                     self.data, self.volume, os.path.dirname(os.path.realpath(__file__))
                 )
 
@@ -54,7 +54,7 @@ class HirshfeldTest:
             2.66407612e-01,
             2.66407322e-01,
         ]  # Hydrogen first five densities
-        refH_r = [
+        refH_r = [  # noqa: F841
             1.17745807e-07,
             4.05209491e-06,
             3.21078677e-05,
@@ -68,7 +68,7 @@ class HirshfeldTest:
             2.98258487e02,
             2.98258290e02,
         ]  # Oxygen first five densities
-        refO_r = [
+        refO_r = [  # noqa: F841
             5.70916728e-09,
             1.97130512e-07,
             1.56506399e-06,

--- a/test/method/testvolume.py
+++ b/test/method/testvolume.py
@@ -5,7 +5,6 @@
 
 """Test the Volume and related methods in cclib"""
 
-import os
 import sys
 from pathlib import Path
 

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -66,10 +66,15 @@ class FileWrapperTest:
             "data/ADF/basicADF2007.01/dvb_gopt.adfout",
             "data/GAMESS/basicGAMESS-US2017/C_bigbasis.out",
         ]
-        get_attributes = lambda data: [a for a in data._attrlist if hasattr(data, a)]
+
+        def get_attributes(data):
+            return [a for a in data._attrlist if hasattr(data, a)]
+
         for lf in logfiles:
             path = f"{__datadir__}/{lf}"
-            expected_attributes = get_attributes(cclib.io.ccread(path))
+            data = cclib.io.ccread(path)
+            assert data is not None
+            expected_attributes = get_attributes(data)
             with open(path) as handle:
                 contents = handle.read()
 
@@ -78,6 +83,7 @@ class FileWrapperTest:
             monkeypatch.setattr("sys.stdin", io.StringIO(contents))
 
             data = cclib.io.ccread(sys.stdin)
+            assert data is not None
             assert get_attributes(data) == expected_attributes
 
 

--- a/test/parser/testlogfileparser.py
+++ b/test/parser/testlogfileparser.py
@@ -37,7 +37,7 @@ class FileWrapperTest:
     def test_file_seek(self):
         """Can we seek anywhere in a file object?"""
         fpath = os.path.join(__datadir__, "data/ADF/basicADF2007.01/dvb_gopt.adfout")
-        with open(fpath, "r") as fobject:
+        with open(fpath) as fobject:
             wrapper = cclib.parser.logfileparser.FileWrapper(fobject)
             self.check_seek(wrapper)
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -2032,9 +2032,9 @@ def testQChem_QChem4_2_CH3___Na__RS_out(logfile):
     assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
-    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
+    assert isinstance(logfile.data.moenergies[1], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
@@ -2065,9 +2065,9 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_out(logfile):
     assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
-    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
+    assert isinstance(logfile.data.moenergies[1], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CH4___Na__out(logfile):
@@ -2095,8 +2095,8 @@ def testQChem_QChem4_2_CH4___Na__out(logfile):
 
     assert logfile.data.nbasis == logfile.data.nmo == 42
     assert len(logfile.data.moenergies[0]) == 42
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
@@ -2126,9 +2126,9 @@ def testQChem_QChem4_2_CH3___Na__RS_SCF_noprint_out(logfile):
     assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
-    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
+    assert isinstance(logfile.data.moenergies[1], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CH3___Na__RS_noprint_out(logfile):
@@ -2156,9 +2156,9 @@ def testQChem_QChem4_2_CH3___Na__RS_noprint_out(logfile):
     assert logfile.data.nbasis == logfile.data.nmo == 40
     assert len(logfile.data.moenergies[0]) == 40
     assert len(logfile.data.moenergies[1]) == 40
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
-    assert type(logfile.data.moenergies[1]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
+    assert isinstance(logfile.data.moenergies[1], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CH4___Na__noprint_out(logfile):
@@ -2183,8 +2183,8 @@ def testQChem_QChem4_2_CH4___Na__noprint_out(logfile):
 
     assert logfile.data.nbasis == logfile.data.nmo == 42
     assert len(logfile.data.moenergies[0]) == 42
-    assert type(logfile.data.moenergies) == type([])
-    assert type(logfile.data.moenergies[0]) == type(numpy.array([]))
+    assert isinstance(logfile.data.moenergies, list)
+    assert isinstance(logfile.data.moenergies[0], numpy.ndarray)
 
 
 def testQChem_QChem4_2_CO2_out(logfile):

--- a/test/regression.py
+++ b/test/regression.py
@@ -3132,12 +3132,6 @@ class JaguarSPTest_nmo45(JaguarSPTest_noatomcharges):
         """atombasis was not parsed correctly here."""
 
 
-class JaguarGeoOptTest_nmo45(GenericGeoOptTest):
-    def testlengthmoenergies(self, data: "ccData") -> None:
-        """Without special options, Jaguar only print Homo+10 orbital energies."""
-        assert len(data.moenergies[0]) == 45
-
-
 class JaguarGeoOptTest_6_31gss(GenericGeoOptTest):
     nbasisdict = {1: 5, 6: 15}
     scfenergy = -387.064207

--- a/test/regression.py
+++ b/test/regression.py
@@ -31,6 +31,7 @@ inside the data directory, like so:
     python -m pytest test/regression.py -k 'Gaussian_Gaussian03_borane_opt_log'
 """
 
+# ruff: noqa: E402, F401
 import datetime
 import logging
 import sys


### PR DESCRIPTION
Closes #1313

This now runs clean, and enforces a lot of default flake8 and pylint checks using ruff.
```diff
diff --git pyproject.toml pyproject.toml
index 837c3b4c..afa3293b 100644
--- pyproject.toml
+++ pyproject.toml
@@ -86,13 +86,11 @@ sections = ["FUTURE", "STDLIB", "FIRSTPARTY", "THIRDPARTY", "LOCALFOLDER"]
 [tool.ruff]
 line-length = 100
 src = ["cclib"]
+target-version = "py37"

 [tool.ruff.format]
 skip-magic-trailing-comma = true

-[tool.ruff.lint]
-select = []
-
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 section-order = ["future", "standard-library", "first-party", "third-party", "local-folder"]
```

Most of the `noqa` ignores are for unused variables that contain data we may want to parse in the future.  Some of the unused variables I was able to either delete or, if they were the result of a `next(inputfile)`, convert that into a `skip_line` or `skip_lines` call.

Despite the name of the branch, I decided to hold off on combining more type annotations into this PR.


I'll add commit hashes to `.git-blame-ignore-revs` in a followup PR for both the lint fixes and the type annotations.