### PR TITLE
End of spin down orbitals section properly detected

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -951,7 +951,7 @@ Dispersion correction           -0.016199959
             def continue_orbital_section(line: str) -> bool:
                 # terminated by ------
                 # OR has *Only the first 10 virtual orbitals were printed.
-                return len(line) > 20 and line[:5] not in ("*Only", "Total")
+                return len(line) > 25 and line[:5] not in ("*Only", "Total")
 
             line = next(inputfile)
             while continue_orbital_section(line):


### PR DESCRIPTION
In Orca 6.1.1, the final line ends with 25*'-', it was not detected with the previous definition. It should not affect previous versions (the previous lines are > 25 chars long anyway)