### PR TITLE
Fix publishing to (Test)PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -69,7 +69,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
 
   github-release:
     name: >-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
         with:
           repository-url: https://test.pypi.org/legacy/
+          # Temporary workaround for
+          # https://github.com/pypa/gh-action-pypi-publish/issues/283
+          attestations: false
 
   publish-to-pypi:
     name: Publish Python distribution to PyPI
@@ -70,6 +73,10 @@ jobs:
           path: dist/
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+        with:
+          # Temporary workaround for
+          # https://github.com/pypa/gh-action-pypi-publish/issues/283
+          attestations: false
 
   github-release:
     name: >-


### PR DESCRIPTION
The reference issue is https://github.com/pypa/gh-action-pypi-publish/issues/283.  I don't know how to trivially how to rework the workflow (I think the problem is the `on:` rules that trigger it), but this is a common fix.