### PR TITLE
Fix ORCA 6.1 'Singles norm' case change in CC energy parser (closes #1728)

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -778,7 +778,7 @@ Dispersion correction           -0.016199959
             self.append_attribute("ccenergies", float(line.split()[-1]))
             self.metadata["methods"].append("CCSD")
             line = next(inputfile)
-            assert line[:23] == "Singles Norm <S|S>**1/2"
+            assert line[:23].lower() == "singles norm <s|s>**1/2"
             line = next(inputfile)
             self.metadata["t1_diagnostic"] = float(line.split()[-1])
 


### PR DESCRIPTION
Fixes #1728

## Problem

ORCA changed the output format of the coupled-cluster energy block in version 6.x:

- **ORCA ≤ 5.x:** `Singles Norm <S|S>**1/2` (capital N)
- **ORCA 6.x:** `Singles norm <S|S>**1/2` (lowercase n)

The cclib ORCA parser has a hard-coded assertion:
```python
assert line[:23] == "Singles Norm <S|S>**1/2"  # fails on ORCA 6.1
```

This raises `AssertionError` when parsing any ORCA 6.1 coupled-cluster output that contains the CC energy block.

## Fix

Make the assertion case-insensitive:
```python
assert line[:23].lower() == "singles norm <s|s>**1/2"  # handles both ORCA 5.x and 6.x
```

## Testing

Tested with an ORCA 6.1.1 CCSD(T) output file that triggered the original error. The lowercase comparison passes for ORCA 6.1 output and remains compatible with ORCA 5.x output (which uses capital N — `.lower()` makes both work).

Note: This is a minimal fix targeting the case mismatch. A follow-up could also handle ORCA 6.1's extended Singles norm line which includes per-spin contributions in parentheses, e.g. `0.074499160 ( 0.028751503, 0.045747658)`.