### PR TITLE
start psi4 moments attribute parser, turn on tests

### DIFF
--- a/cclib/attribute_parsers/__init__.py
+++ b/cclib/attribute_parsers/__init__.py
@@ -26,7 +26,7 @@ from cclib.attribute_parsers.mult import mult
 from cclib.attribute_parsers.natom import natom
 from cclib.attribute_parsers.nbasis import nbasis
 from cclib.attribute_parsers.nmo import nmo
-from cclib.attribute_parsers.parser_metadata import parser_metadata
+from cclib.attribute_parsers.parser_state import parser_state
 from cclib.attribute_parsers.scfenergies import scfenergies
 from cclib.attribute_parsers.scftargets import scftargets
 from cclib.attribute_parsers.scfvalues import scfvalues

--- a/cclib/attribute_parsers/__init__.py
+++ b/cclib/attribute_parsers/__init__.py
@@ -26,6 +26,7 @@ from cclib.attribute_parsers.mult import mult
 from cclib.attribute_parsers.natom import natom
 from cclib.attribute_parsers.nbasis import nbasis
 from cclib.attribute_parsers.nmo import nmo
+from cclib.attribute_parsers.parser_metadata import parser_metadata
 from cclib.attribute_parsers.scfenergies import scfenergies
 from cclib.attribute_parsers.scftargets import scftargets
 from cclib.attribute_parsers.scfvalues import scfvalues

--- a/cclib/attribute_parsers/__init__.py
+++ b/cclib/attribute_parsers/__init__.py
@@ -19,6 +19,7 @@ from cclib.attribute_parsers.dispersionenergies import dispersionenergies
 from cclib.attribute_parsers.gbasis import gbasis
 from cclib.attribute_parsers.mocoeffs import mocoeffs
 from cclib.attribute_parsers.moenergies import moenergies
+from cclib.attribute_parsers.moments import moments
 from cclib.attribute_parsers.mosyms import mosyms
 from cclib.attribute_parsers.mpenergies import mpenergies
 from cclib.attribute_parsers.mult import mult

--- a/cclib/attribute_parsers/data.py
+++ b/cclib/attribute_parsers/data.py
@@ -138,7 +138,7 @@ class ccData:
         """
 
         self._parsed_attributes = dict()
-        self.parser_metadata = dict()
+        self.parser_state = dict()
 
         if attributes:
             self.setattributes(attributes)

--- a/cclib/attribute_parsers/data.py
+++ b/cclib/attribute_parsers/data.py
@@ -138,6 +138,7 @@ class ccData:
         """
 
         self._parsed_attributes = dict()
+        self.parser_metadata = dict()
 
         if attributes:
             self.setattributes(attributes)

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+from typing import Optional
+
+from cclib.attribute_parsers import utils
+from cclib.attribute_parsers.base_parser import base_parser
+
+import numpy
+
+
+class moments(base_parser):
+    """
+    Docstring? Units?
+    """
+
+    known_codes = ["psi4"]
+
+    @staticmethod
+    def psi4(file_handler, ccdata) -> Optional[dict]:
+        line = file_handler.last_line
+        if line.strip() == "Dipole Moment: (a.u.)":
+            line = file_handler.virtual_next()
+            tokens = line.split()
+            dipole = utils.convertor(
+                numpy.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]),
+                "ebohr",
+                "Debye",
+            )
+
+            # AED: I don't know how to handle this in version 2 yet
+            # this line below is an ugly fix to always assume the origin is at zero until i figure it out.
+
+            origin = numpy.array([0.0, 0.0, 0.0])
+            if getattr(ccdata, "moments") is None:
+                # Old versions of Psi4 don't print the origin; assume
+                # it's at zero.
+                if getattr(ccdata, "origin") is None:
+                    # AED: I don't know how to handle this in version 2 yet
+                    origin = numpy.array([0.0, 0.0, 0.0])
+                return {moments.__name__: [origin, dipole]}
+            else:
+                try:
+                    assert numpy.all(ccdata.moments[1] == dipole)
+                except AssertionError:
+                    return {moments.__name__: [origin, dipole]}
+        return None
+
+    @staticmethod
+    def parse(file_handler, program: str, ccdata) -> Optional[dict]:
+        constructed_data = None
+        if program in moments.known_codes:
+            file_handler.virtual_set()
+            program_parser = getattr(moments, program)
+            constructed_data = program_parser(file_handler, ccdata)
+            file_handler.virtual_reset()
+        return constructed_data

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -19,77 +19,70 @@ class moments(base_parser):
 
     @staticmethod
     def psi4(file_handler, ccdata) -> Optional[dict]:
