### PR TITLE
Add initial pixi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ cclib/_version.py
 .direnv
 # Auto-generated from running tests, introduced by https://github.com/cclib/cclib/pull/1653
 dvb_gopt.xyz
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dvb_gopt.xyz
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+pixi.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,24 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tool.pixi.pypi-dependencies]
+cclib = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+all = { features = ["all"], solve-group = "default" }
+bridges = { features = ["bridges"], solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }
+docs = { features = ["docs"], solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }
+test-infrastructure = { features = ["test-infrastructure"], solve-group = "default" }
+
+[tool.pixi.tasks]
+
 [tool.ruff]
 line-length = 100
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,13 @@ test-infrastructure = [
     "pytest-cov",
     "pytest-xdist",
     "pyyaml",
+    "pytest-xdist",
+]
+
+[dependency-groups]
+pixi-bridges = [
+    "pyquante2 @ git+https://github.com/cclib/pyquante2.git@cythonize-becke",
+    "pyscf-properties @ git+https://github.com/pyscf/properties.git",
 ]
 
 [build-system]
@@ -130,21 +137,68 @@ ignore_missing_imports = true
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]
-platforms = ["linux-64"]
+platforms = [
+    "linux-64",
+    "osx-64",
+    "osx-arm64",
+    "win-64",
+]
 
 [tool.pixi.pypi-dependencies]
 cclib = { path = ".", editable = true }
 
 [tool.pixi.environments]
-default = { solve-group = "default" }
-all = { features = ["all"], solve-group = "default" }
-bridges = { features = ["bridges"], solve-group = "default" }
-dev = { features = ["dev"], solve-group = "default" }
-docs = { features = ["docs"], solve-group = "default" }
-test = { features = ["test"], solve-group = "default" }
-test-infrastructure = { features = ["test-infrastructure"], solve-group = "default" }
+# default = { solve-group = "default" }
+# all = { features = ["all"], solve-group = "default" }
+# bridges = { features = ["bridges"], solve-group = "default" }
+# dev = { features = ["dev"], solve-group = "default" }
+# docs = { features = ["docs"], solve-group = "default" }
+# test = { features = ["test"], solve-group = "default" }
+# test-infrastructure = { features = ["test-infrastructure"], solve-group = "default" }
+# py37 = { features = ["py37", "dev"], solve-group = "py37" }
+py38 = { features = ["py38", "dev", "pixi-bridges"], solve-group = "py38" }
+py39 = { features = ["py39", "dev", "pixi-bridges"], solve-group = "py39" }
+py310 = { features = ["py310", "dev", "pixi-bridges"], solve-group = "py310" }
+py311 = { features = ["py311", "dev", "pixi-bridges"], solve-group = "py311" }
+py312 = { features = ["py312", "dev", "pixi-bridges"], solve-group = "py312" }
+py313 = { features = ["py313", "dev", "pixi-bridges"], solve-group = "py313" }
+py314 = { features = ["py314", "dev", "pixi-bridges"], solve-group = "py314" }
+# dev = { features = ["dev"], no-default-feature = true }
 
-[tool.pixi.tasks]
+# [tool.pixi.feature.dev.dependencies]
+# # TODO this is a missing transitive dependency of pyberny
+# pkg_resources = "*"
+
+# [tool.pixi.feature.py37.dependencies]
+# python = "3.7.*"
+# openbabel = "*"
+
+[tool.pixi.feature.py38.dependencies]
+python = "3.8.*"
+psi4 = "*"
+
+[tool.pixi.feature.py39.dependencies]
+python = "3.9.*"
+psi4 = "*"
+
+[tool.pixi.feature.py310.dependencies]
+python = "3.10.*"
+psi4 = "*"
+
+[tool.pixi.feature.py311.dependencies]
+python = "3.11.*"
+psi4 = "*"
+
+[tool.pixi.feature.py312.dependencies]
+python = "3.12.*"
+psi4 = "*"
+
+[tool.pixi.feature.py313.dependencies]
+python = "3.13.*"
+psi4 = "*"
+
+[tool.pixi.feature.py314.dependencies]
+python = "3.14.*"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,33 +43,44 @@ ccwrite = "cclib.scripts.ccwrite:main"
 cda = "cclib.scripts.cda:main"
 
 [project.optional-dependencies]
+# The Open Babel PyPI package for version < 3.2.0 is missing native wheels and
+# requires using SWIG to compile the Python extension against a preinstalled
+# native library.  The wheels for version >= 3.2.0 only support Python >=
+# 3.10.
+#
+# With Pixi v0.67.2, specifying a (conda) dependency via Pixi doesn't seem
+# override the corresponding PyPI dependency, so we create groups that leave
+# out Open Babel and manually specify it as a Pixi dependency for Python <
+# 3.10 versions while keeping everything as-is for Python >= 3.10.
 all = ["cclib[bridges]"]
