### PR TITLE
fix: correct two xtb parser bugs (hessian reshape, HOMO detection)

### DIFF
--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -505,7 +505,7 @@ def _extract_orbitals(line: str) -> Optional[Tuple[int, float, float, bool]]:
             int(line_split[0]),
             float(line_split[1]),
             float(line_split[3]),
-            bool("(HOMO) in line"),
+            "(HOMO)" in line,
         )
     if "(LUMO)" in line or (len(line_split) == 3 and "MO" not in line):
         return int(line_split[0]), 0.0, float(line_split[2]), False

--- a/cclib/parser/xtbparser.py
+++ b/cclib/parser/xtbparser.py
@@ -299,7 +299,9 @@ class XTB(logfileparser.Logfile):
             while line != "\n":
                 hessian.extend([float(v) for v in line.split()])
                 line = next(inputfile)
-            self.set_attribute("hessian", np.reshape(hessian, 3 * self.natom, 3 * self.natom))
+            self.set_attribute(
+                "hessian", np.reshape(hessian, (3 * self.natom, 3 * self.natom))
+            )
 
 
 def _extract_version(line: str) -> Optional[str]:


### PR DESCRIPTION
Two independent bugs in `cclib/parser/xtbparser.py`, each verified against the current code and reproduced.

## 1. Hessian reshape passes shape as separate args

`XTB.extract` calls:

```python
np.reshape(hessian, 3 * self.natom, 3 * self.natom)
```

`np.reshape` takes the target shape as a single argument (tuple or int). Passing the two dimensions as separate positional args puts the second one in the `order` parameter, which expects `'C'`, `'F'`, or `'A'`. Any xtb output with a `$hessian` block raises:

```
TypeError: order must be str, not int
```

before the hessian is ever usable. Fixed by wrapping the dimensions in a tuple: `(3 * self.natom, 3 * self.natom)`.

## 2. HOMO always flagged True

`_extract_orbitals` returned:

```python
bool("(HOMO) in line")
```

That's `bool()` of a non-empty string literal, so it's always `True`. Every occupied orbital reaching this branch (the `len == 4` case covers all occupied orbitals, not just the HOMO) got flagged as the HOMO, so `homos` collected every occupied orbital index instead of just the actual HOMO. Fixed to the membership test `"(HOMO)" in line` that was clearly intended (it matches the guard on the same branch).

## Testing

`test/testdata` here pulls from the `cclib-data` submodule, which isn't available in this environment, so I couldn't run the repo's xtb regression fixtures directly. I reproduced each bug and verified each fix using data taken from the docstrings already in `xtbparser.py`:

**Hessian:** built a minimal xtb log (GFN2 charge block to set `natom`, followed by the `$hessian` block from `_is_hessian_line`'s docstring) and ran it through `cclib.io.ccread()`.
- Before: `TypeError: order must be str, not int` at the `np.reshape` call.
- After: parses cleanly, `data.hessian.shape == (9, 9)` for the 3-atom system, matrix is symmetric as expected.

**HOMO:** fed the real orbital lines from `_extract_orbitals`'s docstring.
- Before: a plain occupied orbital (`31 ... -11.9473`, no `(HOMO)` tag) returned `is_homo=True`.
- After: only the line tagged `(HOMO)` returns `True`; occupied and `(LUMO)` lines return `False`.

Also ran the full offline parser suite (`pytest test/parser`, 30 tests, no submodule dependency) after both changes: all pass, no regressions.

## Note on a third audit flag

An automated pass also flagged `line_split[0].istitle()` in `_extract_symbol_coords` as skipping single-letter symbols. I checked this and it's not a bug: `"C".istitle()`, `"H".istitle()`, etc. all return `True`, and the real xtb XYZ coordinate lines from the docstring parse correctly. Left unchanged.