### PR TITLE
Add non-ghost placeholder atom symbols directly to periodic table

### DIFF
--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -222,6 +222,10 @@ class PeriodicTable:
                 self.element.append(e.symbol)
                 self.number[e.symbol] = e.number
 
+        # Add common placeholder atoms.  These are not ghost atoms, which
+        # still have basis functions associated with a parent element.
+        self.number["-"] = 0
+
 
 class WidthSplitter:
     """Split a line based not on a character, but a given number of field


### PR DESCRIPTION
Closes https://github.com/cclib/cclib/issues/1038

We don't have a comprehensive solution for ghost atoms, but this seems good for unambiguously "not an atom" cases.