### PR TITLE
Remove logfile skips for ORCA 4.x files moved to regressions

### DIFF
--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -149,7 +149,6 @@ class GenericSPTest:
     @skipForParser("NBO", "attribute not implemented in this version")
     @skipForParser("Molcas", "Hirshfeld charges not implemented")
     @skipForParser("Molpro", "Hirshfeld charges not implemented")
-    @skipForLogfile("ORCA/basicORCA4.1", "This needs to be moved to regressions")
     @skipForParser("Psi4", "Hirshfeld charges not implemented")
     @skipForParser("PySCF", "Hirshfeld charges not implemented")
     @skipForParser("QChem", "Hirshfeld charges not implemented")

--- a/test/data/testTD.py
+++ b/test/data/testTD.py
@@ -106,8 +106,6 @@ class GenericTDTest:
     @skipForParser("Jaguar", "etsyms are not yet implemented")
     @skipForParser("NWChem", "etsyms are not yet implemented")
     @skipForParser("QChem", "etsyms are not yet implemented")
-    @skipForLogfile("ORCA/basicORCA4.2", "etsyms are only available in ORCA >= 5.0")
-    @skipForLogfile("ORCA/basicORCA4.1", "etsyms are only available in ORCA >= 5.0")
     @skipForLogfile("Gaussian/basicGaussian09", "symmetry is missing for this log file")
     @skipForLogfile("FChk/basicQChem5.4", "etsyms are not yet implemented")
     def testsyms(self, data) -> None:


### PR DESCRIPTION
Related to https://github.com/cclib/cclib-data/pull/204, https://github.com/cclib/cclib-data/pull/209, https://github.com/cclib/cclib/pull/1517

The fix for CI is https://github.com/cclib/cclib-data/pull/209 and these changes are not strictly necessary to get things passing again.