### PR TITLE
refactor: standardize MissingAttributeError to cclib namespace

### DIFF
--- a/cclib/__init__.py
+++ b/cclib/__init__.py
@@ -20,6 +20,13 @@ as well as example methods that take parsed data as input.
 # ruff: noqa: F401
 from cclib._version import __version__
 
+
+class MissingAttributeError(Exception):
+    """Raised when a required attribute is missing from parsed data."""
+
+    pass
+
+
 # isort: off
 from cclib import parser, progress, method, bridge, io
 # isort: on

--- a/cclib/bridge/cclib2chemfiles.py
+++ b/cclib/bridge/cclib2chemfiles.py
@@ -7,12 +7,9 @@
 from collections import defaultdict
 from typing import Optional
 
+from cclib import MissingAttributeError
 from cclib.parser.data import ccData
 from cclib.parser.utils import PeriodicTable, find_package
-
-
-class MissingAttributeError(Exception):
-    pass
 
 
 _found_chemfiles = find_package("chemfiles")

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -14,10 +14,7 @@ import numpy
 if TYPE_CHECKING:
     from cclib.parser.data import ccData
 
-
-class MissingAttributeError(Exception):
-    pass
-
+from cclib import MissingAttributeError
 
 _found_pyquante2 = find_package("pyquante2")
 if _found_pyquante2:

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -18,10 +18,7 @@ import periodictable
 
 l_sym2num = {"S": 0, "P": 1, "D": 2, "F": 3, "G": 4}
 
-
-class MissingAttributeError(Exception):
-    pass
-
+from cclib import MissingAttributeError
 
 _found_pyscf = find_package("pyscf")
 if _found_pyscf:

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -42,9 +42,7 @@ if sys.version_info.minor >= 9:
 else:
     from typing import Iterable
 
-
-class MissingAttributeError(Exception):
-    pass
+from cclib import MissingAttributeError
 
 
 class Writer(ABC):

--- a/cclib/io/wfxwriter.py
+++ b/cclib/io/wfxwriter.py
@@ -8,6 +8,7 @@
 import os.path
 from typing import List, Tuple, Union
 
+from cclib import MissingAttributeError
 from cclib.io import filewriter
 from cclib.parser import utils
 
@@ -450,7 +451,7 @@ class WFXWriter(filewriter.Writer):
         elif hasattr(self.ccdata, "scfenergies"):
             energy = self.ccdata.scfenergies[-1]
         else:
-            raise filewriter.MissingAttributeError("scfenergies/mpenergies/ccenergies")
+            raise MissingAttributeError("scfenergies/mpenergies/ccenergies")
         return WFX_FIELD_FMT % (utils.convertor(energy, "eV", "hartree"))
 
     def _virial_ratio(self) -> str:
@@ -506,7 +507,7 @@ class WFXWriter(filewriter.Writer):
                 wfx_lines.extend(_section(section_name, section_data))
             except:  # noqa: E722
                 if section_required:
-                    raise filewriter.MissingAttributeError(
+                    raise MissingAttributeError(
                         f"Unable to write required wfx section: {section_name}"
                     )
 

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
     from cclib.parser.data import ccData
     from cclib.progress import Progress
 
-
-class MissingAttributeError(Exception):
-    pass
+from cclib import MissingAttributeError
 
 
 class Method:

--- a/cclib/method/population.py
+++ b/cclib/method/population.py
@@ -8,7 +8,8 @@
 import logging
 from typing import TYPE_CHECKING, List, Optional
 
-from cclib.method.calculationmethod import Method, MissingAttributeError
+from cclib import MissingAttributeError
+from cclib.method.calculationmethod import Method
 from cclib.progress import Progress
 
 import numpy

--- a/test/io/testmoldenwriter.py
+++ b/test/io/testmoldenwriter.py
@@ -8,7 +8,7 @@
 import os
 
 import cclib
-from cclib.io.filewriter import MissingAttributeError
+from cclib import MissingAttributeError
 from cclib.io.moldenwriter import MoldenReformatter, round_molden
 
 import pytest

--- a/test/io/testwfxwriter.py
+++ b/test/io/testwfxwriter.py
@@ -8,7 +8,7 @@
 import os
 
 import cclib
-from cclib.io.filewriter import MissingAttributeError
+from cclib import MissingAttributeError
 from cclib.io.wfxwriter import _list_format, _section
 
 import numpy as np

--- a/test/method/testbader.py
+++ b/test/method/testbader.py
@@ -9,7 +9,7 @@ import os
 
 from cclib.io import ccread
 from cclib.method import Bader
-from cclib.method.calculationmethod import MissingAttributeError
+from cclib import MissingAttributeError
 from cclib.method.volume import Volume, read_from_cube
 from cclib.parser import Psi4
 

--- a/test/method/testddec.py
+++ b/test/method/testddec.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from cclib.io import ccread
 from cclib.method import DDEC6, volume
-from cclib.method.calculationmethod import MissingAttributeError
+from cclib import MissingAttributeError
 from cclib.parser import Psi4
 
 import numpy

--- a/test/method/testhirshfeld.py
+++ b/test/method/testhirshfeld.py
@@ -9,7 +9,7 @@ import os
 
 from cclib.io import ccread
 from cclib.method import Hirshfeld, volume
-from cclib.method.calculationmethod import MissingAttributeError
+from cclib import MissingAttributeError
 from cclib.parser import Psi4
 
 import numpy

--- a/test/method/testpopulation.py
+++ b/test/method/testpopulation.py
@@ -10,8 +10,9 @@ import os
 import sys
 from typing import Type
 
+from cclib import MissingAttributeError
 from cclib.method import CSPA, LPA, MPA, OPA, Bickelhaupt
-from cclib.method.calculationmethod import Method, MissingAttributeError
+from cclib.method.calculationmethod import Method
 from cclib.parser import Gaussian
 
 import numpy


### PR DESCRIPTION
## Problem

`MissingAttributeError` is defined as a standalone `class MissingAttributeError(Exception): pass` in 5 different files across the cclib codebase:

- `cclib/bridge/cclib2pyquante.py`
- `cclib/bridge/cclib2chemfiles.py`
- `cclib/bridge/cclib2pyscf.py`
- `cclib/method/calculationmethod.py`
- `cclib/io/filewriter.py`

This duplication violates the DRY principle and makes maintenance harder — if the exception needs a docstring or custom behavior, it must be updated in every location.

## Fix

Define `MissingAttributeError` once in `cclib/__init__.py` under the top-level `cclib` namespace, then import it in all files that previously defined their own duplicate.

**Files changed:**
- `cclib/__init__.py` — added `MissingAttributeError` class definition
- `cclib/bridge/cclib2pyquante.py` — replaced class def with `from cclib import MissingAttributeError`
- `cclib/bridge/cclib2chemfiles.py` — replaced class def with `from cclib import MissingAttributeError`
- `cclib/bridge/cclib2pyscf.py` — replaced class def with `from cclib import MissingAttributeError`
- `cclib/method/calculationmethod.py` — replaced class def with `from cclib import MissingAttributeError`
- `cclib/io/filewriter.py` — replaced class def with `from cclib import MissingAttributeError`
- `cclib/io/wfxwriter.py` — added import, changed `filewriter.MissingAttributeError` → `MissingAttributeError`
- `cclib/method/population.py` — updated import to use central location
- 6 test files — updated imports to use `from cclib import MissingAttributeError`

## Test Plan

- [ ] Unit tests pass (tests that raise/expect `MissingAttributeError` verify the import still works)
- [ ] Import `cclib.MissingAttributeError` works from outside the package

Closes #1746