-        dependency_list = ["parser_metadata['origin']"]
         line = file_handler.last_line
         if line.strip() == "Dipole Moment: (a.u.)":
-            print("found dipole line")
-            if base_parser.check_dependencies(dependency_list, ccdata, "moments"):
-                line = file_handler.virtual_next()
-                tokens = line.split()
-                dipole = utils.convertor(
-                    np.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]),
-                    "ebohr",
-                    "Debye",
-                )
+            line = file_handler.virtual_next()
+            tokens = line.split()
+            dipole = utils.convertor(
+                np.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]), "ebohr", "Debye"
+            )
 
-                # AED: I don't know how to handle this in version 2 yet
-                # this line below is an ugly fix to always assume the origin is at zero until i figure it out.
-                if getattr(ccdata, "moments") is None:
-                    # Old versions of Psi4 don't print the origin; assume
-                    # it's at zero.
-                    if "origin" in ccdata.parser_metadata:
-                        # AED: I don't know how to handle this in version 2 yet
-                        origin = ccdata.parser_metadata["origin"]
-                    else:
-                        origin = np.array([0.0, 0.0, 0.0])
-
-                    return {moments.__name__: [origin, dipole]}
+            if getattr(ccdata, "moments") is None:
+                # Old versions of Psi4 don't print the origin; assume
+                # it's at zero.
+                if "origin" in ccdata.parser_metadata.keys():
+                    origin = ccdata.parser_metadata["origin"]
                 else:
-                    try:
-                        assert np.all(ccdata.moments[1] == dipole)
-                    except AssertionError:
-                        return {moments.__name__: [origin, dipole]}
+                    origin = np.array([0.0, 0.0, 0.0])
+
+                return {moments.__name__: [origin, dipole]}
+            else:
+                try:
+                    assert np.all(ccdata.moments[1] == dipole)
+                except AssertionError:
+                    return {moments.__name__: [origin, dipole]}
 
         if line.strip() == "Multipole Moments:":
-            if base_parser.check_dependencies(dependency_list, ccdata, "natom"):
+            if "origin" in ccdata.parser_metadata.keys():
+                origin = ccdata.parser_metadata["origin"]
+            else:
                 origin = np.array([0.0, 0.0, 0.0])
-                file_handler.skip_lines(["b", "d", "header", "d", "b"])
+            file_handler.skip_lines(["b", "d", "header", "d", "b"])
 
-                # The reference used here should have been printed somewhere
-                # before the properties and parsed above.
-                this_moments = [origin]
+            # The reference used here should have been printed somewhere
+            # before the properties and parsed above.
+            this_moments = [origin]
 
+            line = file_handler.virtual_next()
+            while "----------" not in line.strip():
+                rank = int(line.split()[2].strip("."))
+
+                multipole = []
                 line = file_handler.virtual_next()
-                while "----------" not in line.strip():
-                    rank = int(line.split()[2].strip("."))
-
-                    multipole = []
-                    line = file_handler.virtual_next()
-                    while line.strip():
-                        tokens = line.split()
-                        if tokens[0] in ("Magnitude", "Traceless"):
-                            line = file_handler.virtual_next()
-                            continue
-                        value = float(tokens[-1])
-                        fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
-                        tounits = f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"
-                        value = utils.convertor(value, fromunits, tounits)
-                        multipole.append(value)
-
+                while line.strip():
+                    tokens = line.split()
+                    if tokens[0] in ("Magnitude", "Traceless"):
                         line = file_handler.virtual_next()
