### PR TITLE
Fix ValueError parsing Gaussian freq output with frozen coordinates (fixes #905)

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1684,6 +1684,12 @@ class Gaussian(logfileparser.Logfile):
                         self.set_attribute("nqmf", self.natom)
                     for n in range(self.nqmf):
                         line = next(inputfile)
+                        # Frozen coordinates: Gaussian omits frozen atoms from the
+                        # displacement block. Stop if we reach a non-atom line
+                        # (blank, separator, or thermochemistry), fixing #905.
+                        stripped = line.strip()
+                        if not stripped or not stripped.split()[0].isdigit():
+                            break
                         numbers = [float(s) for s in line[10:].split()]
                         N = len(numbers) // 3
                         if not disps:


### PR DESCRIPTION
## Problem

Fixes #905.

Parsing a Gaussian frequency log with frozen coordinates raises:

```
ValueError: could not convert string to float: '----------'
# or, for jobs with > 3 modes:
ValueError: could not convert string to float: 'A'
```

### Root cause

When frozen coordinates are present, Gaussian **omits frozen atoms** from the
normal-mode displacement table. For example, for H₂O with O frozen and both H
fixed:

```
  Atom  AN      X      Y      Z        X      Y      Z        X      Y      Z
     1   8     1.00  -0.00   0.00    -0.00  -0.00   1.00     0.00   1.00   0.00
                                   ← blank line — H atoms are absent
```

The Gaussian parser's inner loop reads `self.nqmf` (= `natom` = 3) rows, but
only 1 row is present. The 2nd read returns a blank line; the 3rd read returns
the thermochemistry separator `' -------------------'`. On that line:

```python
numbers = [float(s) for s in line[10:].split()]
# → float('---------') → ValueError
```

The `'A'` variant occurs when the symmetry block header is read instead.

### Fix

Before parsing each displacement row, check that it begins with an integer
(the atom index). If the line is blank, a separator, or a label — the
displacement block is over and we break early.

```python
stripped = line.strip()
if not stripped or not stripped.split()[0].isdigit():
    break  # frozen atoms omitted; displacement block ended early
```

This is a conservative fix: `vibdisps` for frozen systems will contain only
the non-frozen atom displacements rather than raising. Downstream code that
expects `len(vibdisps[n]) == natom` should be aware of this for frozen-atom
jobs, but at minimum the parser no longer crashes.

## Verification

Tested against the `h2o.log` file attached to the original issue (H₂O with
O frozen, 1 of 3 atoms in displacement block). Before fix: `ValueError`.
After fix: parses cleanly; `vibdisps` contains 1-atom displacements per mode.
