### PR TITLE
fix: correctly handle frozen-atom Gaussian frequency output (#905)

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -1684,6 +1684,11 @@ class Gaussian(logfileparser.Logfile):
                         self.set_attribute("nqmf", self.natom)
                     for n in range(self.nqmf):
                         line = next(inputfile)
+                        if not line.strip():
+                            # Blank line terminates the normal coordinate block
+                            # early, e.g. when fewer atoms are printed because
+                            # some coordinates are frozen (NQMF > NQM atoms).
+                            break
                         numbers = [float(s) for s in line[10:].split()]
                         N = len(numbers) // 3
                         if not disps:
@@ -1692,6 +1697,12 @@ class Gaussian(logfileparser.Logfile):
                         for n in range(N):
                             disps[n].append(numbers[3 * n : 3 * n + 3])
                     self.vibdisps.extend(disps)
+                    if not line.strip():
+                        # The blank line that ended the atom block also marks
+                        # the end of the harmonic frequency while-loop. Skip
+                        # the line = next(inputfile) advance below so the
+                        # while condition sees the blank line and exits.
+                        continue
 
                 # Block with high-precision (freq=hpmodes) displacements should start with this.
                 #                           1         2         3         4         5


### PR DESCRIPTION
## Problem

When a Gaussian frequency calculation has frozen atoms (e.g. `!Freeze` keyword
or `Geom=ModRedundant` with frozen coordinates), Gaussian only prints normal-mode
displacement vectors for the NQM non-frozen atoms, not for all NQMF atoms.
After the last printed atom, Gaussian inserts a blank line and then begins the
Thermochemistry section.

The inner `for n in range(self.nqmf):` loop read exactly `nqmf` lines.
Because NQMF ≥ NQM (number of free atoms), the loop consumed the blank-line
separator as a silent 'empty' atom record. The outer `while line.strip() != "":`
loop then continued reading into the Thermochemistry section.

Inside Thermochemistry there is a line like:

```
                           1         2         3
     Eigenvalues --     2.03353   4.51506   6.54859
```

This "1  2  3" principal-axes index line satisfied both the `line[1:15].strip()
== ""` and `.isdigit()` conditions, causing `freqbase = 1`. Because `vibsyms`
was already set from the real frequency block, the `freqbase == 1 and
hasattr(self, "vibsyms")` branch reset `vibfreqs`, `vibsyms`, `vibrmasses`,
etc. to empty lists, silently discarding all correctly parsed frequency data.

## Fix

In the inner atom-displacement for-loop, break on a blank line. After
`self.vibdisps.extend(disps)`, if the last line read was blank, use `continue`
to skip the `line = next(inputfile)` advance at the end of the while body.
This keeps `line == ""` so the while condition sees the blank-line sentinel and
exits cleanly.

## Test

The reported log file (attached to the original issue) now parses correctly:

```python
>>> import cclib
>>> d = cclib.io.ccread("h2o_frozen_bonds_freq.log")
>>> d.vibfreqs
array([   1.6788,  818.5084, 1058.4364])
>>> d.vibsyms
['B1', 'A1', 'B2']
```

Before the fix: `vibfreqs = []`, `vibsyms = ['2.68563', '(Kcal/Mol)']`.

Closes #905.
