### PR TITLE
Fix parsing of elements in xtb parser

### DIFF
--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -434,10 +434,10 @@ def _extract_symbol_coords(line: str, mode: str) -> Optional[Tuple[str, List[flo
     """
     line_split = line.split()
     if mode == "xyz":
-        if line_split[0].isupper():
+        if line_split[0].istitle():
             return line_split[0], [float(coord) for coord in line_split[1:]]
     elif mode in {"mol", "sdf"}:
-        if line_split[3].isupper():
+        if line_split[3].istitle():
             return line_split[3], [float(coord) for coord in line_split[:3]]
     else:
         raise ValueError(f"Unsupported coordinate file type: {mode}")


### PR DESCRIPTION
Closes https://github.com/cclib/cclib/issues/1448 by fixing the parsing of double-letter element names.

Naturally, a test should be added, but I don't have the capacity to do so at this time. Any external help would be greatly appreciated!