-bridges = [
+bridges = ["cclib[bridges-no-openbabel,openbabel]"]
+bridges-no-openbabel = [
     "ase>=3.21",
     "biopython",
     "chemfiles",
-    "openbabel",
     "pandas",
     "pyscf",
     "geometric",
     "qc-iodata>=1.0.0a2",
 ]
 dev = ["cclib[bridges,docs,test-infrastructure]"]
+dev-no-openbabel = ["cclib[bridges-no-openbabel,docs,test-infrastructure]"]
 docs = [
     "build",
     "sphinx",
     "sphinx_rtd_theme",
 ]
+openbabel = ["openbabel"]
 test = ["cclib[bridges,docs,test-infrastructure]"]
 test-infrastructure = [
     "pytest-cov",
     "pytest-xdist",
     "pyyaml",
-    "pytest-xdist",
 ]
 
 [dependency-groups]
-pixi-bridges = [
+bridges-git = [
+    "pyberny @ git+https://github.com/cclib/pyberny.git@8142ce1bc468664aef18e88099b03734bff982e5",
     "pyquante2 @ git+https://github.com/cclib/pyquante2.git@cythonize-becke",
     "pyscf-properties @ git+https://github.com/pyscf/properties.git",
 ]
@@ -139,66 +150,75 @@ ignore_missing_imports = true
 channels = ["conda-forge"]
 platforms = [
     "linux-64",
-    "osx-64",
     "osx-arm64",
     "win-64",
 ]
+preview = ["pixi-build"]
+
+# This can't be present until Psi4 is packaged for Python 3.14.
+#
+# [tool.pixi.dependencies]
+# psi4 = "*"
 
 [tool.pixi.pypi-dependencies]
 cclib = { path = ".", editable = true }
 
 [tool.pixi.environments]
-# default = { solve-group = "default" }
-# all = { features = ["all"], solve-group = "default" }
-# bridges = { features = ["bridges"], solve-group = "default" }
-# dev = { features = ["dev"], solve-group = "default" }
-# docs = { features = ["docs"], solve-group = "default" }
-# test = { features = ["test"], solve-group = "default" }
-# test-infrastructure = { features = ["test-infrastructure"], solve-group = "default" }
-# py37 = { features = ["py37", "dev"], solve-group = "py37" }
-py38 = { features = ["py38", "dev", "pixi-bridges"], solve-group = "py38" }
-py39 = { features = ["py39", "dev", "pixi-bridges"], solve-group = "py39" }
-py310 = { features = ["py310", "dev", "pixi-bridges"], solve-group = "py310" }
-py311 = { features = ["py311", "dev", "pixi-bridges"], solve-group = "py311" }
-py312 = { features = ["py312", "dev", "pixi-bridges"], solve-group = "py312" }
-py313 = { features = ["py313", "dev", "pixi-bridges"], solve-group = "py313" }
-py314 = { features = ["py314", "dev", "pixi-bridges"], solve-group = "py314" }
-# dev = { features = ["dev"], no-default-feature = true }
-
-# [tool.pixi.feature.dev.dependencies]
-# # TODO this is a missing transitive dependency of pyberny
-# pkg_resources = "*"
-
-# [tool.pixi.feature.py37.dependencies]
-# python = "3.7.*"
-# openbabel = "*"
+py38 = { features = ["py38", "dev-no-openbabel", "bridges-git"], solve-group = "py38" }
+py39 = { features = ["py39", "dev-no-openbabel", "bridges-git"], solve-group = "py39" }
+py310 = { features = ["py310", "dev", "bridges-git"], solve-group = "py310" }
+py311 = { features = ["py311", "dev", "bridges-git"], solve-group = "py311" }
+py312 = { features = ["py312", "dev", "bridges-git"], solve-group = "py312" }
+py313 = { features = ["py313", "dev", "bridges-git"], solve-group = "py313" }
+py314 = { features = ["py314", "dev", "bridges-git"], solve-group = "py314" }
 
 [tool.pixi.feature.py38.dependencies]
-python = "3.8.*"
+libint = { version = "==2.9.0", build = "*_4" }
+openbabel = "*"
 psi4 = "*"
+python = "3.8.*"
 
 [tool.pixi.feature.py39.dependencies]
-python = "3.9.*"
+libint = { version = "==2.9.0", build = "*_4" }
+openbabel = "*"
 psi4 = "*"
+python = "3.9.*"
 
 [tool.pixi.feature.py310.dependencies]
-python = "3.10.*"
 psi4 = "*"
+python = "3.10.*"
 
 [tool.pixi.feature.py311.dependencies]
-python = "3.11.*"
 psi4 = "*"
+python = "3.11.*"
 
 [tool.pixi.feature.py312.dependencies]
-python = "3.12.*"
 psi4 = "*"
+python = "3.12.*"
 
 [tool.pixi.feature.py313.dependencies]
-python = "3.13.*"
 psi4 = "*"
+python = "3.13.*"
 
 [tool.pixi.feature.py314.dependencies]
 python = "3.14.*"
+
+[tool.pixi.package]
+name = "cclib"
+version = "1.8.1"
+
+[tool.pixi.package.build]
+backend = { name = "pixi-build-python", version = "0.*" }
+
+[tool.pixi.package.host-dependencies]
+setuptools = ">=61.0"
+versioningit = ">=2.0"
+
+[tool.pixi.package.run-dependencies]
+numpy = "*"
+packaging = ">=19.0"
+periodictable = "*"
+scipy = ">=1.2.0"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,10 @@ python = "3.14.*"
 
 [tool.pixi.package]
 name = "cclib"
-version = "1.8.1"
+# This means `pixi build` will fail, but leaving it in causes problems with
+# `nix build`, which must be using regex to find the version in this file.
+#
+# version = "1.8.1"
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "0.*" }


### PR DESCRIPTION
Closes #1774

Try it with
```bash
pixi run -e py38 -x python -m pytest -n 8 --dist worksteal -k 'not pyscf'
# Psi4 not available for Python 3.14 yet
pixi run -e py314 -x python -m pytest -n 8 --dist worksteal -k '(not pyscf) and (not psi4)'
```

I've confirmed locally that all 6 Python versions are working.  The lockfile solve time is annoying since it's the Cartesian product of Python versions and platforms but :shrug: 