### PR TITLE
Add citation details for new paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ See https://github.com/cclib/cclib/issues/1395 for more information.
 - We do not expect to make any further tagged or versioned releases on the `master` branch.
 - This message will disappear when the final release of 2.0, after any alphas/release candidates/etc. is made.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8280878.svg)](https://doi.org/10.5281/zenodo.8280878)
+[![Paper](https://zenodo.org/badge/DOI/10.1063/5.0216778.svg)](https://doi.org/10.1063/5.0216778)
+[![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.8280878.svg)](https://doi.org/10.5281/zenodo.8280878)
 [![PyPI version](http://img.shields.io/pypi/v/cclib.svg?style=flat)](https://pypi.python.org/pypi/cclib)
 [![GitHub release](https://img.shields.io/github/release/cclib/cclib.svg?style=flat)](https://github.com/cclib/cclib/releases)
 [![build status](https://github.com/cclib/cclib/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/cclib/cclib/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See https://github.com/cclib/cclib/issues/1395 for more information.
 - We do not expect to make any further tagged or versioned releases on the `master` branch.
 - This message will disappear when the final release of 2.0, after any alphas/release candidates/etc. is made.
 
-[![Paper](https://zenodo.org/badge/DOI/10.1063/5.0216778.svg)](https://doi.org/10.1063/5.0216778)
+[![Paper](https://img.shields.io/badge/Paper-10.1063/5.0216778-blue)](https://doi.org/10.1063/5.0216778)
 [![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.8280878.svg)](https://doi.org/10.5281/zenodo.8280878)
 [![PyPI version](http://img.shields.io/pypi/v/cclib.svg?style=flat)](https://pypi.python.org/pypi/cclib)
 [![GitHub release](https://img.shields.io/github/release/cclib/cclib.svg?style=flat)](https://github.com/cclib/cclib/releases)

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -51,7 +51,7 @@ The code behind cclib was started as a collaboration between Noel O'Boyle, Adam 
 
 If you use cclib (version 2.0+) in your scientific work, please support our work by adding a reference to the following article:
 
-|           E\. Berquist, A\.Dumi, S\. Upadhyay, O\.D\. Abarbanel, M\. Cho, S\. Gaur, V\. Hugo Cano Gil, G\.R\. Hutchinson, O\.S\. Lee, A\.S\. Rosen, S\. Schamnad, F\.S\.S Schneider, C\. Steinmann, M\. Stolyarchuk, J\.E\. Vandezande, W\. Zak, K\.M\. Langner, *cclib 2.0: An updated architecture for interoperable computational chemistry*, J. Chem. Phys. 161, 042501, **2024** (DOI_).
+|           E\. Berquist, A\. Dumi, S\. Upadhyay, O\. D\. Abarbanel, M\. Cho, S\. Gaur, V\. Hugo Cano Gil, G\. R\. Hutchinson, O\. S\. Lee, A\. S\. Rosen, S\. Schamnad, F\. S\. S\. Schneider, C\. Steinmann, M\. Stolyarchuk, J\. E\. Vandezande, W\. Zak, K\. M\. Langner, *cclib 2.0: An updated architecture for interoperable computational chemistry*, J. Chem. Phys. 161, 042501, **2024** (DOI_).
 |
 
 An older reference for version 1.x is also available:

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -49,9 +49,14 @@ About cclib
 
 The code behind cclib was started as a collaboration between Noel O'Boyle, Adam Tenderholt and Karol M. Langner (see page about Development_ for details) and is licensed under the `BSD 3-clause license`_. Other developers are encouraged to contribute to this open source project -- send an email to the `mailing list`_. Applications that use cclib include GaussSum_ and QMForge_. It has also been used in the literature_.
 
-If you use cclib in your scientific work, please support our work by adding a reference to the following article:
+If you use cclib (version 2.0+) in your scientific work, please support our work by adding a reference to the following article:
 
-|           N\. M\. O'Boyle, A\. L\. Tenderholt, K\. M\. Langner, *cclib: a library for package-independent computational chemistry algorithms*, J. Comp. Chem. 29 (5), pp. 839-845, **2008** (DOI_).
+|           E\. Berquist, A\.Dumi, S\. Upadhyay, O\.D\. Abarbanel, M\. Cho, S\. Gaur, V\. Hugo Cano Gil, G\.R\. Hutchinson, O\.S\. Lee, A\.S\. Rosen, S\. Schamnad, F\.S\.S Schneider, C\. Steinmann, M\. Stolyarchuk, J\.E\. Vandezande, W\. Zak, K\.M\. Langner, *cclib 2.0: An updated architecture for interoperable computational chemistry*, J. Chem. Phys. 161, 042501, **2024** (DOI_).
+|
+
+An older reference for version 1.x is also available:
+
+|           N\. M\. O'Boyle, A\. L\. Tenderholt, K\. M\. Langner, *cclib: a library for package-independent computational chemistry algorithms*, J. Comp. Chem. 29 (5), pp. 839-845, **2008** (DOI-old_).
 |
 
 A record for the latest release is also available on Zenodo_.
@@ -93,5 +98,6 @@ A record for the latest release is also available on Zenodo_.
 .. _GaussSum: http://gausssum.sourceforge.net/
 .. _QMForge: https://qmforge.net/
 .. _literature: https://doi.org/10.1021/jacs.5b05600
-.. _DOI: https://doi.org/10.1002/jcc.20823
+.. _DOI: https://doi.org/10.1063/5.0216778
+.. _DOI-old: https://doi.org/10.1002/jcc.20823
 .. _Zenodo: https://zenodo.org/record/8280878


### PR DESCRIPTION
This PR adds citation details for the new JCP paper. I added it to the docs as well as a badge to the README. In principle, one could also add a `citation.cff` file, but I didn't want to bother with that.

Note that I have this PR set to merge into `main`. Let me know if you'd like that to be `master` instead.