### PR TITLE
Parse rotational constants for DALTON, GAMESS, and xTB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,11 +3,15 @@
 
 root = true
 
-[*.py]
+[*]
 charset = utf-8
-indent_style = space
 indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{yaml,yml}]
-indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -34,6 +34,14 @@ if _found_pyscf:
 
     # This is an optional install.
     try:
+        import warnings
+
+        warnings.filterwarnings(
+            action="ignore", category=UserWarning, message=r"Module [\w-]+ is under testing"
+        )
+        warnings.filterwarnings(
+            action="ignore", category=UserWarning, message=r"Module [\w-]+ is not fully tested"
+        )
         import pyscf.prop as pyscf_prop
 
     except ModuleNotFoundError:

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -37,6 +37,9 @@ if _found_pyscf:
         import warnings
 
         warnings.filterwarnings(
+            action="ignore", category=UserWarning, message="Since PySCF-2.3, B3LYP"
+        )
+        warnings.filterwarnings(
             action="ignore", category=UserWarning, message=r"Module [\w-]+ is under testing"
         )
         warnings.filterwarnings(

--- a/cclib/parser/daltonparser.py
+++ b/cclib/parser/daltonparser.py
@@ -435,6 +435,14 @@ class DALTON(logfileparser.Logfile):
             # At the end we have the final primitive to save.
             self.primitives.append(prims)
 
+        if line.strip() == "Rotational constants":
+            _ = self.skip_lines(inputfile, ["d", "b"])
+            line = next(inputfile)
+            if "The molecule" in line:
+                _ = self.skip_lines(inputfile, ["b", "header", "b"])
+            line = next(inputfile)
+            self.append_attribute("rotconsts", [float(x) * 1.0e-3 for x in line.split()[:3]])
+
         # This is the corresponding section to the primitive definitions parsed above, so we
         # assume those numbers are available in the variable 'primitives'. Here we read in the
         # indicies of primitives, which we use to construct gbasis.
@@ -1329,21 +1337,3 @@ class DALTON(logfileparser.Logfile):
 
         if line[:37] == " >>>> Total wall time used in DALTON:":
             self.metadata["success"] = True
-
-        # TODO:
-        # aonames
-        # aooverlaps
-        # atomcharges
-        # atomspins
-        # coreelectrons
-        # etrotats
-        # grads
-        # hessian
-        # mocoeffs
-        # nocoeffs
-        # nooccnos
-        # scancoords
-        # scanenergies
-        # scannames
-        # scanparm
-        # vibanharms

--- a/cclib/parser/gamessparser.py
+++ b/cclib/parser/gamessparser.py
@@ -1564,9 +1564,10 @@ class GAMESS(logfileparser.Logfile):
                     "moments of inertia",
                     "THE ROTATIONAL SYMMETRY NUMBER IS",
                     "THE ROTATIONAL CONSTANTS ARE (IN GHZ)",
-                    "rotational constants",
                 ],
             )
+            line = next(inputfile)
+            self.append_attribute("rotconsts", [float(x) for x in line.split()])
             # Sometimes the volume is printed between the pressure and "ALL
             # FREQUENCIES ARE SCALED".
             if lines[0][:3] == " V=":

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -2523,22 +2523,18 @@ class Gaussian(logfileparser.Logfile):
         # matrix.
         if line[1:26] == "SCF Polarizability for W=":
             self.hp_polarizabilities = True
-            if not hasattr(self, "polarizabilities"):
-                self.polarizabilities = []
             polarizability = numpy.zeros(shape=(3, 3))
             self.skip_line(inputfile, "directions")
             for i in range(3):
                 line = next(inputfile)
                 polarizability[i, : i + 1] = [utils.float(x) for x in line.split()[1:]]
-
-            polarizability = utils.symmetrize(polarizability, use_triangle="lower")
-            self.polarizabilities.append(polarizability)
+            self.append_attribute(
+                "polarizabilities", utils.symmetrize(polarizability, use_triangle="lower")
+            )
 
         # Static polarizability (from `freq`), lower triangular matrix.
         if line[1:16] == "Polarizability=":
             self.hp_polarizabilities = True
-            if not hasattr(self, "polarizabilities"):
-                self.polarizabilities = []
             polarizability = numpy.zeros(shape=(3, 3))
             polarizability_list = []
             polarizability_list.extend([line[16:31], line[31:46], line[46:61]])
