### PR TITLE
Fix NWChem parsing when atom names are not capitalized

### DIFF
--- a/cclib/parser/nwchemparser.py
+++ b/cclib/parser/nwchemparser.py
@@ -38,7 +38,10 @@ class NWChem(logfileparser.Logfile):
 
     @staticmethod
     def name2element(lbl: str) -> str:
-        return "".join(itertools.takewhile(str.isalpha, str(lbl)))
+        # NWChem echoes atom names with the capitalization used in the input
+        # (e.g. "n" or "FE"), while these are looked up against the standard
+        # symbols in PeriodicTable, so normalize the case.
+        return "".join(itertools.takewhile(str.isalpha, str(lbl))).capitalize()
 
     def extract(self, inputfile: "FileWrapper", line: str) -> None:
         """Extract information from the file object inputfile."""
@@ -106,7 +109,9 @@ class NWChem(logfileparser.Logfile):
                 tokens = next(inputfile).split()
                 mtch = re.search(r"[a-zA-Z]+", tokens[0])
                 assert mtch is not None
-                name2mass[mtch.group()] = float(tokens[1])
+                # The atom name is echoed as typed in the input (e.g. "n"),
+                # but is looked up below via the standard PeriodicTable symbol.
+                name2mass[mtch.group().capitalize()] = float(tokens[1])
             masses = [name2mass[self.table.element[number]] for number in self.atomnos]
             self.set_attribute("atommasses", masses)
 
@@ -271,7 +276,9 @@ class NWChem(logfileparser.Logfile):
                     atomelement = self.name2element(atomname)
                     self.metadata["basis_set"] = desc
 
-                    self.shells[atomname] = types
+                    # Keyed by element since after_parsing looks the types up
+                    # via PeriodicTable symbols when building aonames.
+                    self.shells[atomelement] = types
                     atombasis_dict[atomelement] = int(funcs)
                     line = next(inputfile)
 
@@ -289,9 +296,13 @@ class NWChem(logfileparser.Logfile):
             self.skip_lines(inputfile, ["d", "b"])
             if not hasattr(self, "symlabels"):
                 self.symlabels = []
-            for _ in range(self.pg_order):
-                line = next(inputfile)
+            # One line per irreducible representation; only for abelian groups
+            # does their number equal the group order (e.g. D4h: order 16 but
+            # 10 irreps), so read until the blank line ending the block.
+            line = next(inputfile)
+            while line.strip():
                 self.symlabels.append(self.normalisesym(line.split()[0]))
+                line = next(inputfile)
 
         # This section contains general parameters for Hartree-Fock calculations,
         # which do not contain the 'General Information' section like most jobs.

--- a/test/parser/testspecificparsers.py
+++ b/test/parser/testspecificparsers.py
@@ -158,3 +158,81 @@ class NormalisesymTest:
         labels = ["a", "a1", "ag"]
         ref = ["A", "A1", "Ag"]
         assert list(map(sym, labels)) == ref
+
+
+def _nwchem_n2_output(symbol: str) -> str:
+    """A minimal NWChem logfile for N2, with atoms named as typed in the input.
+
+    Modeled on the output attached to https://github.com/cclib/cclib/issues/1801;
+    NWChem echoes atom names with the capitalization the user typed (e.g. "n"),
+    and D4h is a non-abelian group whose order (16) exceeds its irrep count (10).
+    """
+    return f"""\
+                             Geometry "geometry" -> ""
+                             -------------------------
+
+ Output coordinates in angstroms (scale by  1.889725989 to convert to a.u.)
+
+  No.       Tag          Charge          X              Y              Z
+ ---- ---------------- ---------- -------------- -------------- --------------
+    1 {symbol}                    7.0000     0.00000000     0.00000000    -0.54000000
+    2 {symbol}                    7.0000     0.00000000     0.00000000     0.54000000
+
+      Atomic Mass
+      -----------
+
+      {symbol}                 14.003070
+
+
+      Symmetry information
+      --------------------
+
+ Group name             D4h
+ Group number             28
+ Group order              16
+ No. of unique centers     1
+
+ Summary of "ao basis" -> "ao basis" (cartesian)
+ ------------------------------------------------------------------------------
+       Tag                 Description            Shells   Functions and Types
+ ---------------- ------------------------------  ------  ---------------------
+ {symbol}                          cc-pvdz                  6       15   3s2p1d
+
+
+      Symmetry analysis of basis
+      --------------------------
+
+        a1g         7
+        a1u         0
+        a2g         0
+        a2u         7
+        b1g         1
+        b1u         1
+        b2g         1
+        b2u         1
+        eg          6
+        eu          6
+
+ Forming initial guess at       0.0s
+"""
+
+
+class NWChemTest:
+    def test_atom_names_as_typed_in_input(self) -> None:
+        """NWChem echoes atom names as typed (e.g. lowercase "n"), while masses,
+        atombasis and aonames are resolved via standard PeriodicTable symbols (#1801)."""
+        from cclib.parser.nwchemparser import NWChem
+
+        data = NWChem(io.StringIO(_nwchem_n2_output("n"))).parse()
+        assert data.atommasses.tolist() == [14.003070, 14.003070]
+        assert data.atombasis == [list(range(15)), list(range(15, 30))]
+        assert data.aonames[:4] == ["N1_1S", "N1_2S", "N1_3S", "N1_2PX"]
+        assert len(data.aonames) == 30
+
+    def test_symlabels_nonabelian_group(self) -> None:
+        """The symmetry analysis block has one line per irrep, which is fewer
+        than the group order for non-abelian groups (D4h: 10 irreps, order 16)."""
+        from cclib.parser.nwchemparser import NWChem
+
+        data = NWChem(io.StringIO(_nwchem_n2_output("N"))).parse()
+        assert data.atommasses.tolist() == [14.003070, 14.003070]


### PR DESCRIPTION
Fixes #1801.

NWChem echoes atom names with the capitalization the user typed in the input geometry — the attached `n2_opt.out` from the issue has `n 14.003070` in its Atomic Mass block because the input said `n 0 0 0`. The parser, however, resolves atoms through standard `PeriodicTable` symbols (`'N'`), so `name2mass['N']` raised the reported `KeyError: 'N'`. The same as-typed-name vs. canonical-symbol mismatch exists in the two basis summary sections (`gbasis_dict`/`atombasis_dict` via `name2element`) and in `self.shells`, whose `after_parsing` consumer looks up by element and silently dropped `aonames` with a warning when the keys didn't match.

Changes:
- `name2element` now capitalizes the extracted symbol, fixing the `gbasis`/`atombasis` lookups; the Atomic Mass block gets the same normalization, and `self.shells` is keyed by element so `aonames` are built.
- With the KeyError gone, the issue's file then crashed in `Symmetry analysis of basis`: that block has one line per irrep, and the parser read `pg_order` lines, which only matches for abelian groups. The file's D4h has order 16 but 10 irreps, so the parser ran past the block into a blank line (`IndexError`). It now reads until the blank line that ends the block.

With both fixes the file from the issue parses end to end: `atommasses` is `[14.00307, 14.00307]`, `atombasis`/`gbasis` resolve, and `aonames` (`N1_1S`…) are produced instead of being dropped.

Tests: two unit tests in `test/parser/testspecificparsers.py` drive the parser over a minimal fragment modeled on the issue's file — one with lowercase atom names, one with capitalized names isolating the non-abelian symlabels case. Both fail on master and pass with the fix; the existing NWChem data tests (486) pass unchanged.