### PR TITLE
unpin versioningit upper bound

### DIFF
--- a/.github/workflows/test_and_package.yml
+++ b/.github/workflows/test_and_package.yml
@@ -44,7 +44,7 @@ jobs:
           git config --global --add safe.directory /__w/cclib/cclib
       - name: Prepare conda environment
         run: |
-          echo "/opt/conda/envs/cclib/bin" >> $GITHUB_PATH
+          echo "/opt/conda/envs/cclib/bin" >> "${GITHUB_PATH}"
       - name: Install cclib
         run: |
           python -m pip install .
@@ -102,6 +102,7 @@ jobs:
       matrix:
         install-method: [wheel, source]
         python-version:
+          - 3.7
           - 3.8
           - 3.9
           - "3.10"

--- a/cclib/bridge/cclib2openbabel.py
+++ b/cclib/bridge/cclib2openbabel.py
@@ -27,7 +27,7 @@ def _check_openbabel(found_openbabel: bool) -> None:
         raise ImportError("You must install `openbabel` to use this function")
 
 
-def makecclib(mol: ob.OBMol) -> ccData:
+def makecclib(mol: "ob.OBMol") -> ccData:
     """Create cclib attributes and return a ccData from an OpenBabel molecule.
 
     Beyond the numbers, masses and coordinates, we could also set the total charge
@@ -50,7 +50,7 @@ def makeopenbabel(
     atomnos: Optional[np.ndarray] = None,
     charge: int = 0,
     mult: int = 1,
-) -> ob.OBMol:
+) -> "ob.OBMol":
     """Create an Open Babel molecule."""
     _check_openbabel(_found_openbabel)
     if atomcoords is None and atomnos is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = ["cclib[bridges,docs,test]"]
 all = ["cclib[bridges]"]
 
 [build-system]
-requires = ["setuptools >= 61.0", "versioningit~=2.0"]
+requires = ["setuptools >= 61.0", "versioningit>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ test = [
     "pytest",
     "coverage",
     "pytest-cov",
+    "pyyaml",
 ]
 dev = ["cclib[bridges,docs,test]"]
 all = ["cclib[bridges]"]


### PR DESCRIPTION
Closes #1444

I'm not sure this is strictly necessary for the issue, but I don't see a problem with doing it.

This also has a smoke test ensuring the code still runs on Python 3.7.

```
[eric@osmium]$ python -m pip install -v .
Using pip 24.0 from /tmp/cclib/venv/lib/python3.12/site-packages/pip (python 3.12)
Processing /tmp/cclib
  Running command pip subprocess to install build dependencies
  Collecting setuptools>=61.0
    Using cached setuptools-70.1.0-py3-none-any.whl.metadata (6.0 kB)
  Collecting versioningit>=2.0
    Using cached versioningit-3.1.1-py3-none-any.whl.metadata (9.5 kB)
...
  Created wheel for cclib: filename=cclib-1.8.1.post192+077a1995-py3-none-any.whl size=354461 sha256=b95843af90e0a6e498f3fe6d2a70d438827e42a7518ca885738783a62621c331
  Stored in directory: /tmp/pip-ephem-wheel-cache-7s3ugsi2/wheels/9b/38/ca/7d486a815902fb50f9118029beb563f9dad72e12d84ea85e3e
Successfully built cclib
Installing collected packages: pyparsing, packaging, numpy, scipy, periodictable, cclib
  changing mode of /tmp/cclib/venv/bin/f2py to 755
  changing mode of /tmp/cclib/venv/bin/numpy-config to 755
  changing mode of /tmp/cclib/venv/bin/ccframe to 755
  changing mode of /tmp/cclib/venv/bin/ccget to 755
  changing mode of /tmp/cclib/venv/bin/ccwrite to 755
  changing mode of /tmp/cclib/venv/bin/cda to 755
Successfully installed cclib-1.8.1.post192+077a1995 numpy-2.0.0 packaging-24.1 periodictable-1.7.0 pyparsing-3.1.2 scipy-1.13.1
```