### PR TITLE
Don't run nix build in CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,5 +26,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check nix flake
         run: nix flake check -L
-      - name: Build nix package
-        run: nix build -L
+      # Disabled until https://github.com/Nix-QChem/NixOS-QChem/issues/513 is fixed
+      # - name: Build nix package
+      #   run: nix build -L


### PR DESCRIPTION
Follow up to https://github.com/cclib/cclib/pull/1467.  Unfortunately it looks like part of the package stack is not available in the cache, probably because our flake lockfile is months old, and building from scratch takes too long.

This may be solved by https://github.com/Nix-QChem/NixOS-QChem/issues/513 and then updating our flake lockfile.