+                        continue
+                    value = float(tokens[-1])
+                    fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
+                    tounits = f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"
+                    value = utils.convertor(value, fromunits, tounits)
+                    multipole.append(value)
 
-                    multipole = np.array(multipole)
-                    this_moments.append(multipole)
                     line = file_handler.virtual_next()
-
-                    if getattr(ccdata, "moments") is None:
-                        return {moments.__name__: this_moments}
+                multipole = np.array(multipole)
+                this_moments.append(multipole)
+                line = file_handler.virtual_next()
+            if getattr(ccdata, "moments") is None:
+                return {moments.__name__: this_moments}
+            else:
+                for im, m in enumerate(this_moments):
+                    if len(ccdata.moments) <= im:
+                        this_moments.append(m)
                     else:
-                        for im, m in enumerate(this_moments):
-                            if len(ccdata.moments) <= im:
-                                this_moments.append(m)
-                            else:
-                                assert np.allclose(this_moments[im], m, atol=1.0e4)
+                        assert np.allclose(this_moments[im], m, atol=1.0e4)
+                return {moments.__name__: this_moments}
         return None
 
     @staticmethod

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -19,70 +19,77 @@ class moments(base_parser):
 
     @staticmethod
     def psi4(file_handler, ccdata) -> Optional[dict]:
+        dependency_list = ["parser_metadata['origin']"]
         line = file_handler.last_line
         if line.strip() == "Dipole Moment: (a.u.)":
-            line = file_handler.virtual_next()
-            tokens = line.split()
-            dipole = utils.convertor(
-                np.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]), "ebohr", "Debye"
-            )
+            print("found dipole line")
+            if base_parser.check_dependencies(dependency_list, ccdata, "moments"):
+                line = file_handler.virtual_next()
+                tokens = line.split()
+                dipole = utils.convertor(
+                    np.array([float(tokens[1]), float(tokens[3]), float(tokens[5])]),
+                    "ebohr",
+                    "Debye",
+                )
 
-            # AED: I don't know how to handle this in version 2 yet
-            # this line below is an ugly fix to always assume the origin is at zero until i figure it out.
+                # AED: I don't know how to handle this in version 2 yet
+                # this line below is an ugly fix to always assume the origin is at zero until i figure it out.
+                if getattr(ccdata, "moments") is None:
+                    # Old versions of Psi4 don't print the origin; assume
+                    # it's at zero.
+                    if "origin" in ccdata.parser_metadata:
+                        # AED: I don't know how to handle this in version 2 yet
+                        origin = ccdata.parser_metadata["origin"]
+                    else:
+                        origin = np.array([0.0, 0.0, 0.0])
 
-            origin = np.array([0.0, 0.0, 0.0])
-            if getattr(ccdata, "moments") is None:
-                # Old versions of Psi4 don't print the origin; assume
-                # it's at zero.
-                if getattr(ccdata, "origin") is None:
-                    # AED: I don't know how to handle this in version 2 yet
-                    origin = np.array([0.0, 0.0, 0.0])
-                return {moments.__name__: [origin, dipole]}
-            else:
-                try:
-                    assert np.all(ccdata.moments[1] == dipole)
-                except AssertionError:
                     return {moments.__name__: [origin, dipole]}
+                else:
+                    try:
+                        assert np.all(ccdata.moments[1] == dipole)
+                    except AssertionError:
+                        return {moments.__name__: [origin, dipole]}
 
         if line.strip() == "Multipole Moments:":
