### PR TITLE
Fix IndexError in coordinate extraction and improve robustness of line-ending

### DIFF
--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -440,27 +440,12 @@ def _extract_symbol_coords(line: str, mode: str) -> Optional[Tuple[str, List[flo
     M  END
     """
     line_split = line.split()
-
-    # Guard against empty lines or headers that are too short to hold coordinates
-    if len(line_split) < 4:
-        return None
-    
     if mode == "xyz":
-        # Check if index 0 is a valid chemical symbol (e.g., 'C', 'Fe')
-        if line_split[0].isalpha() and line_split[0][0].isupper():
-            try:
-                # Safely slice to grab exactly 3 coordinates
-                return line_split[0], [float(coord) for coord in line_split[1:4]]
-            except ValueError:
-                return None
-                
+        if line_split[0].istitle():
+            return line_split[0], [float(coord) for coord in line_split[1:]]
     elif mode in {"mol", "sdf"}:
-        # Check if index 3 is a valid chemical symbol
-        if line_split[3].isalpha() and line_split[3][0].isupper():
-            try:
-                return line_split[3], [float(coord) for coord in line_split[:3]]
-            except ValueError:
-                return None
+        if line_split[3].istitle():
+            return line_split[3], [float(coord) for coord in line_split[:3]]
     else:
         raise ValueError(f"Unsupported coordinate file type: {mode}")
 

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -440,6 +440,10 @@ def _extract_symbol_coords(line: str, mode: str) -> Optional[Tuple[str, List[flo
     M  END
     """
     line_split = line.split()
+    # Guard against empty lines or headers that are too short to hold coordinates
+    if len(line_split) < 4:
+        return None
+
     if mode == "xyz":
         if line_split[0].istitle():
             return line_split[0], [float(coord) for coord in line_split[1:]]
@@ -833,7 +837,7 @@ def _is_end_of_structure_block(line: str, mode: str) -> bool:
     Refer to _extract_symbol_coords for examples of structure blocks.
     """
     if mode == "xyz":
-        return line == "\n"
+        return line.strip() == ""
     elif mode in {"mol", "sdf"}:
         return "M" in line and "END" in line
     else:

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -440,12 +440,27 @@ def _extract_symbol_coords(line: str, mode: str) -> Optional[Tuple[str, List[flo
     M  END
     """
     line_split = line.split()
+
+    # Guard against empty lines or headers that are too short to hold coordinates
+    if len(line_split) < 4:
+        return None
+    
     if mode == "xyz":
-        if line_split[0].istitle():
-            return line_split[0], [float(coord) for coord in line_split[1:]]
+        # Check if index 0 is a valid chemical symbol (e.g., 'C', 'Fe')
+        if line_split[0].isalpha() and line_split[0][0].isupper():
+            try:
+                # Safely slice to grab exactly 3 coordinates
+                return line_split[0], [float(coord) for coord in line_split[1:4]]
+            except ValueError:
+                return None
+                
     elif mode in {"mol", "sdf"}:
-        if line_split[3].istitle():
-            return line_split[3], [float(coord) for coord in line_split[:3]]
+        # Check if index 3 is a valid chemical symbol
+        if line_split[3].isalpha() and line_split[3][0].isupper():
+            try:
+                return line_split[3], [float(coord) for coord in line_split[:3]]
+            except ValueError:
+                return None
     else:
         raise ValueError(f"Unsupported coordinate file type: {mode}")
 


### PR DESCRIPTION
- This PR fixes a bug where _extract_symbol_coords throws an IndexError when parsing non-coordinate header lines (e.g., "final structure:"). Original line 93 'if "final structure:" in line:' appeared to cause this bug in "mol/sdf" mode (require line_split[3]).

- The previous implementation was susceptible to failure if lines contained trailing spaces. Using .strip() ensures that any line containing only whitespace is correctly identified as an empty line. The previous implementation failed to detect end_of_structure_block in my xTB log in "xyz" mode because of  an extra space.