### PR TITLE
Support parallel test execution in generate_coverage.py via PYTEST_NWORKERS

### DIFF
--- a/doc/sphinx/generate_coverage.py
+++ b/doc/sphinx/generate_coverage.py
@@ -81,7 +81,11 @@ def generate_coverage(cclib_base_dir: Path) -> str:
             # Ignore one or more checked-out cclib source trees under doc/sphinx/,
             # since there will be conftest.py multiple detection issues.
             # TODO specify in pytest config?
-            retcode = pytest.main(["--ignore=doc", "-m", "is_data"], plugins=[capture_coverage_dir])
+            pytest_args = ["--ignore=doc", "-m", "is_data"]
+            nworkers = os.environ.get("PYTEST_NWORKERS")
+            if nworkers:
+                pytest_args = ["-n", nworkers, "--dist", "worksteal"] + pytest_args
+            retcode = pytest.main(pytest_args, plugins=[capture_coverage_dir])
             sys.stdout = stdout_backup
         if retcode != 0:
             print("Unit tests did not run correctly. Check log file for errors:")


### PR DESCRIPTION
## Summary

This PR allows `generate_coverage.py` to run tests in parallel when the `PYTEST_NWORKERS` environment variable is set, matching the pattern already used in `.github/scripts/run_pytest.bash`.

Fixes #1806.

## Changes

`doc/sphinx/generate_coverage.py` (pytest path only):
- Read `os.environ.get("PYTEST_NWORKERS")`
- When set, prepend `-n <N> --dist worksteal` to pytest arguments
- When not set, behavior is unchanged (serial execution)

## Motivation

The docs CI is currently the bottleneck because `generate_coverage.py` runs pytest serially, while `run_pytest.bash` already supports parallelism. This change brings the same capability to the coverage generation script.

## Verification

- Python syntax verified
- When `PYTEST_NWORKERS` is unset: `pytest_args = ["--ignore=doc", "-m", "is_data"]` (unchanged)
- When `PYTEST_NWORKERS=4`: `pytest_args = ["-n", "4", "--dist", "worksteal", "--ignore=doc", "-m", "is_data"]`

## References

- Issue: #1806
- Existing parallel pattern: `.github/scripts/run_pytest.bash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>