@@ -2546,16 +2542,15 @@ class Gaussian(logfileparser.Logfile):
             polarizability_list.extend([line[16:31], line[31:46], line[46:61]])
             indices = numpy.tril_indices(3)
             polarizability[indices] = [utils.float(x) for x in polarizability_list]
-            polarizability = utils.symmetrize(polarizability, use_triangle="lower")
-            self.polarizabilities.append(polarizability)
+            self.append_attribute(
+                "polarizabilities", utils.symmetrize(polarizability, use_triangle="lower")
+            )
 
         # Static polarizability, compressed into a single line from
         # terse printing.
         # Order is XX, YX, YY, ZX, ZY, ZZ (lower triangle).
         if line[2:23] == "Exact polarizability:":
             if not self.hp_polarizabilities:
-                if not hasattr(self, "polarizabilities"):
-                    self.polarizabilities = []
                 polarizability = numpy.zeros(shape=(3, 3))
                 indices = numpy.tril_indices(3)
                 try:
@@ -2588,8 +2583,9 @@ class Gaussian(logfileparser.Logfile):
                             line[63:71],
                         ]
                     ]
-                polarizability = utils.symmetrize(polarizability, use_triangle="lower")
-                self.polarizabilities.append(polarizability)
+                self.append_attribute(
+                    "polarizabilities", utils.symmetrize(polarizability, use_triangle="lower")
+                )
 
         # IRC Computation convergence checks.
         #

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -816,13 +816,10 @@ class Gaussian(logfileparser.Logfile):
         # This is generally parsed before coordinates, so atomnos is not defined.
         # Note that in Gaussian03 the comments are not there yet and the labels are different.
         if line.strip() == "Isotopes and Nuclear Properties:":
-            if not hasattr(self, "atommasses"):
-                self.atommasses = []
-
             line = next(inputfile)
             while line[1:16] != "Leave Link  101":
                 if line[1:8] == "AtmWgt=":
-                    self.atommasses.extend(list(map(float, line.split()[1:])))
+                    self.extend_attribute("atommasses", list(map(float, line.split()[1:])))
                 line = next(inputfile)
 
         # Symmetry: point group

--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -844,10 +844,8 @@ class Gaussian(logfileparser.Logfile):
 
         # Symmetry: ordering of irreducible representations
         if "symmetry adapted cartesian basis functions" in line:
-            if not hasattr(self, "symlabels"):
-                self.symlabels = []
             irrep = self.normalisesym(line.split()[-2])
-            self.symlabels.append(irrep)
+            self.append_attribute("symlabels", irrep)
 
         # Extract the atomic numbers and coordinates of the atoms.
         if line.strip() == "Standard orientation:":

--- a/cclib/parser/molcasparser.py
+++ b/cclib/parser/molcasparser.py
@@ -462,6 +462,9 @@ class Molcas(logfileparser.Logfile):
         #
         #  ++    Isotopic shifts:
         if line[4:19] == "THERMOCHEMISTRY":
+            while "Rotational Constants (GHz)" not in line:
+                line = next(inputfile)
+            self.append_attribute("rotconsts", [float(x) for x in reversed(line.split()[-3:])])
             while "ZPVE" not in line:
                 line = next(inputfile)
             self.set_attribute("zpve", float(line.split()[3]))

