### PR TITLE
NumPy 2.x fixes

### DIFF
--- a/.github/workflows/test_and_package.yml
+++ b/.github/workflows/test_and_package.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           filters: |
             methods:
-              - 'cclib/cclib/method/**'
+              - 'cclib/method/**'
               - 'test/method/**'
       - name: Test core code with pytest
         run: |

--- a/cclib/method/ddec.py
+++ b/cclib/method/ddec.py
@@ -763,8 +763,8 @@ class DDEC6(Stockholder):
             lowerbigPhi = self._candidates_bigPhi[atomi][lower_ind]
             lowerphi = self._candidates_phi[atomi][lower_ind]
         else:  # assign some large negative number otherwise
-            lowerbigPhi = numpy.NINF
-            lowerphi = numpy.NINF
+            lowerbigPhi = -numpy.inf
+            lowerphi = -numpy.inf
         if numpy.count_nonzero(self._candidates_phi[atomi] > 0) > 0:
             # If there is at least one candidate phi that is positive
             upper_ind = numpy.where(
@@ -774,8 +774,8 @@ class DDEC6(Stockholder):
             upperbigPhi = self._candidates_bigPhi[atomi][upper_ind]
             upperphi = self._candidates_phi[atomi][upper_ind]
         else:  # assign some large positive number otherwise
-            upperbigPhi = numpy.PINF
-            upperphi = numpy.PINF
+            upperbigPhi = numpy.inf
+            upperphi = numpy.inf
 
         for iteration in range(self.max_iteration):
             # Flow diagram on Figure S1 in doi: 10.1039/c6ra04656h details the procedure.


### PR DESCRIPTION
I think this wasn't caught before because the CI images were generally failing to build with NumPy 2.0, so we weren't testing against it.