-            origin = np.array([0.0, 0.0, 0.0])
-            file_handler.skip_lines(["b", "d", "header", "d", "b"])
+            if base_parser.check_dependencies(dependency_list, ccdata, "natom"):
+                origin = np.array([0.0, 0.0, 0.0])
+                file_handler.skip_lines(["b", "d", "header", "d", "b"])
 
-            # The reference used here should have been printed somewhere
-            # before the properties and parsed above.
-            this_moments = [origin]
+                # The reference used here should have been printed somewhere
+                # before the properties and parsed above.
+                this_moments = [origin]
 
-            line = file_handler.virtual_next()
-            while "----------" not in line.strip():
-                rank = int(line.split()[2].strip("."))
-
-                multipole = []
                 line = file_handler.virtual_next()
-                while line.strip():
-                    tokens = line.split()
-                    if tokens[0] in ("Magnitude", "Traceless"):
-                        line = file_handler.virtual_next()
-                        continue
-                    value = float(tokens[-1])
-                    fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
-                    tounits = f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"
-                    value = utils.convertor(value, fromunits, tounits)
-                    multipole.append(value)
+                while "----------" not in line.strip():
+                    rank = int(line.split()[2].strip("."))
 
+                    multipole = []
+                    line = file_handler.virtual_next()
+                    while line.strip():
+                        tokens = line.split()
+                        if tokens[0] in ("Magnitude", "Traceless"):
+                            line = file_handler.virtual_next()
+                            continue
+                        value = float(tokens[-1])
+                        fromunits = f"ebohr{(rank > 1) * f'{int(rank)}'}"
+                        tounits = f"Debye{(rank > 1) * '.ang'}{(rank > 2) * f'{int(rank - 1)}'}"
+                        value = utils.convertor(value, fromunits, tounits)
+                        multipole.append(value)
+
+                        line = file_handler.virtual_next()
+
+                    multipole = np.array(multipole)
+                    this_moments.append(multipole)
                     line = file_handler.virtual_next()
 
-                multipole = np.array(multipole)
-                this_moments.append(multipole)
-                line = file_handler.virtual_next()
-
-            if getattr(ccdata, "moments") is None:
-                return {moments.__name__: this_moments}
-            else:
-                for im, m in enumerate(this_moments):
-                    if len(ccdata.moments) <= im:
-                        this_moments.append(m)
+                    if getattr(ccdata, "moments") is None:
+                        return {moments.__name__: this_moments}
                     else:
-                        assert np.allclose(this_moments[im], m, atol=1.0e4)
+                        for im, m in enumerate(this_moments):
+                            if len(ccdata.moments) <= im:
+                                this_moments.append(m)
+                            else:
+                                assert np.allclose(this_moments[im], m, atol=1.0e4)
         return None
 
     @staticmethod

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -30,8 +30,8 @@ class moments(base_parser):
             if getattr(ccdata, "moments") is None:
                 # Old versions of Psi4 don't print the origin; assume
                 # it's at zero.
-                if "origin" in ccdata.parser_metadata.keys():
-                    origin = ccdata.parser_metadata["origin"]
+                if "origin" in ccdata.parser_state.keys():
+                    origin = ccdata.parser_state["origin"]
                 else:
                     origin = np.array([0.0, 0.0, 0.0])
 
@@ -43,8 +43,8 @@ class moments(base_parser):
                     return {moments.__name__: [origin, dipole]}
 
         if line.strip() == "Multipole Moments:":
-            if "origin" in ccdata.parser_metadata.keys():
-                origin = ccdata.parser_metadata["origin"]
+            if "origin" in ccdata.parser_state.keys():
+                origin = ccdata.parser_state["origin"]
             else:
                 origin = np.array([0.0, 0.0, 0.0])
             file_handler.skip_lines(["b", "d", "header", "d", "b"])

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -71,18 +71,20 @@ class moments(base_parser):
                     multipole.append(value)
 
                     line = file_handler.virtual_next()
