### PR TITLE
xTB: test for atomcoords when elements have two-letter symbols

### DIFF
--- a/test/regression.py
+++ b/test/regression.py
@@ -2790,6 +2790,15 @@ def testTurbomole_Turbomole7_5_mp2_opt__(logfile):
     assert len(logfile.data.scfenergies) == len(logfile.data.mpenergies)
 
 
+def testXTB_basicXTB6_5_1_1448_out(logfile):
+    """Atomic coordinates for elements with two-letter symbols were not being
+    parsed.
+
+    See https://github.com/cclib/cclib/issues/1448
+    """
+    assert logfile.data.atomcoords.shape == (1, 5, 3)
+
+
 # These regression tests are for logfiles that are not to be parsed
 # for some reason, and the function should start with 'testnoparse'.
 


### PR DESCRIPTION
- Closes https://github.com/cclib/cclib/issues/1448
- Follow-up to https://github.com/cclib/cclib/pull/1463

Requires https://github.com/cclib/cclib-data/pull/196 to be merged first