### PR TITLE
Fix ORCA gradient parser crash when D4/gCP text concatenated onto gradient line (fixes #1317)

### DIFF
--- a/cclib/parser/orcaparser.py
+++ b/cclib/parser/orcaparser.py
@@ -812,9 +812,22 @@ Dispersion correction           -0.016199959
                 self.skip_line(inputfile, "constrained Cartesian coordinate warning")
                 line = next(inputfile).strip()
 
+            _numeric_re = re.compile(r"^-?\d+\.?\d*(?:[eE][+-]?\d+)?")
             while line:
                 tokens = line.split()
-                x, y, z = float(tokens[-3]), float(tokens[-2]), float(tokens[-1])
+                # Robustly extract the last 3 numeric values from each gradient
+                # line. ORCA sometimes concatenates module startup text onto the
+                # last value (e.g. '0.000111Starting D4'), causing float() to fail
+                # on a naive tokens[-1] approach (fixes #1317).
+                numeric_vals = []
+                for _tok in tokens:
+                    _m = _numeric_re.match(_tok)
+                    if _m:
+                        try:
+                            numeric_vals.append(float(_m.group()))
+                        except ValueError:
+                            pass
+                x, y, z = numeric_vals[-3], numeric_vals[-2], numeric_vals[-1]
                 grads.append((x, y, z))
                 line = next(inputfile).strip()
 


### PR DESCRIPTION
## Problem

Fixes #1317.

Parsing an ORCA log with D4 dispersion or gCP correction fails with:

```
ValueError: could not convert string to float: 'D4'
# or:
ValueError: could not convert string to float: '0.000111Starting'
```

The parser reports:

```
Last line read: 34   H   :    0.000091913   -0.001034066    0.000111Starting D4
```

### Root cause

When the ORCA DFT-D4 or gCP module starts printing, it occasionally does so
without a preceding newline, concatenating its startup text onto the last
Cartesian gradient line:

```
   34   H   :    0.000091913   -0.001034066    0.000111Starting D4
```

The current parser uses `float(tokens[-1])` and `float(tokens[-3])`, which
fail when the last 1–2 tokens are `'D4'` or `'0.000111Starting'`.

### Fix

Instead of relying on positional indices into `tokens`, extract all numerically
parseable values from the line using a regex that captures the numeric prefix
of each token, then take the last 3:

```python
_numeric_re = re.compile(r"^-?\d+\.?\d*(?:[eE][+-]?\d+)?")
numeric_vals = []
for _tok in tokens:
    _m = _numeric_re.match(_tok)
    if _m:
        try:
            numeric_vals.append(float(_m.group()))
        except ValueError:
            pass
x, y, z = numeric_vals[-3], numeric_vals[-2], numeric_vals[-1]
```

This handles:
- Normal ORCA gradient lines: `"1   H   :   0.000000004   0.019501450   -0.021537091"`
- MP2 gradient format: `"0:   0.01527469  -0.00292883   0.01125000"`
- Concatenated D4 case: `"34   H   :   0.000091913   -0.001034066   0.000111Starting D4"`

All three cases verified analytically before submission.

> **Note:** No test log file was available from the original report, but the
> error message unambiguously identifies the cause. The fix is defensive and
> does not change behavior for normal gradient lines.