-                multipole = np.array(multipole)
-                this_moments.append(multipole)
+                this_moments.append(np.array(multipole))
                 line = file_handler.virtual_next()
             if getattr(ccdata, "moments") is None:
+                print("the moments are none")
                 return {moments.__name__: this_moments}
             else:
-                for im, m in enumerate(this_moments):
-                    if len(ccdata.moments) <= im:
-                        this_moments.append(m)
+                print("the moments are NOT none")
+                existing_moments_list = getattr(ccdata, "moments")
+                for m_idx, m in enumerate(this_moments):
+                    if len(ccdata.moments) <= m_idx:
+                        existing_moments_list.append(m)
                     else:
-                        assert np.allclose(this_moments[im], m, atol=1.0e4)
-                return {moments.__name__: this_moments}
+                        assert np.allclose(existing_moments_list[m_idx], m, atol=1.0e4)
+                return {moments.__name__: existing_moments_list}
         return None
 
     @staticmethod

--- a/cclib/attribute_parsers/moments.py
+++ b/cclib/attribute_parsers/moments.py
@@ -74,10 +74,8 @@ class moments(base_parser):
                 this_moments.append(np.array(multipole))
                 line = file_handler.virtual_next()
             if getattr(ccdata, "moments") is None:
-                print("the moments are none")
                 return {moments.__name__: this_moments}
             else:
-                print("the moments are NOT none")
                 existing_moments_list = getattr(ccdata, "moments")
                 for m_idx, m in enumerate(this_moments):
                     if len(ccdata.moments) <= m_idx:

--- a/cclib/attribute_parsers/parser_metadata.py
+++ b/cclib/attribute_parsers/parser_metadata.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+from typing import Optional
+
+from cclib.attribute_parsers import utils
+from cclib.attribute_parsers.base_parser import base_parser
+
+import numpy as np
+
+
+class parser_metadata(base_parser):
+    """
+    A temporary variable
+    """
+
+    known_codes = ["psi4"]
+
+    def psi4(file_handler, ccdata):
+        line = file_handler.last_line
+        if "Properties will be evaluated at" in line.strip():
+            if getattr(ccdata, "parser_metadata"):
+                this_metadata = ccdata.parser_metadata
+            else:
+                this_metadata = {}
+            tokens = line.split()
+            assert tokens[-1] in ["Bohr", "[a0]"]
+            this_metadata["origin"] = utils.convertor(
+                np.array([float(x.strip(",")) for x in line.split()[-4:-1]]), "bohr", "Angstrom"
+            )
+            return {parser_metadata.__name__: this_metadata}
+
+    @staticmethod
+    def parse(file_handler, program: str, ccdata) -> Optional[dict]:
+        constructed_data = None
+        if program in parser_metadata.known_codes:
+            file_handler.virtual_set()
+            program_parser = getattr(parser_metadata, program)
+            constructed_data = program_parser(file_handler, ccdata)
+            file_handler.virtual_reset()
+        return constructed_data

--- a/cclib/attribute_parsers/parser_state.py
+++ b/cclib/attribute_parsers/parser_state.py
@@ -10,7 +10,7 @@ from cclib.attribute_parsers.base_parser import base_parser
 import numpy as np
 
 
-class parser_metadata(base_parser):
+class parser_state(base_parser):
     """
     A temporary variable
     """
@@ -20,8 +20,8 @@ class parser_metadata(base_parser):
     def psi4(file_handler, ccdata):
         line = file_handler.last_line
         if "Properties will be evaluated at" in line.strip():
-            if getattr(ccdata, "parser_metadata"):
-                this_metadata = ccdata.parser_metadata
+            if getattr(ccdata, "parser_state"):
+                this_metadata = ccdata.parser_state
             else:
                 this_metadata = {}
             tokens = line.split()
@@ -29,14 +29,14 @@ class parser_metadata(base_parser):
             this_metadata["origin"] = utils.convertor(
                 np.array([float(x.strip(",")) for x in line.split()[-4:-1]]), "bohr", "Angstrom"
             )
