### PR TITLE
fix: stop accumulating atommasses past natom in repeated Isotopes sections (#1080)

### DIFF
--- a/cclib/parser/gaussianparser.py
+++ b/cclib/parser/gaussianparser.py
@@ -900,7 +900,11 @@ class Gaussian(logfileparser.Logfile):
             line = next(inputfile)
             while line[1:16] != "Leave Link  101":
                 if line[1:8] == "AtmWgt=":
-                    self.extend_attribute("atommasses", list(map(float, line.split()[1:])))
+                    # Guard against duplicate "Isotopes and Nuclear Properties"
+                    # blocks in opt+freq jobs (issue #1080): stop accumulating
+                    # once we have one mass per atom.
+                    if not hasattr(self, "atommasses") or len(self.atommasses) < self.natom:
+                        self.extend_attribute("atommasses", list(map(float, line.split()[1:])))
                 line = next(inputfile)
 
         # Symmetry: point group


### PR DESCRIPTION
## Problem

Gaussian 09 (and later) prints the "Isotopes and Nuclear Properties" block
multiple times in combined opt+freq jobs. The parser unconditionally extends
`self.atommasses` from every `AtmWgt=` line it finds, so the list ends up with
`k × natom` entries (where `k` is the number of times the block appears) instead
of `natom`.

Example (7-atom molecule, block appears twice):

```python
>>> data.natom
7
>>> len(data.atommasses)
14   # should be 7
```

## Fix

Add a length guard: only extend `atommasses` while `len(atommasses) < natom`.
Once one entry per atom has been collected the redundant sections are silently
skipped.

## Verification

With the log file attached to the original issue (`AcO-_0.gau.out`,
B97X-D/6-311++G** opt+freq):

```python
>>> data.natom
7
>>> len(data.atommasses)
7   # ✓
```

All existing tests continue to pass.

Closes #1080.
