### PR TITLE
pre-commit: forbid CRLF line endings in code once and for all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,35 +97,6 @@ repos:
               ^data/Turbomole|
               ^data/XTB
           )
-      - id: mixed-line-ending
-        exclude: |
-          (?x)(
-              \.bpa$|
-              \.bpaspn$|
-              \.cube$|
-              \.in$|
-              \.inp$|
-              \.molden$|
-              \.out$|
-              ^data/ADF|
-              ^data/CFOUR|
-              ^data/DALTON|
-              ^data/FChk|
-              ^data/GAMESS|
-              ^data/Gaussian|
-              ^data/Jaguar|
-              ^data/Molcas|
-              ^data/Molpro|
-              ^data/MOPAC|
-              ^data/NBO|
-              ^data/NWChem|
-              ^data/ORCA|
-              ^data/Psi4|
-              ^data/QChem|
-              ^data/regression|
-              ^data/Turbomole|
-              ^data/XTB
-          )
       - id: check-merge-conflict
       - id: check-json
       - id: check-yaml
@@ -173,6 +144,35 @@ repos:
           - .github/license_header.txt
           - --use-current-year
           - --no-extra-eol
+      - id: remove-crlf
+        exclude: |
+          (?x)(
+              \.bpa$|
+              \.bpaspn$|
+              \.cube$|
+              \.in$|
+              \.inp$|
+              \.molden$|
+              \.out$|
+              ^data/ADF|
+              ^data/CFOUR|
+              ^data/DALTON|
+              ^data/FChk|
+              ^data/GAMESS|
+              ^data/Gaussian|
+              ^data/Jaguar|
+              ^data/Molcas|
+              ^data/Molpro|
+              ^data/MOPAC|
+              ^data/NBO|
+              ^data/NWChem|
+              ^data/ORCA|
+              ^data/Psi4|
+              ^data/QChem|
+              ^data/regression|
+              ^data/Turbomole|
+              ^data/XTB
+          )
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.10.0"
     hooks:


### PR DESCRIPTION
Closes #1440 

pre-commit/pre-commit-hooks/mixed-line-ending will allow files through that are entirely CRLF (Windows) line endings.  We only want LF (Unix) line endings.  There is the EditorConfig setting for this, but that is not enforced as part of CI.  This technically allows non-CRLF and non-LF line endings through, but those only exist on obsolete operating systems.

We continue to allow non-LF line endings, including a mix, in data files, since they may originate from Windows.