### PR TITLE
Switch from pre-commit.ci to regular GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prechecks:
+    uses: ./.github/workflows/pre-commit.yml
   nix:
     uses: ./.github/workflows/nix.yml
   unit-tests:
+    needs: [prechecks]
     uses: ./.github/workflows/test_and_package.yml
   docs:
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+---
+name: pre-commit
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+
+concurrency:
+  group: style-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - name: install dependencies for sorting regressionfiles.yaml
+        run: |
+          python -m pip install 'ruamel.yaml'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 ---
 fail_fast: false
+ci:
+  autofix_prs: false
 repos:
   - repo: meta
     hooks:


### PR DESCRIPTION
In doing so, this also removes the auto-fix commits.  My reasoning for doing this, only having commented on it in the past without explanation, is that

1. If you are new to Git and GitHub, or even experienced, it is easy to start making a bunch of commits after the autofix, push, be surprised when it's rejected, then either not know how to do the rebase, or panic, or be annoyed by it.
2. If you are experienced, you should install the tools required for development.  There are some others that can be added to mitigate pre-commit failures, such as EditorConfig, but these are editor-specific, such as auto-running ruff on save.  Maybe eventually we'll get there.  I recently learned that there is a "recommended extensions" section of `.vscode/settings.json` that could cover this for many people.
3. More like 2a, but this can only be a reasonable expectation when there's documentation about it, and currently there is none.  A lot has been done as part of https://github.com/cclib/cclib/issues/555 but pre-commit (among other points) is missing.
4. (Complete opinion) I think it is easier to teach and promote Git cleanliness when you don't have this tool helping you.  I'm ok with commits not being perfect, an individual commit doesn't need to pass tests, going nuts on your branch history isn't required despite that being what I do, but seeing all the bot commits enter history irritates me, since I don't like squashing.  I'd rather help people avoid those or at least have their own "pre-commit fixes" commits rather than wanting to squash the branch.