### PR TITLE
Fix Nix build and add to CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,6 +24,7 @@ jobs:
           name: nix-qchem
       # Checkout of the current head in the working dir
       - uses: actions/checkout@v4
-      # Build the nix package
-      - name: Build nix package
+      - name: Check nix flake
         run: nix flake check -L
+      - name: Build nix package
+        run: nix build -L

--- a/nix/cclib.nix
+++ b/nix/cclib.nix
@@ -67,6 +67,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Parsers and algorithms for computational chemistry logfiles";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ sheepforce ];
+    maintainers = with maintainers; [ berquist sheepforce ];
   };
 }

--- a/nix/cclib.nix
+++ b/nix/cclib.nix
@@ -25,11 +25,19 @@ buildPythonPackage rec {
 
   pyproject = true;
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  postPatch = ''
+    # Upstream uses versioningit to set the version
+    sed -i "/versioningit>=/d" pyproject.toml
+    sed -i '/^name =.*/a version = "${version}"' pyproject.toml
+    sed -i "/dynamic =/d" pyproject.toml
+    echo '__version__ = "${version}"' > cclib/_version.py
+  '';
+
+  dependencies = [
     numpy
     scipy
     periodictable
@@ -47,14 +55,17 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
+  pythonImportsCheck = [ "cclib" ];
+
   disabledTests = [
-    "test_url_io"
+    "test_ccread_url"
     "test_multi_url_io"
+    "test_url_io"
     "test_url_seek"
   ];
 
   meta = with lib; {
-    description = "Parsers and algorithms for computational chemistry logfiles ";
+    description = "Parsers and algorithms for computational chemistry logfiles";
     license = licenses.bsd3;
     maintainers = with maintainers; [ sheepforce ];
   };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,10 @@ dev = ["cclib[bridges,docs,test]"]
 all = ["cclib[bridges]"]
 
 [build-system]
-requires = ["setuptools >= 61.0", "versioningit>=2.0"]
+requires = [
+    "setuptools>=61.0",
+    "versioningit>=2.0",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Part of https://github.com/cclib/cclib/issues/1460

There is not a universal way of dealing with `versioningit` in Nixpkgs, but it seems like a common solution is to bypass it altogether, so I combined https://github.com/NixOS/nixpkgs/blob/0d8f17feeaf68d76bc7ffe69be358e9f01b81c93/pkgs/development/python-modules/scramp/default.nix#L39 with the idea from https://github.com/NixOS/nixpkgs/blob/0d8f17feeaf68d76bc7ffe69be358e9f01b81c93/pkgs/development/python-modules/limits/default.nix#L53.

Waiting to update the flake lockfile until the `gau2grid` part of https://github.com/Nix-QChem/NixOS-QChem/issues/513 is resolved, which it sounds like they've already started on.