### PR TITLE
Consolidate MissingAttributeError into cclib/exceptions.py (fixes #1746)

### DIFF
--- a/cclib/__init__.py
+++ b/cclib/__init__.py
@@ -19,6 +19,7 @@ as well as example methods that take parsed data as input.
 
 # ruff: noqa: F401
 from cclib._version import __version__
+from cclib.exceptions import MissingAttributeError  # noqa: F401
 
 
 # isort: off

--- a/cclib/bridge/cclib2chemfiles.py
+++ b/cclib/bridge/cclib2chemfiles.py
@@ -11,8 +11,7 @@ from cclib.parser.data import ccData
 from cclib.parser.utils import PeriodicTable, find_package
 
 
-class MissingAttributeError(Exception):
-    pass
+from cclib.exceptions import MissingAttributeError
 
 
 _found_chemfiles = find_package("chemfiles")

--- a/cclib/bridge/cclib2pyquante.py
+++ b/cclib/bridge/cclib2pyquante.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
     from cclib.parser.data import ccData
 
 
-class MissingAttributeError(Exception):
-    pass
+from cclib.exceptions import MissingAttributeError
 
 
 _found_pyquante2 = find_package("pyquante2")

--- a/cclib/bridge/cclib2pyscf.py
+++ b/cclib/bridge/cclib2pyscf.py
@@ -20,8 +20,7 @@ import periodictable
 l_sym2num = {"S": 0, "P": 1, "D": 2, "F": 3, "G": 4}
 
 
-class MissingAttributeError(Exception):
-    pass
+from cclib.exceptions import MissingAttributeError
 
 
 _found_pyscf = find_package("pyscf")

--- a/cclib/exceptions.py
+++ b/cclib/exceptions.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024, the cclib development team
+#
+# This file is part of cclib (http://cclib.github.io) and is distributed under
+# the terms of the BSD 3-Clause License.
+
+"""Canonical exception classes for cclib."""
+
+
+class MissingAttributeError(Exception):
+    """Raised when a required ccData attribute is absent.
+
+    This is the single canonical definition for the package.
+    It replaces the local copies that were previously defined in
+    each bridge and method module.
+    """
+
+    pass

--- a/cclib/io/filewriter.py
+++ b/cclib/io/filewriter.py
@@ -44,8 +44,7 @@ else:
     from typing import Iterable
 
 
-class MissingAttributeError(Exception):
-    pass
+from cclib.exceptions import MissingAttributeError
 
 
 class Writer(ABC):

--- a/cclib/method/calculationmethod.py
+++ b/cclib/method/calculationmethod.py
@@ -15,8 +15,7 @@ if TYPE_CHECKING:
     from cclib.progress import Progress
 
 
-class MissingAttributeError(Exception):
-    pass
+from cclib.exceptions import MissingAttributeError
 
 
 class Method:


### PR DESCRIPTION
## Summary

Fixes #1746.

`MissingAttributeError` was independently defined (as `class MissingAttributeError(Exception): pass`)
in five separate files:

- `cclib/bridge/cclib2pyquante.py`
- `cclib/bridge/cclib2chemfiles.py`
- `cclib/method/calculationmethod.py`
- `cclib/io/filewriter.py`
- `cclib/bridge/cclib2pyscf.py`

This PR consolidates them into a single canonical definition in a new
`cclib/exceptions.py` module, and updates each of the five files to import
from there instead.

## Backward compatibility

Each file still exposes `MissingAttributeError` in its own namespace via the
`from cclib.exceptions import MissingAttributeError` statement, so existing
imports like:

```python
from cclib.method.calculationmethod import MissingAttributeError
from cclib.io.filewriter import MissingAttributeError
```

continue to work without changes in test code or user code.

Additionally, `MissingAttributeError` is now available at the package top level:

```python
from cclib import MissingAttributeError   # new canonical import
```

## Changes

- **New file**: `cclib/exceptions.py` — single canonical definition with docstring
- **5 modified files**: duplicate class definitions replaced with
  `from cclib.exceptions import MissingAttributeError`
- **`cclib/__init__.py`**: exports `MissingAttributeError` at the package level
