### PR TITLE
Add a section for `optstatus` to the "Parsed data notes" page

### DIFF
--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -517,7 +517,7 @@ optstatus
 ---------
 
 A list of integers representing the status of each step in an optimisation. The possible optimisation statuses are defined in bit value notation to allow for coding for multiple states and are given by:
-    
+
     * ``OPT_UNKNOWN = 0b000 = 0`` is the default and means optimisation is in progress.
     * ``OPT_NEW = 0b001 = 1`` is set for every new optimisation (e.g. PES, IRCs, etc.)
     * ``OPT_DONE = 0b010 = 2`` is set for the last step of an optimisation that converged.

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -513,6 +513,18 @@ optdone
 
 A list that indexes which elements of `atomcoords`_ represent converged geometries.
 
+optstatus
+---------
+
+A list of integers representing the status of each step in an optimisation. The possible optimisation statuses are defined in bit value notation to allow for coding for multiple states and are given by:
+    
+    * ``OPT_UNKNOWN = 0b000 = 0`` is the default and means optimisation is in progress.
+    * ``OPT_NEW = 0b001 = 1`` is set for every new optimisation (e.g. PES, IRCs, etc.)
+    * ``OPT_DONE = 0b010 = 2`` is set for the last step of an optimisation that converged.
+    * ``OPT_UNCONVERGED = 0b100 = 4`` is set for every unconverged step (e.g. should be mutually exclusive with ``OPT_DONE``)
+
+So, to robustly check if step `i` has converged, one should check ``data.optstatus[i] & OPT_DONE`` instead of ``data.optstatus[i] == OPT_DONE``.
+
 scancoords
 ----------
 

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -523,7 +523,7 @@ A list of integers representing the status of each step in an optimisation. The 
     * ``OPT_DONE = 0b010 = 2`` is set for the last step of an optimisation that converged.
     * ``OPT_UNCONVERGED = 0b100 = 4`` is set for every unconverged step (e.g. should be mutually exclusive with ``OPT_DONE``)
 
-So, to robustly check if step `i` has converged, one should check ``data.optstatus[i] & OPT_DONE`` instead of ``data.optstatus[i] == OPT_DONE``.
+So, to robustly check if step ``i`` has converged, one should check ``data.optstatus[i] & OPT_DONE`` instead of ``data.optstatus[i] == OPT_DONE``.
 
 scancoords
 ----------


### PR DESCRIPTION

Addresses #1455

The hyperlink reference created by `attributes.py` for `optstatus`:

https://github.com/cclib/cclib/blob/9dfad1a1df488d63b2afb314218e6f1fecf8e773/doc/sphinx/attributes.py#L93-L94

redirects to the top of the "Parsed data notes" webpage instead of the `optstatus` heading. Looks like this is because the target is the nonexistent heading for `optstatus` in `data_notes.rst`. Adding a section for `optstatus` should solve this problem.