--- a/cclib/parser/qchemparser.py
+++ b/cclib/parser/qchemparser.py
@@ -1686,14 +1686,16 @@ cannot be determined. Rerun without `$molecule read`."""
                     line = next(inputfile)
                     # Not supported yet.
                     assert "Zero point vibrational energy" in line
-                    if not hasattr(self, "zpe"):
+                    if not hasattr(self, "zpve"):
                         # Convert from kcal/mol to Hartree/particle.
-                        self.zpve = utils.convertor(float(line.split()[4]), "kcal/mol", "hartree")
+                        self.set_attribute(
+                            "zpve", utils.convertor(float(line.split()[4]), "kcal/mol", "hartree")
+                        )
+                    _ = self.skip_line(inputfile, "b")
+                    line = next(inputfile)
                     atommasses = []
-                    while "Translational Enthalpy" not in line:
-                        if "Has Mass" in line:
-                            atommass = float(line.split()[6])
-                            atommasses.append(atommass)
+                    while "Molecular Mass" not in line:
+                        atommasses.append(float(line.split()[6]))
                         line = next(inputfile)
                     if not hasattr(self, "atommasses"):
                         self.atommasses = numpy.array(atommasses)

--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -58,24 +58,6 @@ def symmetrize(m: numpy.ndarray, use_triangle: str = "lower") -> numpy.ndarray:
     return ms
 
 
-_BUILTIN_FLOAT = float
-
-
-def float(number: str) -> float:
-    """Convert a string to a float.
-
-    This method should perform certain checks that are specific to cclib,
-    including avoiding the problem with Ds instead of Es in scientific notation.
-    Another point is converting string signifying numerical problems (*****)
-    to something we can manage (Numpy's NaN).
-    """
-
-    if list(set(number)) == ["*"]:
-        return numpy.nan
-
-    return _BUILTIN_FLOAT(number.replace("D", "E"))
-
-
 def convertor(value: float, fromunits: str, tounits: str) -> float:
     """Convert from one set of units to another.
 
@@ -273,3 +255,23 @@ def block_to_matrix(block: numpy.ndarray) -> numpy.ndarray:
     mat = numpy.empty(shape=(dim, dim), dtype=block.dtype)
     mat[numpy.tril_indices_from(mat)] = block
     return symmetrize(mat)
+
+
+_BUILTIN_FLOAT = float
+
+
+# This is at the bottom of the file so it doesn't interfere with type hints in
+# any of the file's other functions.
+def float(number: str) -> float:
+    """Convert a string to a float.
+
+    This method should perform certain checks that are specific to cclib,
+    including avoiding the problem with Ds instead of Es in scientific notation.
+    Another point is converting string signifying numerical problems (*****)
+    to something we can manage (Numpy's NaN).
+    """
+
+    if list(set(number)) == ["*"]:
+        return numpy.nan
+
+    return _BUILTIN_FLOAT(number.replace("D", "E"))

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -507,7 +507,7 @@ def _extract_gfn2_mulliken_charge(line: str) -> Optional[Tuple[float, int]]:
     3   1 H        0.805     0.282     0.777     1.384
     """
     line_split = line.split()
-    return (float(line_split[4]), line_split[1]) if len(line_split) == 7 else None
+    return (float(line_split[4]), int(line_split[1])) if len(line_split) == 7 else None
 
 
 def _extract_gfn1_mulliken_cm5_charges(line: str) -> Optional[Tuple[float, float]]:

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -12,6 +12,7 @@ from cclib.parser.logfilewrapper import FileWrapper
 from cclib.parser.utils import convertor
 
 import numpy as np
+import scipy.constants as spc
 
 
 class XTB(logfileparser.Logfile):
@@ -183,6 +184,10 @@ class XTB(logfileparser.Logfile):
 
         if atomcharges:
             self.set_attribute("atomcharges", atomcharges)
+
+        rotconsts = _extract_rotational_constants(line)
+        if rotconsts is not None:
+            self.append_attribute("rotconsts", rotconsts)
 
         final_energy = _extract_final_energy(line)
         if final_energy is not None:
@@ -521,6 +526,26 @@ def _extract_gfn1_mulliken_cm5_charges(line: str) -> Optional[Tuple[float, float
     """
     line_split = line.split()
     return [float(line_split[1]), float(line_split[2])] if len(line_split) == 6 else None
+
+
+def _extract_rotational_constants(line: str) -> Optional[np.ndarray]:
+    """Extract the rotational constants in GHz.
+
+               -------------------------------------------------
+              |                Geometry Summary                 |
+               -------------------------------------------------
+
+          molecular mass/u    :       94.9380859
+       center of mass at/Å    :        1.4342479       0.0012299       0.0245854
+      moments of inertia/u·Å² :        0.3216841E+01   0.5275963E+02   0.5275963E+02
+    rotational constants/cm⁻¹ :        0.5240431E+01   0.3195177E+00   0.3195177E+00
+    """
+    if line.startswith("rotational constants/cm⁻¹"):
+        line_split = line.split()
+        _CENTI = 0.01
+        _GIGA = 1000000000.0
+        ghz2invcm = _GIGA * _CENTI / spc.c
+        return np.array([float(x) for x in line_split[-3:]]) / ghz2invcm
 
 
 def _extract_wall_time(line: str) -> Optional[List[timedelta]]:

--- a/cclib/scripts/ccget.py
+++ b/cclib/scripts/ccget.py
@@ -38,7 +38,7 @@ def ccget() -> None:
     parser.add_argument(
         "attribute_or_compchemlogfile",
         nargs="+",
-        help="one or more attributes to be parsed from one ore more logfiles",
+        help="one or more attributes to be parsed from one or more logfiles",
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -185,7 +185,6 @@ class GenericGeoOptTest:
 
     @skipForParser("ADF", "Not implemented yet")
     @skipForParser("CFOUR", "The parser is still being developed so we skip this test")
-    @skipForParser("DALTON", "Not implemented yet")
     @skipForParser("FChk", "Rotational constants are never written to fchk files")
     @skipForParser("GAMESS", "Not implemented yet")
     @skipForParser("GAMESSUK", "Not implemented yet")
@@ -253,6 +252,10 @@ class DALTONGeoOptTest(GenericGeoOptTest):
         """Has the geometry converged and set optdone to True?"""
         convergence = numpy.abs(data.geovalues[-1]) <= data.geotargets
         assert sum(convergence) >= 2
+
+    def testrotconsts(self, data) -> None:
+        """DALTON only prints rotational constants for the first geometry."""
+        assert data.rotconsts.shape == (1, 3)
 
 
 class GaussianGeoOptTest(GenericGeoOptTest):

--- a/test/data/testGeoOpt.py
+++ b/test/data/testGeoOpt.py
@@ -196,7 +196,6 @@ class GenericGeoOptTest:
     @skipForParser("Psi4", "Not implemented yet")
     @skipForParser("QChem", "Not implemented yet")
     @skipForParser("Turbomole", "Not implemented yet")
-    @skipForParser("xTB", "not implemented yet")
     def testrotconsts(self, data) -> None:
         """Each geometry leads to a row in the rotational constants entry."""
         assert data.rotconsts.shape == (len(data.atomcoords), 3)

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -49,7 +49,6 @@ class GenericSPTest:
         assert data.natom == 20
 
     @skipForParser("NBO", "attribute not implemented in this version")
-    @skipForParser("xTB", "not implemented yet")
     def testatomnos(self, data) -> None:
         """Are the atomnos correct?"""
 

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -651,6 +651,17 @@ class ADFSPTest(GenericSPTest):
         assert abs(data.fooverlaps[2, 2] - self.foverlap22) < 0.0001
 
 
+class DALTONSPTest(GenericSPTest):
+    """Customized restricted single point unittest"""
+
+    # taken from basicDALTON-2013/dvb_sp_hf.out
+    rotconsts = [4.6178434, 0.6857618, 0.5970921]
+
+
+class DALTONHFSPTest(DALTONSPTest, GenericHFSPTest):
+    """Customized restricted single point unittest"""
+
+
 class GaussianSPTest(GenericSPTest):
     """Customized restricted single point unittest"""
 

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -75,7 +75,6 @@ class GenericSPTest:
         "These tests were run a long time ago and since we don't have access to Molpro 2006 anymore, we can skip this test (it is tested in 2012)",
     )
     @skipForParser("Turbomole", "The parser is still being developed so we skip this test")
-    @skipForParser("xTB", "not implemented yet")
     def testatomcharges(self, data) -> None:
         """Are atomic charges consistent with natom?"""
         for atomcharge_type in data.atomcharges:

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -402,23 +402,22 @@ class GenericSPTest:
         """There should be no optdone attribute set."""
         assert not hasattr(data, "optdone")
 
-    @skipForParser("ADF", "Not implemented yes")
+    @skipForParser("ADF", "Not implemented yet")
     @skipForParser("CFOUR", "The parser is still being developed so we skip this test")
-    @skipForParser("DALTON", "Not implemented yes")
     @skipForParser("FChk", "Rotational constants are never written to fchk files")
-    @skipForParser("GAMESS", "Not implemented yes")
+    @skipForParser("GAMESS", "Not implemented yet")
     @skipForParser("GAMESSUK", "Not implemented yet")
     @skipForParser("GAMESSDAT", "Not implemented yet")
-    @skipForParser("Molcas", "Not implemented yes")
-    @skipForParser("Molpro", "Not implemented yes")
+    @skipForParser("Molcas", "Not implemented yet")
+    @skipForParser("Molpro", "Not implemented yet")
     @skipForParser("NBO", "attribute not implemented in this version")
-    @skipForParser("NWChem", "Not implemented yes")
-    @skipForParser("Psi4", "Not implemented yes")
-    @skipForParser("QChem", "Not implemented yes")
-    @skipForParser("Turbomole", "Not implemented yes")
     @skipForParser("xTB", "not implemented yet")
+    @skipForParser("NWChem", "Not implemented yet")
+    @skipForParser("Psi4", "Not implemented yet")
+    @skipForParser("QChem", "Not implemented yet")
+    @skipForParser("Turbomole", "Not implemented yet")
     def testrotconsts(self, data) -> None:
-        """A single geometry leads to single set of rotational constants."""
+        """A single geometry leads to single set of rotational constants (in GHz)."""
         assert data.rotconsts.shape == (1, 3)
         numpy.testing.assert_allclose(data.rotconsts[0], self.rotconsts, rtol=0, atol=1.0e-3)
 

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -41,7 +41,7 @@ class GenericSPTest:
     # Generally, one criteria for SCF energy convergence.
     num_scf_criteria = 1
 
-    # taken from Gaussian16/dvb_sp.out
+    # taken from Gaussian16/dvb_sp.out, in GHz
     rotconsts = [4.6266363, 0.6849065, 0.5965900]
 
     def testnatom(self, data) -> None:
@@ -418,7 +418,7 @@ class GenericSPTest:
     def testrotconsts(self, data) -> None:
         """A single geometry leads to single set of rotational constants (in GHz)."""
         assert data.rotconsts.shape == (1, 3)
-        numpy.testing.assert_allclose(data.rotconsts[0], self.rotconsts, rtol=0, atol=1.0e-3)
+        numpy.testing.assert_allclose(data.rotconsts[0], self.rotconsts, rtol=5.0e-5)
 
     @skipForParser("CFOUR", "The parser is still being developed so we skip this test")
     @skipForParser("FChk", "The parser is still being developed so we skip this test")

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -675,7 +675,7 @@ class JaguarSPTest(GenericSPTest):
 
 
 class JaguarHFSPTest(JaguarSPTest, GenericHFSPTest):
-    """Customized restricted single point KS unittest"""
+    """Customized restricted single point unittest"""
 
 
 class Jaguar7SPTest(JaguarSPTest):

--- a/test/data/testvib.py
+++ b/test/data/testvib.py
@@ -5,6 +5,7 @@
 
 """Test logfiles with vibration output in cclib"""
 
+import numpy as np
 import pytest
 from skip import skipForLogfile, skipForParser
 
@@ -38,6 +39,10 @@ class GenericIRTest:
     # Molecular mass of DVB in mD.
     molecularmass = 130078.25
     molecularmass_thresh = 0.25
+
+    # taken from Gaussian16/dvb_sp.out, in GHz
+    nrotconsts = 1
+    rotconsts = [4.6266363, 0.6849065, 0.5965900]
 
     @pytest.fixture
     def numvib(self, data) -> int:
@@ -241,6 +246,21 @@ class GenericIRTest:
             f"Molecule mass: {mm:f} not {self.molecularmass:f} +- {self.molecularmass_thresh:f} mD"
         )
 