-            return {parser_metadata.__name__: this_metadata}
+            return {parser_state.__name__: this_metadata}
 
     @staticmethod
     def parse(file_handler, program: str, ccdata) -> Optional[dict]:
         constructed_data = None
-        if program in parser_metadata.known_codes:
+        if program in parser_state.known_codes:
             file_handler.virtual_set()
-            program_parser = getattr(parser_metadata, program)
+            program_parser = getattr(parser_state, program)
             constructed_data = program_parser(file_handler, ccdata)
             file_handler.virtual_reset()
         return constructed_data

--- a/cclib/combinator/combinator.py
+++ b/cclib/combinator/combinator.py
@@ -37,6 +37,7 @@ DEFAULT_PARSERS = [
     cprops.atombasis,
     cprops.scftargets,
     cprops.scfvalues,
+    cprops.parser_metadata,
 ]
 
 

--- a/cclib/combinator/combinator.py
+++ b/cclib/combinator/combinator.py
@@ -31,6 +31,7 @@ DEFAULT_PARSERS = [
     cprops.atommasses,
     cprops.mosyms,
     cprops.mpenergies,
+    cprops.moments,
     cprops.nmo,
     cprops.atombasis,
     cprops.scftargets,

--- a/cclib/combinator/combinator.py
+++ b/cclib/combinator/combinator.py
@@ -14,7 +14,7 @@ class combinator:
 
 
 DEFAULT_PARSERS = [
-    cprops.parser_metadata,
+    cprops.parser_state,
     cprops.scfenergies,
     cprops.atomcoords,
     cprops.atomcharges,
@@ -37,7 +37,6 @@ DEFAULT_PARSERS = [
     cprops.atombasis,
     cprops.scftargets,
     cprops.scfvalues,
-    cprops.parser_metadata,
 ]
 
 

--- a/cclib/combinator/combinator.py
+++ b/cclib/combinator/combinator.py
@@ -14,6 +14,7 @@ class combinator:
 
 
 DEFAULT_PARSERS = [
+    cprops.parser_metadata,
     cprops.scfenergies,
     cprops.atomcoords,
     cprops.atomcharges,
@@ -24,7 +25,7 @@ DEFAULT_PARSERS = [
     cprops.mult,
     cprops.moenergies,
     cprops.natom,
-    cprops.coreelectrons,  # dependncy on natom
+    cprops.coreelectrons,  # dependency on natom
     cprops.nbasis,
     cprops.gbasis,
     cprops.aooverlaps,

--- a/cclib/driver/ccdriver.py
+++ b/cclib/driver/ccdriver.py
@@ -523,4 +523,7 @@ class ccDriver:
                 if parsed_data is not None:
                     self._ccCollection.parsed_data[current_idx].setattributes(parsed_data)
             line = next(self._fileHandler)
+        # prune ccCollection
+        for i in self._ccCollection._parsed_data:
+            del i.parser_state
         return self._ccCollection

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -462,7 +462,6 @@ class GenericSPTest:
     @skipForParser("Jaguar", "No dipole moments in the logfile")
     @skipForParser("Molcas", "The parser is still being developed so we skip this test")
     @skipForParser("NBO", "attribute not implemented in this version")
-    @skipForParser("Psi4", "The parser is still being converted to version 2")
     @skipForParser("xTB", "not implemented yet")
     def testmoments(self, data) -> None:
         """Does the dipole and possible higher molecular moments look reasonable?"""


### PR DESCRIPTION
Initial conversion for the moments attribute, being done first for Psi4.

There is a reliance on an origin attribute, which i'm unclear on if this is something that can be stored in ccdata, or was only ever meant to exist within the parser.

To Do:
- [x] get attribute in workflow with tests turned on
- [x] figure out this origin isssue.
- [x] move the additional moments over
    - [x] dipole (started)
    - [x] multipole 
