### PR TITLE
Fix Molpro log misdetected as Molcas: use OPENMOLCAS trigger (fixes #1268)

### DIFF
--- a/cclib/io/ccio.py
+++ b/cclib/io/ccio.py
@@ -81,7 +81,7 @@ triggers = [
     (GAMESSDAT, ["$DATA"], True),
     (Gaussian, ["Gaussian, Inc."], True),
     (Jaguar, ["Jaguar"], True),
-    (Molcas, ["MOLCAS"], True),
+    (Molcas, ["OPENMOLCAS"], True),
     (Molpro, ["PROGRAM SYSTEM MOLPRO"], True),
     (Molpro, ["1PROGRAM"], False),
     (MOPAC, ["MOPAC20"], True),


### PR DESCRIPTION
Fixes #1268

## Root cause

The file type detection in `ccio.py` uses the trigger `["MOLCAS"]` to identify OpenMolcas files. However, Molpro 2012 log files contain `MOLCAS` as a column header in their timing/statistics table:

```
                         T        V       H0       H01     AOSYM     SMH    MOLCAS    ERIS ...
```

This causes `guess_filetype` to override the correct Molpro detection (from the earlier `1PROGRAM` trigger, which has `do_break=False`) with Molcas (which has `do_break=True`), resulting in a `Molcas` parser being used for a Molpro file.

## Fix

Change the Molcas trigger from `["MOLCAS"]` to `["OPENMOLCAS"]`. OpenMolcas files contain `OPENMOLCAS` in their ASCII art banner and throughout the output. Molpro files only contain compact `MOLCAS` as a timing module name and never contain `OPENMOLCAS`.

## Verification

Tested with `data/Molpro/basicMolpro2012/dvb_gopt.log` (the file from the issue) and `data/Molcas/basicOpenMolcas18.0/dvb_gopt.out` (an OpenMolcas reference file):
- `OPENMOLCAS` in Molpro file: **False** (no false positive)
- `OPENMOLCAS` in OpenMolcas file: **True** (detection preserved)

```python
from cclib.io import ccread
# Before fix: AttributeError - Molcas object has no attribute core_array
# After fix:
data = ccread('dvb_gopt.log')  # correctly parsed as Molpro
```