+    @skipForParser("ADF", "not implemented yet")
+    @skipForParser("CFOUR", "not implemented yet")
+    @skipForParser("FChk", "Rotational constants are never written to fchk files")
+    @skipForParser("GAMESSUK", "not implemented yet")
+    @skipForParser("Molpro", "not implemented yet")
+    @skipForParser("NWChem", "not implemented yet")
+    @skipForParser("Psi4", "not implemented yet")
+    @skipForParser("QChem", "Rotational constants are not printed")
+    @skipForParser("Turbomole", "Not implemented yet")
+    @skipForParser("xTB", "Rotational constants not printed for frequency calculations")
+    def testrotconsts(self, data) -> None:
+        """A single geometry leads to single set of rotational constants (in GHz)."""
+        assert data.rotconsts.shape == (self.nrotconsts, 3)
+        np.testing.assert_allclose(data.rotconsts[0], self.rotconsts, rtol=5.0e-5)
+
 
 class ADFIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
@@ -260,6 +280,17 @@ class CFOURIRTest(GenericIRTest):
     zpve = 0.1935035993144163
 
 
+class DALTONIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    # 2015/dvb_ir.out
+    #
+    # Once in the molecule/basis section at the beginning that all outputs
+    # have, then once again in ABACUS as part of the vibrational analysis.
+    nrotconsts = 2
+    rotconsts = [4.6178434, 0.6857618, 0.5970921]
+
+
 class FireflyIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
 
