### PR TITLE
Fix vibfconsts description in docs

### DIFF
--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -696,7 +696,7 @@ The attribute ``vibdisps`` stores the Cartesian displacement vectors from the ou
 vibfconsts
 ----------
 
-The attribute ``vibrmasses`` stores the force constants in :math:`\mathrm{Å^4/Da}` from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
+The attribute ``vibfconsts`` stores the force constants in :math:`\mathrm{mDyne/Å}` from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
 
 vibrmasses
 ----------

--- a/doc/sphinx/data_notes.rst
+++ b/doc/sphinx/data_notes.rst
@@ -696,7 +696,7 @@ The attribute ``vibdisps`` stores the Cartesian displacement vectors from the ou
 vibfconsts
 ----------
 
-The attribute ``vibfconsts`` stores the force constants in :math:`\mathrm{mDyne/Å}` from vibrational frequency calculation. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
+The attribute ``vibfconsts`` stores the force constants in :math:`\mathrm{mDyne/Å}` from vibrational frequency calculations. It is a rank 1 array having dimension ``M``, where ``M`` is the number of normal modes.
 
 vibrmasses
 ----------


### PR DESCRIPTION
The docs description of `vibfconsts` contained some mistakes. I updated it so it now states the correct unit (the same one stated in the table in https://cclib.github.io/data.html) and text. 