### PR TITLE
Sync dependencies between pyproject.toml and CI image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,6 @@ jobs:
       run:
         shell: bash -eo pipefail -l {0}
     steps:
-      - name: Installs for ssh-agent
-        run: |
-          apt-get update && apt-get install -y openssh-client
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:

--- a/.github/workflows/test_and_package.yml
+++ b/.github/workflows/test_and_package.yml
@@ -98,9 +98,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.container == 'shivupa/cclib-ci:py311-edge'
-      - name: Install pypa/build
-        run: |
-          python -m pip install build
       - name: Build distribution packages (binary wheel and source tarball)
         run: |
           python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test-infrastructure = [
     "pytest",
     "coverage",
     "pytest-cov",
+    "pytest-xdist",
     "pyyaml",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,6 @@ docs = [
 ]
 test = ["cclib[bridges,docs,test-infrastructure]"]
 test-infrastructure = [
-    "pytest",
-    "coverage",
     "pytest-cov",
     "pytest-xdist",
     "pyyaml",


### PR DESCRIPTION
Up to now it has been independently installed in the CI images.