@@ -270,6 +301,9 @@ class FireflyIRTest(GenericIRTest):
     freeenergy = -379.61838132136285
 
     entropy_places = 5
+
+    # 8.0/dvb_ir.out
+    rotconsts = [4.79366, 0.69975, 0.61062]
 
 
 class GaussianIRTest(GenericIRTest):
@@ -305,6 +339,9 @@ class MolcasIRTest(GenericIRTest):
     enthalpy = -382.11385
     freeenergy = -382.153812
 
+    # OpenMolcas 18.0/dvb_ir.out
+    rotconsts = [4.6160, 0.7067, 0.6129]
+
 
 class NWChemIRTest(GenericIRTest):
     """Generic imaginary vibrational frequency unittest"""
@@ -322,6 +359,9 @@ class GamessIRTest(GenericIRTest):
     enthalpy = -381.86372805188300
     freeenergy = -381.90808120060200
 
+    # GAMESS-US 2018/dvb_ir.out
+    rotconsts = [4.61361, 0.68513, 0.59655]
+
 
 class OrcaIRTest(GenericIRTest):
     """Customized vibrational frequency unittest"""
@@ -336,6 +376,9 @@ class OrcaIRTest(GenericIRTest):
     freeenergy_places = 2
 
     molecularmass = 130190
+
+    # ORCA 6.0/dvb_ir.out
+    rotconsts = [4.614498, 0.685206, 0.596614]
 
 
 class Psi4HFIRTest(GenericIRTest):
@@ -355,6 +398,12 @@ class Psi4KSIRTest(GenericIRTest):
 
     enthalpy_places = 2
     freeenergy_places = 2
+
+
+class PySCFIRTest(GenericIRTest):
+    """Customized vibrational frequency unittest"""
+
+    rotconsts = [4.617848, 0.685763, 0.597093]
 
 
 class TurbomoleIRTest(GenericIRTest):

--- a/test/regression.py
+++ b/test/regression.py
@@ -101,6 +101,7 @@ from .data.testPolar import GenericPolarTest, ReferencePolarTest
 from .data.testScan import GaussianRelaxedScanTest, GenericRelaxedScanTest
 from .data.testSP import (
     ADFSPTest,
+    DALTONSPTest,
     GaussianSPTest,
     GenericHFSPTest,
     GenericSPTest,
@@ -3467,7 +3468,7 @@ class DALTONBigBasisTest_aug_cc_pCVQZ(GenericBigBasisTest):
     spherical = True
 
 
-class DALTONSPTest_nosymmetry(GenericSPTest):
+class DALTONSPTest_nosymmetry(DALTONSPTest):
     def testsymlabels(self, data: "ccData") -> None:
         """Are all the symmetry labels either Ag/u or Bg/u?"""
         # A calculation without symmetry, meaning it belongs to the C1 point

--- a/test/regression.py
+++ b/test/regression.py
@@ -3521,6 +3521,14 @@ class GamessIRTest_old(GamessIRTest):
     entropy_places = 5
     freeenergy_places = 2
 
+    def testrotconsts(self, data) -> None:
+        """A single geometry leads to single set of rotational constants (in GHz).
+
+        Don't check against reference values since the multiple outputs that
+        use this test vary substantially.
+        """
+        assert data.rotconsts.shape == (1, 3)
+
 
 class GAMESSUSIRTest_ts(GenericIRimgTest):
     @pytest.mark.skip("This is a transition state with different intensities")
@@ -3584,7 +3592,7 @@ class JaguarGeoOptTest_norotconsts(SkipRotconstsMixin, JaguarGeoOptTest):
     """Older Jaguar versions don't print rotational constants"""
 
 
-class JaguarIRTest_v42(JaguarIRTest):
+class JaguarIRTest_v42(SkipRotconstsMixin, JaguarIRTest):
     @pytest.mark.skip("Data file does not contain force constants")
     def testvibfconsts(self, data: "ccData") -> None:
         pass
@@ -3817,7 +3825,11 @@ class OrcaTDDFTTest_pre1085(OrcaTDDFTTest_pre5):
         assert abs(max(data.etoscs) - 0.94) < 0.2
 
 
-class OrcaIRTest_pre4(OrcaIRTest):
+class OrcaIRTest_norotconsts(OrcaSkipRotconstsMixin, OrcaIRTest):
+    """Versions pre-4.1 did not print rotational constants."""
+
+
+class OrcaIRTest_pre4(OrcaIRTest_norotconsts):
     """Customized vibrational frequency unittest"""
 
     # ORCA has a bug in the intensities for version < 4.0

--- a/test/testdata
+++ b/test/testdata
@@ -284,10 +284,10 @@ Scan      ORCA         GenericUnrelaxedScanTest              basicORCA6.0       
 SP        ADF         ADFSPTest             basicADF2007.01             dvb_sp_b.adfout
 SP        ADF         ADFSPTest             basicADF2013.01             dvb_sp_b.adfout
 SP        CFOUR       GenericHFSPTest       basicCFOUR2.1               dvb_sp.c4
-SP        DALTON      GenericHFSPTest       basicDALTON-2013            dvb_sp_hf.out
-SP        DALTON      GenericSPTest         basicDALTON-2013            dvb_sp_ks.out
-SP        DALTON      GenericHFSPTest       basicDALTON-2015            dvb_sp_hf.out
-SP        DALTON      GenericSPTest         basicDALTON-2015            dvb_sp_ks.out
+SP        DALTON      DALTONHFSPTest        basicDALTON-2013            dvb_sp_hf.out
+SP        DALTON      DALTONSPTest          basicDALTON-2013            dvb_sp_ks.out
+SP        DALTON      DALTONHFSPTest        basicDALTON-2015            dvb_sp_hf.out
+SP        DALTON      DALTONSPTest          basicDALTON-2015            dvb_sp_ks.out
 SP        FChk        GenericSPTest         basicGaussian09             dvb_sp.fchk
 SP        FChk        GenericSPTest         basicGaussian16             dvb_sp.fchk
 SP        FChk        GenericSPTest         basicQChem5.2               dvb_sp_modified.fchk

--- a/test/testdata
+++ b/test/testdata
@@ -470,8 +470,8 @@ TDun	  Turbomole   TurbomoleTDunTest     basicTurbomole7.4     CO_cc2_TD_un/basi
 vib       ADF         ADFIRTest             basicADF2007.01       dvb_ir.adfout
 vib       ADF         ADFIRTest             basicADF2013.01       dvb_ir.adfout
 vib       CFOUR       CFOURIRTest           basicCFOUR2.1         dvb_ir.c4
-vib       DALTON      GenericIRTest         basicDALTON-2013      dvb_ir.out
-vib       DALTON      GenericIRTest         basicDALTON-2015      dvb_ir.out
+vib       DALTON      DALTONIRTest          basicDALTON-2013      dvb_ir.out
+vib       DALTON      DALTONIRTest          basicDALTON-2015      dvb_ir.out
 vib       FChk        GaussianIRTest        basicGaussian09       dvb_ir.fchk
 vib       FChk        GaussianIRTest        basicGaussian16       dvb_ir.fchk
 vib       FChk        GenericIRTest         basicQChem5.4         dvb_ir.fchk
@@ -495,7 +495,7 @@ vib       Psi4        Psi4HFIRTest          basicPsi4-1.2.1       dvb_ir_rhf.out
 vib       Psi4        Psi4HFIRTest          basicPsi4-1.3.1       dvb_ir_rhf.out
 vib       Psi4        Psi4HFIRTest          basicPsi4-1.7         dvb_ir_rhf.out
 vib       Psi4        Psi4KSIRTest          basicPsi4-1.7         dvb_ir_rks.out
-vib       PySCF       GenericIRTest         basicPySCF2.6         dvb_ir.py
+vib       PySCF       PySCFIRTest           basicPySCF2.6         dvb_ir.py
 vib       QChem       GenericIRTest         basicQChem5.1         dvb_ir.out
 vib       QChem       GenericIRTest         basicQChem5.4         dvb_ir.out
 vib       Turbomole   TurbomoleIRTest       basicTurbomole5.9     dvb_ir/basis            dvb_ir/control            dvb_ir/mos            dvb_ir/aoforce.out


### PR DESCRIPTION
Done while working on #1610 but is distinctly different.

Includes:
- a bunch of other cleanup
- some more EditorConfig updates for cleaning locally before pre-commit even runs
- silencing the warnings that now come from importing PySCF packages